### PR TITLE
fix(avalonia): Force Sortie editor Write is now undo-tracked (UndoService scope) (#1427)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/EventForceSortieUndoCoverageTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EventForceSortieUndoCoverageTests.cs
@@ -12,15 +12,16 @@
 //     pattern in UndoCoverageScannerTests.
 //  2. Behavioral round-trip (ROM-gated) — load an entry, write inside a scope,
 //     assert ROM bytes changed, RunUndo, assert bytes restored byte-identical.
+//
+// Both gates use [SkippableFact] + Skip.If so an unavailable source tree / ROM
+// reports as a real SKIP (not a silent pass that hides the guard not running).
 using System;
 using System.IO;
-using System.Linq;
 using FEBuilderGBA;
 using FEBuilderGBA.Avalonia.GapSweep;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace FEBuilderGBA.Avalonia.Tests
 {
@@ -28,12 +29,10 @@ namespace FEBuilderGBA.Avalonia.Tests
     public class EventForceSortieUndoCoverageTests : IClassFixture<RomFixture>
     {
         private readonly RomFixture _fixture;
-        private readonly ITestOutputHelper _output;
 
-        public EventForceSortieUndoCoverageTests(RomFixture fixture, ITestOutputHelper output)
+        public EventForceSortieUndoCoverageTests(RomFixture fixture)
         {
             _fixture = fixture;
-            _output = output;
         }
 
         // ---- (1) Static-analysis guard: View wraps _vm.Write() in a scope --------
@@ -43,17 +42,14 @@ namespace FEBuilderGBA.Avalonia.Tests
         /// OnWrite wraps _vm.Write() in _undoService.Begin / try-Commit / catch-Rollback.
         /// FAILS before the #1427 fix (no Begin/Commit), PASSES after.
         /// </summary>
-        [Fact]
+        [SkippableFact]
         public void EventForceSortieView_WrapsVmWrite_InUndoScope()
         {
             string? repoRoot = FindRepoRoot();
-            if (repoRoot == null)
-            {
-                _output.WriteLine("SKIP: repo root not found (running from published binary)");
-                return;
-            }
+            Skip.If(repoRoot == null,
+                "Repo root (FEBuilderGBA.sln) not found — running from a published binary outside the source tree.");
 
-            string viewPath = Path.Combine(repoRoot,
+            string viewPath = Path.Combine(repoRoot!,
                 "FEBuilderGBA.Avalonia", "Views", "EventForceSortieView.axaml.cs");
             Assert.True(File.Exists(viewPath), $"View source not found at {viewPath}");
 
@@ -69,22 +65,15 @@ namespace FEBuilderGBA.Avalonia.Tests
         /// bytes byte-identical. Confirms the VM/WriteFields path participates in
         /// undo once a scope is active (which the View now opens).
         /// </summary>
-        [Fact]
+        [SkippableFact]
         public void Write_UnderUndoScope_IsRevertedByUndo()
         {
-            if (!_fixture.IsAvailable)
-            {
-                _output.WriteLine("SKIP: no ROM available");
-                return;
-            }
+            Skip.IfNot(_fixture.IsAvailable, "No ROM available for the behavioral undo round-trip.");
 
             var vm = new EventForceSortieViewModel();
             var list = vm.LoadList();
-            if (list == null || list.Count < 2)
-            {
-                _output.WriteLine($"SKIP: force-sortie list has {list?.Count ?? 0} entries (need >= 2)");
-                return;
-            }
+            Skip.If(list == null || list.Count < 2,
+                $"Force-sortie list has {list?.Count ?? 0} entries (need >= 2).");
 
             uint addr = list[1].addr;
             vm.LoadEntry(addr);
@@ -105,17 +94,26 @@ namespace FEBuilderGBA.Avalonia.Tests
                 vm.Write();
                 svc.Commit();
 
-                // ROM byte at the Unit field (u16 @ +0) must reflect the new value.
-                Assert.Equal((ushort)testValue, CoreState.ROM.u16(addr));
-                bool anyChanged = false;
-                for (int i = 0; i < (int)size; i++)
+                // From here the undo buffer holds a record; ALWAYS RunUndo (even on
+                // assertion failure) so the shared [Collection("SharedState")] undo
+                // state can't leak into unrelated tests.
+                try
                 {
-                    if (snapshot[i] != CoreState.ROM.Data[(int)addr + i]) { anyChanged = true; break; }
+                    // ROM byte at the Unit field (u16 @ +0) must reflect the new value.
+                    Assert.Equal((ushort)testValue, CoreState.ROM.u16(addr));
+                    bool anyChanged = false;
+                    for (int i = 0; i < (int)size; i++)
+                    {
+                        if (snapshot[i] != CoreState.ROM.Data[(int)addr + i]) { anyChanged = true; break; }
+                    }
+                    Assert.True(anyChanged, "Write did not change any ROM bytes");
                 }
-                Assert.True(anyChanged, "Write did not change any ROM bytes");
+                finally
+                {
+                    CoreState.Undo.RunUndo();
+                }
 
                 // Undo must restore every byte.
-                CoreState.Undo.RunUndo();
                 for (int i = 0; i < (int)size; i++)
                 {
                     Assert.Equal(snapshot[i], CoreState.ROM.Data[(int)addr + i]);

--- a/FEBuilderGBA.Avalonia.Tests/EventForceSortieUndoCoverageTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EventForceSortieUndoCoverageTests.cs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Regression tests for #1427 — the Avalonia Force Sortie editor (EventForceSortieView)
+// must wrap its _vm.Write() in an UndoService scope so the ROM write is undo-tracked
+// (Edit > Undo can revert it). Before the fix OnWrite called _vm.Write() with no
+// Begin/Commit, so the bare EditorFormRef.WriteFields path recorded nothing into the
+// undo buffer.
+//
+// Two layers:
+//  1. Static-analysis guard (DiscoverViewCoveredVmMethods over the live
+//     EventForceSortieView.axaml.cs) — this is the piece that FAILS pre-fix and
+//     PASSES post-fix, proving the view-level scope exists. Mirrors the canary
+//     pattern in UndoCoverageScannerTests.
+//  2. Behavioral round-trip (ROM-gated) — load an entry, write inside a scope,
+//     assert ROM bytes changed, RunUndo, assert bytes restored byte-identical.
+using System;
+using System.IO;
+using System.Linq;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.GapSweep;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    [Collection("SharedState")]
+    public class EventForceSortieUndoCoverageTests : IClassFixture<RomFixture>
+    {
+        private readonly RomFixture _fixture;
+        private readonly ITestOutputHelper _output;
+
+        public EventForceSortieUndoCoverageTests(RomFixture fixture, ITestOutputHelper output)
+        {
+            _fixture = fixture;
+            _output = output;
+        }
+
+        // ---- (1) Static-analysis guard: View wraps _vm.Write() in a scope --------
+
+        /// <summary>
+        /// The View must register EventForceSortieViewModel.Write as undo-covered:
+        /// OnWrite wraps _vm.Write() in _undoService.Begin / try-Commit / catch-Rollback.
+        /// FAILS before the #1427 fix (no Begin/Commit), PASSES after.
+        /// </summary>
+        [Fact]
+        public void EventForceSortieView_WrapsVmWrite_InUndoScope()
+        {
+            string? repoRoot = FindRepoRoot();
+            if (repoRoot == null)
+            {
+                _output.WriteLine("SKIP: repo root not found (running from published binary)");
+                return;
+            }
+
+            string viewPath = Path.Combine(repoRoot,
+                "FEBuilderGBA.Avalonia", "Views", "EventForceSortieView.axaml.cs");
+            Assert.True(File.Exists(viewPath), $"View source not found at {viewPath}");
+
+            var covered = UndoCoverageScanner.DiscoverViewCoveredVmMethods(new[] { viewPath });
+            Assert.Contains(("EventForceSortieViewModel", "Write"), covered);
+        }
+
+        // ---- (2) Behavioral guard: write is undoable byte-for-byte ----------------
+
+        /// <summary>
+        /// End-to-end: with an undo scope open around the VM's Write(), a mutated
+        /// field is committed to ROM and a subsequent RunUndo restores the original
+        /// bytes byte-identical. Confirms the VM/WriteFields path participates in
+        /// undo once a scope is active (which the View now opens).
+        /// </summary>
+        [Fact]
+        public void Write_UnderUndoScope_IsRevertedByUndo()
+        {
+            if (!_fixture.IsAvailable)
+            {
+                _output.WriteLine("SKIP: no ROM available");
+                return;
+            }
+
+            var vm = new EventForceSortieViewModel();
+            var list = vm.LoadList();
+            if (list == null || list.Count < 2)
+            {
+                _output.WriteLine($"SKIP: force-sortie list has {list?.Count ?? 0} entries (need >= 2)");
+                return;
+            }
+
+            uint addr = list[1].addr;
+            vm.LoadEntry(addr);
+            Assert.Equal(addr, vm.CurrentAddr);
+
+            const uint size = 4; // W0 (u16) + B2 (u8) + B3 (u8)
+            byte[] snapshot = new byte[size];
+            Array.Copy(CoreState.ROM.Data, (int)addr, snapshot, 0, (int)size);
+
+            try
+            {
+                uint original = vm.Unit;
+                uint testValue = original == 0x42u ? 0x43u : 0x42u;
+
+                var svc = new UndoService();
+                svc.Begin("test-force-sortie");
+                vm.Unit = testValue;
+                vm.Write();
+                svc.Commit();
+
+                // ROM byte at the Unit field (u16 @ +0) must reflect the new value.
+                Assert.Equal((ushort)testValue, CoreState.ROM.u16(addr));
+                bool anyChanged = false;
+                for (int i = 0; i < (int)size; i++)
+                {
+                    if (snapshot[i] != CoreState.ROM.Data[(int)addr + i]) { anyChanged = true; break; }
+                }
+                Assert.True(anyChanged, "Write did not change any ROM bytes");
+
+                // Undo must restore every byte.
+                CoreState.Undo.RunUndo();
+                for (int i = 0; i < (int)size; i++)
+                {
+                    Assert.Equal(snapshot[i], CoreState.ROM.Data[(int)addr + i]);
+                }
+            }
+            finally
+            {
+                // Safety-net restore so the shared ROM state is clean for other tests.
+                Array.Copy(snapshot, 0, CoreState.ROM.Data, (int)addr, (int)size);
+            }
+        }
+
+        /// <summary>
+        /// Walk up from the test binary's base directory looking for
+        /// FEBuilderGBA.sln. Returns null when running outside the source tree.
+        /// </summary>
+        static string? FindRepoRoot()
+        {
+            string start = AppDomain.CurrentDomain.BaseDirectory;
+            for (DirectoryInfo? dir = new DirectoryInfo(start); dir != null; dir = dir.Parent)
+            {
+                if (File.Exists(Path.Combine(dir.FullName, "FEBuilderGBA.sln")))
+                    return dir.FullName;
+            }
+            return null;
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/Views/EventForceSortieView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventForceSortieView.axaml.cs
@@ -9,6 +9,7 @@ namespace FEBuilderGBA.Avalonia.Views
     public partial class EventForceSortieView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly EventForceSortieViewModel _vm = new();
+        readonly UndoService _undoService = new();
 
         public string ViewTitle => "Force Sortie Editor";
         public bool IsLoaded => _vm.IsLoaded;
@@ -57,15 +58,25 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void OnWrite(object? sender, RoutedEventArgs e)
         {
+            // Wrap the ROM write in an UndoService scope so Edit > Undo can
+            // revert it — _vm.Write() funnels into the bare
+            // EditorFormRef.WriteFields overload, which only records undo when
+            // an ambient ROM.BeginUndoScope is active (#1427). Mirrors the
+            // sibling EventHaikuView/MapExitPointView Begin/Commit/Rollback
+            // pattern. Runs on the UI thread (button Click), so the ambient
+            // undo is non-null.
+            _undoService.Begin("Edit Force Sortie");
             try
             {
                 _vm.Unit = (uint)(UnitUpDown.Value ?? 0);
                 _vm.Squad = (uint)(SquadUpDown.Value ?? 0);
                 _vm.ChapterId = (uint)(ChapterIdUpDown.Value ?? 0);
                 _vm.Write();
+                _undoService.Commit();
             }
             catch (Exception ex)
             {
+                _undoService.Rollback();
                 Log.Error("EventForceSortieView.OnWrite failed: {0}", ex.Message);
             }
         }

--- a/FEBuilderGBA.Avalonia/Views/EventForceSortieView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventForceSortieView.axaml.cs
@@ -31,7 +31,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventForceSortieView.LoadList failed: {0}", ex.Message);
+                Log.Error($"EventForceSortieView.LoadList failed: {ex.Message}");
             }
         }
 
@@ -44,7 +44,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventForceSortieView.OnSelected failed: {0}", ex.Message);
+                Log.Error($"EventForceSortieView.OnSelected failed: {ex.Message}");
             }
         }
 
@@ -77,7 +77,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EventForceSortieView.OnWrite failed: {0}", ex.Message);
+                Log.Error($"EventForceSortieView.OnWrite failed: {ex.Message}");
             }
         }
 


### PR DESCRIPTION
## Summary
Fixes #1427 (Class-C undo-coverage bug). The Avalonia **Force Sortie editor** (`EventForceSortieView`) wrote force-sortie entries to the ROM without opening an `UndoService` scope, so the change was committed to ROM but **not recorded in the undo buffer** — Edit > Undo could not revert it.

`EventForceSortieView.OnWrite` set three VM properties and called `_vm.Write()`, which funnels into the **bare** `EditorFormRef.WriteFields` overload. Its `rom.write_u16/write_u8` calls record undo **only when an ambient `ROM.BeginUndoScope` is active** — none was open here.

## Fix (1 production file)
`FEBuilderGBA.Avalonia/Views/EventForceSortieView.axaml.cs`:
- Add `readonly UndoService _undoService = new();`
- Wrap the property transfer + `_vm.Write()` in `_undoService.Begin("Edit Force Sortie")` / try-`Commit` / catch-`Rollback`.

This matches the **WinForms ground truth** (`EventForceSortieForm` routes its Write through `Program.Undo`) and the sibling Avalonia editors `EventHaikuView` / `MapExitPointView`. The write runs on the UI thread (button `Click`), so the ambient undo is non-null — no background-thread ambient-undo-NULL trap. No VM/Core/XAML change.

## Scope
Closes #1427. Scoped to `EventForceSortieView` only, per the issue. Note: `EventForceSortieFE7View` has the same unwrapped `_vm.Write()`/`_vm.WriteSubEntry()` pattern and is a separate out-of-scope gap (Copilot's plan review flagged this as non-blocking); it can be addressed in a follow-up.

## Test plan
- [x] **Static-analysis regression** (`EventForceSortieUndoCoverageTests.EventForceSortieView_WrapsVmWrite_InUndoScope`): scans the live `EventForceSortieView.axaml.cs` via `UndoCoverageScanner.DiscoverViewCoveredVmMethods` and asserts `("EventForceSortieViewModel","Write")` is undo-covered. **Verified FAILS pre-fix** (covered set empty), **PASSES post-fix**.
- [x] **Behavioral undo round-trip** (`Write_UnderUndoScope_IsRevertedByUndo`, ROM-gated): load entry, mutate `Unit`, write inside a scope, assert ROM bytes changed, `RunUndo`, assert byte-identical restore. PASSES.
- [x] **Avalonia.Tests** full run: 8580 passed, 0 failed, 6 skipped (includes the 2 new tests).
- [x] **FEBuilderGBA.Tests** (WinForms net9.0-windows) full run: 1925 passed, 0 failed.
- [x] **Core.Tests** full run: 5769 passed, 6 skipped, 10 failed — all 10 are the known pre-existing `SkillSystemsAnimeImportCore`/`SkillConfigSkillSystemBulkImport` failures caused by the `config/patch2` submodule not being checked out in the worktree (env-only; NOT touched by this change, NOT a regression).

## GUI Test Report
| Test | Method | Result |
|------|--------|--------|
| Editor opens & populates (FE8U) | Headless `--screenshot-all` rendered the Force Sortie editor with entry list + Address + Unit/Squad/Chapter ID fields + Write button | PASS |
| Write is undo-tracked | Static-analysis scanner confirms `OnWrite` wraps `_vm.Write()` in `_undoService.Begin/Commit` | PASS |
| Undo reverts the write byte-for-byte | Behavioral round-trip restores all 4 entry bytes after `RunUndo` | PASS |

## Screenshot (Force Sortie editor, FE8U)
![Force Sortie editor](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr1427-forcesortie-undo-fe8u.png)

🤖 Generated with Claude Code (Opus 4.8, 1M context)
