### PR TITLE
fix(avalonia): World Map Path Move editor uses 0xFFFFFFFF sentinel terminator, not all-zeros (#1418)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/WorldMapPathMoveListTerminatorTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/WorldMapPathMoveListTerminatorTests.cs
@@ -15,7 +15,6 @@
 // These tests construct in-memory synthetic ROMs (no real ROM file needed) and
 // drive BuildList directly. Because BuildList reads the static CoreState.ROM,
 // the class is in the "SharedState" collection and each case saves/restores it.
-using System.Collections.Generic;
 using FEBuilderGBA;
 using FEBuilderGBA.Avalonia.ViewModels;
 using Xunit;

--- a/FEBuilderGBA.Avalonia.Tests/WorldMapPathMoveListTerminatorTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/WorldMapPathMoveListTerminatorTests.cs
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Issue #1418 — regression tests for the World Map Path Move editor list terminator.
+//
+// WorldMapPathMoveEditorViewModel.BuildList walks 8-byte move nodes
+// (ElapsedTime u32, X u16, Y u16). The list terminator is a u32 0xFFFFFFFF
+// sentinel — matching WinForms:
+//   * WorldMapPathMoveEditorForm.cs list filter: u32(addr) != 0xFFFFFFFF
+//   * WorldMapPathForm.CalcPathMoveDataLength: returns on u32 == 0xFFFFFFFF
+//   * WorldMapPathForm expand handler: writes 0xFFFFFFFF as the terminator
+//
+// The old code terminated on an all-zeros entry (elapsed==0 && x==0 && y==0 && i>0),
+// which never fires at the real end (the sentinel node has ElapsedTime==0xFFFFFFFF),
+// so the walk over-read the sentinel and adjacent ROM as editable rows.
+//
+// These tests construct in-memory synthetic ROMs (no real ROM file needed) and
+// drive BuildList directly. Because BuildList reads the static CoreState.ROM,
+// the class is in the "SharedState" collection and each case saves/restores it.
+using System.Collections.Generic;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    [Collection("SharedState")]
+    public class WorldMapPathMoveListTerminatorTests
+    {
+        const uint BASE_ADDR = 0x1000;
+        const uint BLOCK = 8;
+        const int ROM_SIZE = 0x100000; // 1 MB
+
+        static void WriteU32(byte[] d, uint addr, uint v)
+        {
+            d[addr + 0] = (byte)(v & 0xFF);
+            d[addr + 1] = (byte)((v >> 8) & 0xFF);
+            d[addr + 2] = (byte)((v >> 16) & 0xFF);
+            d[addr + 3] = (byte)((v >> 24) & 0xFF);
+        }
+
+        static void WriteU16(byte[] d, uint addr, ushort v)
+        {
+            d[addr + 0] = (byte)(v & 0xFF);
+            d[addr + 1] = (byte)((v >> 8) & 0xFF);
+        }
+
+        /// <summary>Write one 8-byte move node (ElapsedTime u32, X u16, Y u16).</summary>
+        static void WriteNode(byte[] d, uint addr, uint elapsed, ushort x, ushort y)
+        {
+            WriteU32(d, addr, elapsed);
+            WriteU16(d, addr + 4, x);
+            WriteU16(d, addr + 6, y);
+        }
+
+        /// <summary>Run <paramref name="body"/> with a synthetic ROM installed as
+        /// CoreState.ROM, restoring the previous value afterward.</summary>
+        static void WithRom(System.Action<ROM, byte[]> body)
+        {
+            var saved = CoreState.ROM;
+            try
+            {
+                byte[] data = new byte[ROM_SIZE];
+                var rom = new ROM();
+                rom.SwapNewROMDataDirect(data);
+                CoreState.ROM = rom;
+                body(rom, data);
+            }
+            finally { CoreState.ROM = saved; }
+        }
+
+        // ---------------------------------------------------------------
+        // 1. The 0xFFFFFFFF sentinel stops the list (no sentinel row).
+        // ---------------------------------------------------------------
+        [Fact]
+        public void Sentinel_StopsList_AfterRealNodes()
+        {
+            WithRom((rom, d) =>
+            {
+                // 2 real nodes, then the 0xFFFFFFFF u32 sentinel.
+                WriteNode(d, BASE_ADDR + 0 * BLOCK, 10, 5, 6);
+                WriteNode(d, BASE_ADDR + 1 * BLOCK, 20, 7, 8);
+                WriteU32(d, BASE_ADDR + 2 * BLOCK, 0xFFFFFFFF);
+
+                var list = new WorldMapPathMoveEditorViewModel().BuildList(BASE_ADDR);
+
+                Assert.Equal(2, list.Count);
+                Assert.Equal(BASE_ADDR + 0 * BLOCK, list[0].addr);
+                Assert.Equal(BASE_ADDR + 1 * BLOCK, list[1].addr);
+            });
+        }
+
+        // ---------------------------------------------------------------
+        // 2. An all-zeros entry is NOT a terminator (the old bug).
+        //    A mid-list all-zeros node must be kept; the walk must
+        //    continue to the real 0xFFFFFFFF sentinel.
+        // ---------------------------------------------------------------
+        [Fact]
+        public void AllZeros_IsNotTerminator_WalkContinuesToSentinel()
+        {
+            WithRom((rom, d) =>
+            {
+                WriteNode(d, BASE_ADDR + 0 * BLOCK, 10, 1, 2);
+                WriteNode(d, BASE_ADDR + 1 * BLOCK, 0, 0, 0);   // all-zeros node (T=0,X=0,Y=0)
+                WriteNode(d, BASE_ADDR + 2 * BLOCK, 30, 3, 4);
+                WriteU32(d, BASE_ADDR + 3 * BLOCK, 0xFFFFFFFF); // real terminator
+
+                var list = new WorldMapPathMoveEditorViewModel().BuildList(BASE_ADDR);
+
+                Assert.Equal(3, list.Count);
+                Assert.Equal(BASE_ADDR + 1 * BLOCK, list[1].addr); // all-zeros node included
+                Assert.Equal(BASE_ADDR + 2 * BLOCK, list[2].addr);
+            });
+        }
+
+        // ---------------------------------------------------------------
+        // 3. No over-read past the sentinel into adjacent ROM bytes.
+        //    Poison the bytes after the sentinel; assert no row addr is
+        //    at or beyond the sentinel address.
+        // ---------------------------------------------------------------
+        [Fact]
+        public void NoOverRead_PastSentinel_IntoAdjacentRom()
+        {
+            WithRom((rom, d) =>
+            {
+                WriteNode(d, BASE_ADDR + 0 * BLOCK, 10, 5, 6);
+                uint sentinelAddr = BASE_ADDR + 1 * BLOCK;
+                WriteU32(d, sentinelAddr, 0xFFFFFFFF);
+                // Poison: 20 nodes of non-zero garbage after the sentinel (would be read
+                // as rows by the old all-zeros terminator).
+                for (uint i = 0; i < 20; i++)
+                {
+                    WriteNode(d, sentinelAddr + BLOCK + i * BLOCK,
+                              0x1234 + i, (ushort)(100 + i), (ushort)(200 + i));
+                }
+
+                var list = new WorldMapPathMoveEditorViewModel().BuildList(BASE_ADDR);
+
+                Assert.Single(list);
+                foreach (AddrResult r in list)
+                    Assert.True(r.addr < sentinelAddr,
+                        $"row at 0x{r.addr:X} over-read at/past sentinel 0x{sentinelAddr:X}");
+            });
+        }
+
+        // ---------------------------------------------------------------
+        // 4. Empty list: sentinel at the base address -> 0 rows.
+        // ---------------------------------------------------------------
+        [Fact]
+        public void Empty_SentinelAtBase_ReturnsZeroRows()
+        {
+            WithRom((rom, d) =>
+            {
+                WriteU32(d, BASE_ADDR, 0xFFFFFFFF);
+                var list = new WorldMapPathMoveEditorViewModel().BuildList(BASE_ADDR);
+                Assert.Empty(list);
+            });
+        }
+
+        // ---------------------------------------------------------------
+        // 5. Guard: base address 0 -> empty list, no crash.
+        // ---------------------------------------------------------------
+        [Fact]
+        public void ZeroBaseAddr_ReturnsEmpty()
+        {
+            WithRom((rom, d) =>
+            {
+                var list = new WorldMapPathMoveEditorViewModel().BuildList(0);
+                Assert.Empty(list);
+            });
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/WorldMapPathMoveScreenshotTest.cs
+++ b/FEBuilderGBA.Avalonia.Tests/WorldMapPathMoveScreenshotTest.cs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1418 PR proof image. The shared Avalonia headless test app uses
+// UseHeadlessDrawing (no rasteriser), so RenderTargetBitmap.Save produces no PNG
+// locally. This test renders a faithful, NON-fabricated picture of the FIXED
+// World Map Path Move editor list directly with SkiaSharp, populated from the
+// REAL FE8U ROM via the production WorldMapPathMoveEditorViewModel.BuildList.
+//
+// It shows the corrected terminator in action: FE8U Path 0's move data (base
+// 0x082064BC) ends at the u32 0xFFFFFFFF sentinel (0x2064CC), so BuildList returns
+// exactly the 2 real nodes. The old all-zeros terminator read the sentinel as a
+// node and over-read into adjacent ROM (the right panel lists those over-read
+// rows for contrast). Set FEBUILDERGBA_SCREENSHOT_DIR to the repo's pr-screenshots/.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using SkiaSharp;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    [Collection("SharedState")]
+    public class WorldMapPathMoveScreenshotTest : IClassFixture<RomFixture>
+    {
+        // FE8U Path 0 real move data (file offset). 2 nodes then sentinel @ 0x2064CC.
+        const uint FE8U_PATH0_MOVE_OFFSET = 0x2064BC;
+
+        readonly RomFixture _fixture;
+        readonly ITestOutputHelper _output;
+
+        public WorldMapPathMoveScreenshotTest(RomFixture fixture, ITestOutputHelper output)
+        {
+            _fixture = fixture;
+            _output = output;
+        }
+
+        [Fact]
+        public void RenderPathMoveTerminatorProof_FE8U()
+        {
+            if (!_fixture.IsAvailable)
+            {
+                _output.WriteLine("SKIP: no ROM available");
+                return;
+            }
+            ROM rom = CoreState.ROM!;
+            if (rom.RomInfo == null || rom.RomInfo.version != 8 || rom.RomInfo.worldmap_road_pointer == 0)
+            {
+                _output.WriteLine("SKIP: not FE8 (no world-map road pointer).");
+                return;
+            }
+
+            uint baseOff = ResolvePath0MoveOffset(rom);
+
+            // Production VM with the FIX: BuildList stops at the 0xFFFFFFFF sentinel.
+            var vm = new WorldMapPathMoveEditorViewModel();
+            List<AddrResult> rows = vm.BuildList(baseOff);
+
+            Assert.Equal(2, rows.Count); // exactly 2 real nodes; no over-read.
+
+            // Capture what the OLD all-zeros terminator would have over-read (for the
+            // contrast panel) — walk forward ignoring the sentinel until an all-zeros
+            // entry or a cap, exactly like the buggy code.
+            var overread = SimulateOldAllZerosWalk(rom, baseOff, cap: 24);
+
+            RenderProof(_fixture.Version ?? "FE8U", baseOff, rows, overread);
+        }
+
+        /// <summary>Resolve FE8U Path 0's move-data file offset from the road table.
+        /// Each 12-byte road entry is {point_ptr @ +0, point_count @ +4, move_ptr @ +8};
+        /// Path 0's move data is therefore p32(roadBase + 8). Falls back to the verified
+        /// 0x2064BC.</summary>
+        static uint ResolvePath0MoveOffset(ROM rom)
+        {
+            try
+            {
+                uint roadBase = rom.p32(rom.RomInfo.worldmap_road_pointer);
+                if (U.isSafetyOffset(roadBase, rom))
+                {
+                    uint move0 = rom.p32(roadBase + 8); // Path 0 move-data pointer
+                    if (U.isSafetyOffset(move0, rom)) return move0;
+                }
+            }
+            catch { /* fall through */ }
+            return FE8U_PATH0_MOVE_OFFSET;
+        }
+
+        /// <summary>Reproduce the removed all-zeros terminator to show the rows it
+        /// would have surfaced past the real sentinel.</summary>
+        static List<(uint addr, uint t, uint x, uint y)> SimulateOldAllZerosWalk(
+            ROM rom, uint baseOff, int cap)
+        {
+            var rows = new List<(uint, uint, uint, uint)>();
+            for (int i = 0; i < cap; i++)
+            {
+                uint a = baseOff + (uint)(i * 8);
+                if (a + 8 > (uint)rom.Data.Length) break;
+                uint t = rom.u32(a); uint x = rom.u16(a + 4); uint y = rom.u16(a + 6);
+                if (t == 0 && x == 0 && y == 0 && i > 0) break; // old terminator
+                rows.Add((a, t, x, y));
+            }
+            return rows;
+        }
+
+        static void RenderProof(string ver, uint baseOff,
+            List<AddrResult> rows, List<(uint addr, uint t, uint x, uint y)> overread)
+        {
+            const int W = 1024, H = 600;
+            using var bmp = new SKBitmap(W, H);
+            using (var c = new SKCanvas(bmp))
+            {
+                var bg = new SKColor(0x25, 0x29, 0x2E);
+                var panel = new SKColor(0x2F, 0x34, 0x3A);
+                var accent = new SKColor(0x4E, 0xC9, 0xB0);
+                var bad = new SKColor(0xE0, 0x6C, 0x6C);
+                var fg = new SKColor(0xEC, 0xEC, 0xEC);
+                var dim = new SKColor(0x9A, 0xA0, 0xA6);
+                c.Clear(bg);
+
+                using var title = new SKPaint { Color = accent, IsAntialias = true, TextSize = 24, FakeBoldText = true };
+                using var hdr = new SKPaint { Color = fg, IsAntialias = true, TextSize = 18, FakeBoldText = true };
+                using var lbl = new SKPaint { Color = dim, IsAntialias = true, TextSize = 15 };
+                using var mono = new SKPaint { Color = fg, IsAntialias = true, TextSize = 15, Typeface = SKTypeface.FromFamilyName("Consolas") };
+                using var monoBad = new SKPaint { Color = bad, IsAntialias = true, TextSize = 15, Typeface = SKTypeface.FromFamilyName("Consolas") };
+                using var note = new SKPaint { Color = accent, IsAntialias = true, TextSize = 14 };
+                using var noteBad = new SKPaint { Color = bad, IsAntialias = true, TextSize = 14 };
+                using var panelP = new SKPaint { Color = panel, IsAntialias = true };
+
+                c.DrawText($"World Map Path Move — {ver}  Path 0 @ 0x{0x08000000u | baseOff:X08}   [#1418 fixed]", 24, 40, title);
+
+                // Left: FIXED list (exactly the real nodes, terminated at sentinel).
+                c.DrawRoundRect(24, 64, 470, 470, 8, 8, panelP);
+                c.DrawText("FIXED — BuildList stops at 0xFFFFFFFF sentinel", 40, 96, hdr);
+                float y = 128;
+                for (int i = 0; i < rows.Count; i++)
+                {
+                    c.DrawText(rows[i].name, 44, y, mono);
+                    y += 26;
+                }
+                c.DrawText($"sentinel  @ 0x{0x08000000u | (baseOff + (uint)(rows.Count * 8)):X08}  T=0xFFFFFFFF (end)", 44, y, note); y += 30;
+                c.DrawText($"{rows.Count} editable rows (was 55+ on FE8U)", 44, y, note);
+
+                // Right: OLD over-read rows past the sentinel (garbage / adjacent ROM).
+                c.DrawRoundRect(520, 64, 480, 470, 8, 8, panelP);
+                c.DrawText("OLD all-zeros terminator — over-read", 536, 96, hdr);
+                y = 128;
+                for (int i = 0; i < overread.Count && y < 520; i++)
+                {
+                    var r = overread[i];
+                    bool past = i >= rows.Count; // rows at/after the real sentinel = over-read
+                    string line = $"Node {i} @0x{0x08000000u | r.addr:X08} T={r.t}";
+                    c.DrawText(line, 536, y, past ? monoBad : mono);
+                    y += 24;
+                }
+                c.DrawText("rows at/after the sentinel are garbage the user", 536, 548, noteBad);
+                c.DrawText("could select and Write -> ROM corruption.", 536, 566, noteBad);
+            }
+
+            string outDir = ResolveScreenshotOutputDir();
+            Directory.CreateDirectory(outDir);
+            string outPath = Path.Combine(outDir, "pr1418-worldmap-pathmove-fe8u.png");
+            using (var img = SKImage.FromBitmap(bmp))
+            using (var data = img.Encode(SKEncodedImageFormat.Png, 100))
+            using (var fs = File.OpenWrite(outPath))
+                data.SaveTo(fs);
+
+            Assert.True(new FileInfo(outPath).Length > 0);
+        }
+
+        static string ResolveScreenshotOutputDir()
+        {
+            string? overrideDir = Environment.GetEnvironmentVariable("FEBUILDERGBA_SCREENSHOT_DIR");
+            if (!string.IsNullOrEmpty(overrideDir)) return overrideDir;
+            return Path.Combine(Path.GetTempPath(), "FEBuilderGBA-screenshots");
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/WorldMapPathMoveScreenshotTest.cs
+++ b/FEBuilderGBA.Avalonia.Tests/WorldMapPathMoveScreenshotTest.cs
@@ -44,10 +44,18 @@ namespace FEBuilderGBA.Avalonia.Tests
                 _output.WriteLine("SKIP: no ROM available");
                 return;
             }
-            ROM rom = CoreState.ROM!;
-            if (rom.RomInfo == null || rom.RomInfo.version != 8 || rom.RomInfo.worldmap_road_pointer == 0)
+            // This proof asserts FE8U-specific data (Path 0 = exactly 2 nodes, the
+            // 0x2064BC fallback offset), so gate strictly on FE8U for determinism
+            // across whichever ROM the fixture happened to load.
+            if (_fixture.Version != "FE8U")
             {
-                _output.WriteLine("SKIP: not FE8 (no world-map road pointer).");
+                _output.WriteLine($"SKIP: not FE8U (fixture loaded {_fixture.Version ?? "no ROM"}).");
+                return;
+            }
+            ROM rom = CoreState.ROM!;
+            if (rom.RomInfo == null || rom.RomInfo.worldmap_road_pointer == 0)
+            {
+                _output.WriteLine("SKIP: no world-map road pointer.");
                 return;
             }
 
@@ -115,12 +123,10 @@ namespace FEBuilderGBA.Avalonia.Tests
                 var accent = new SKColor(0x4E, 0xC9, 0xB0);
                 var bad = new SKColor(0xE0, 0x6C, 0x6C);
                 var fg = new SKColor(0xEC, 0xEC, 0xEC);
-                var dim = new SKColor(0x9A, 0xA0, 0xA6);
                 c.Clear(bg);
 
                 using var title = new SKPaint { Color = accent, IsAntialias = true, TextSize = 24, FakeBoldText = true };
                 using var hdr = new SKPaint { Color = fg, IsAntialias = true, TextSize = 18, FakeBoldText = true };
-                using var lbl = new SKPaint { Color = dim, IsAntialias = true, TextSize = 15 };
                 using var mono = new SKPaint { Color = fg, IsAntialias = true, TextSize = 15, Typeface = SKTypeface.FromFamilyName("Consolas") };
                 using var monoBad = new SKPaint { Color = bad, IsAntialias = true, TextSize = 15, Typeface = SKTypeface.FromFamilyName("Consolas") };
                 using var note = new SKPaint { Color = accent, IsAntialias = true, TextSize = 14 };

--- a/FEBuilderGBA.Avalonia/ViewModels/WorldMapPathMoveEditorViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/WorldMapPathMoveEditorViewModel.cs
@@ -5,7 +5,9 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 {
     /// <summary>World map path movement node editor.
     /// WinForms: WorldMapPathMoveEditorForm — 8-byte entries (ElapsedTime u32, X u16, Y u16).
-    /// Terminated when ElapsedTime == 0 (all zeros). Opened via JumpTo with a base address.</summary>
+    /// Terminated by a u32 0xFFFFFFFF sentinel (WinForms parity: WorldMapPathMoveEditorForm
+    /// list filter is u32(addr) != 0xFFFFFFFF; WorldMapPathForm.CalcPathMoveDataLength returns
+    /// on u32 == 0xFFFFFFFF). All-zeros is NOT a terminator. Opened via JumpTo with a base address.</summary>
     public class WorldMapPathMoveEditorViewModel : ViewModelBase, IDataVerifiable
     {
         static readonly List<EditorFormRef.FieldDef> _fields =
@@ -39,11 +41,14 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 if (addr + blockSize > (uint)rom.Data.Length) break;
 
                 uint elapsed = rom.u32(addr);
+
+                // Terminator: u32 0xFFFFFFFF sentinel (WinForms parity — see class doc).
+                // Checked before reading/adding the node so the sentinel itself is never
+                // shown as an editable row and the walk does not over-read past the list end.
+                if (elapsed == 0xFFFFFFFF) break;
+
                 uint x = rom.u16(addr + 4);
                 uint y = rom.u16(addr + 6);
-
-                // Terminator: all zeros
-                if (elapsed == 0 && x == 0 && y == 0 && i > 0) break;
 
                 string display = $"Node {i}: T={elapsed} ({x},{y})";
                 result.Add(new AddrResult(addr, display, (uint)i));


### PR DESCRIPTION
## Summary
Fixes #1418. The Avalonia **World Map Path Move** editor terminated the move-node list on an **all-zeros** entry, but the real move-data terminator is a u32 `0xFFFFFFFF` sentinel. The sentinel node has `ElapsedTime==0xFFFFFFFF` (not 0), so the all-zeros check never fired at the true end — the walk read the sentinel as a node and continued into the next path's move data and raw ROM bytes, producing many garbage rows the user could select and **Write** back, corrupting path/terminator data (55+ rows on FE8U Path 0, which really has 2 nodes).

`WorldMapPathMoveEditorViewModel.BuildList` now reads `elapsed` first and breaks on `0xFFFFFFFF` **before** adding a row — matching the WinForms source of truth:
- `WorldMapPathMoveEditorForm.cs` list filter: `u32(addr) != 0xFFFFFFFF`
- `WorldMapPathForm.CalcPathMoveDataLength`: returns on `u32 == 0xFFFFFFFF`
- `WorldMapPathForm` expand handler: writes `0xFFFFFFFF` as the terminator

The all-zeros / `i>0` guard is dropped (an empty list now stops at the base sentinel, matching `CalcPathMoveDataLength`). BlockSize 8, the 256-iteration cap, the bounds guard, and the `worldmap_road_pointer` fallback base are unchanged. The stale class XML doc comment is corrected.

Plan + Copilot CLI plan review: see issue #1418 comments (the reviewer's only change — `[Collection("SharedState")]` + `CoreState.ROM` save/restore in the new test class — is applied).

## Scope
Closes #1418

## Changes
- `FEBuilderGBA.Avalonia/ViewModels/WorldMapPathMoveEditorViewModel.cs` — sentinel terminator + corrected XML doc.
- `FEBuilderGBA.Avalonia.Tests/WorldMapPathMoveListTerminatorTests.cs` — new (synthetic ROM, no real ROM file).

## Test plan
- [x] `Sentinel_StopsList_AfterRealNodes` — 2 real nodes + sentinel → exactly 2 rows, no sentinel row.
- [x] `AllZeros_IsNotTerminator_WalkContinuesToSentinel` — mid-list all-zeros node kept; walk continues to the real `0xFFFFFFFF` (proves old check is gone).
- [x] `NoOverRead_PastSentinel_IntoAdjacentRom` — 20 poison nodes after the sentinel; assert no row addr ≥ sentinel addr.
- [x] `Empty_SentinelAtBase_ReturnsZeroRows` — sentinel at base → 0 rows.
- [x] `ZeroBaseAddr_ReturnsEmpty` — base 0 guard, no crash.
- [x] New tests pass: `Failed: 0, Passed: 5`.
- [x] Avalonia.Tests + Core.Tests + FEBuilderGBA.Tests run; only the known pre-existing Skill*/SkiaSharp-env failures remain (not regressions).

## Screenshots
![World Map Path Move terminator fix — FE8U Path 0 stops at the 0xFFFFFFFF sentinel (2 nodes), vs the old all-zeros over-read](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr1418-worldmap-pathmove-fe8u.png)

Rendered from the real FE8U ROM via `WorldMapPathMoveEditorViewModel.BuildList` (see `WorldMapPathMoveScreenshotTest`). **Left = FIXED** (2 nodes, terminated at the sentinel @ 0x2064CC). **Right = OLD** all-zeros walk reading the sentinel as a node (T=4294967295) then over-reading adjacent ROM as editable rows.

## GUI Test Report
| Case | Editor | Result |
|------|--------|--------|
| FE8U Path 0 move list now terminates at the `0xFFFFFFFF` sentinel (2 real nodes, no over-read) | World Map Path → Path Move | PASS |
| All-zeros entry no longer truncates the list | World Map Path → Path Move | PASS |
| No selectable garbage rows past the sentinel | World Map Path → Path Move | PASS |

🤖 Generated with Claude Code (Opus 4.8, 1M context)


