### PR TITLE
fix(avalonia): undo-track Talk Group (FE7) editor write (#1428)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/EventTalkGroupFE7UndoTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EventTalkGroupFE7UndoTests.cs
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1428 — Talk Group (FE7) editor write must be undo-tracked. The Avalonia
+// EventTalkGroupFE7View previously called _vm.Write() with NO UndoService scope,
+// so the ROM write recorded into a null ambient undo and was never captured:
+// the global Undo could not revert it and the dirty indicator never flipped.
+// The fix wraps OnWrite in
+//   _undoService.Begin(...); try { _vm.TextId=...; _vm.Write();
+//   _undoService.Commit(); _vm.MarkClean(); }
+//   catch { _undoService.Rollback(); Log.Error(...); }
+// mirroring the canonical sibling EventFunctionPointerFE7View (#1426).
+//
+// These headless tests drive the EXACT View OnWrite sequence with a REAL
+// UndoService against a synthetic FE7 ROM and prove:
+//   * Commit() records the write into CoreState.Undo (IsModified == true) and
+//     leaves the VM clean (IsDirty == false), and RunUndo() restores byte
+//     identity.
+//   * Rollback() restores byte identity.
+//   * The .axaml.cs view actually contains the undo wiring (source guard).
+//
+// [Collection("SharedState")] because the tests mutate CoreState.ROM / .Undo.
+
+using System;
+using System.IO;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+[Collection("SharedState")]
+public class EventTalkGroupFE7UndoTests : IDisposable
+{
+    const uint SlotAddr   = 0x00900000u; // talk-group entry (u32 TextId at +0)
+    const uint OrigTextId = 0x00000123u; // initial text id
+    const uint NewTextId  = 0x00000456u; // edited text id
+
+    readonly ROM? _savedRom;
+    readonly Undo? _savedUndo;
+
+    public EventTalkGroupFE7UndoTests()
+    {
+        _savedRom = CoreState.ROM;
+        _savedUndo = CoreState.Undo;
+    }
+
+    public void Dispose()
+    {
+        CoreState.ROM = _savedRom;
+        CoreState.Undo = _savedUndo;
+    }
+
+    [Fact]
+    public void Write_IsUndoable_FE7()
+    {
+        ROM rom = MakeRom();
+        CoreState.ROM = rom;
+        CoreState.Undo = new Undo();
+
+        var vm = new EventTalkGroupFE7ViewModel();
+        vm.LoadEntry(SlotAddr);
+        Assert.True(vm.IsLoaded);
+        Assert.Equal(OrigTextId, vm.TextId);
+        vm.MarkClean(); // mirror the View's load (selection settles dirty=false)
+
+        byte[] snap = (byte[])rom.Data.Clone();
+        var undoService = new UndoService();
+
+        // EXACT View OnWrite sequence (Begin -> set -> Write -> Commit -> MarkClean).
+        undoService.Begin("Edit Talk Group (FE7)");
+        vm.TextId = NewTextId;
+        vm.Write();
+        undoService.Commit();
+        vm.MarkClean();
+
+        // The write hit the ROM, was captured by the undo buffer, and the VM is
+        // clean again after the save.
+        Assert.Equal(NewTextId, rom.u32(SlotAddr));
+        Assert.True(CoreState.Undo.IsModified);
+        Assert.False(vm.IsDirty);
+
+        // Undo reverts byte-identity.
+        CoreState.Undo.RunUndo();
+        Assert.Equal(OrigTextId, rom.u32(SlotAddr));
+        Assert.Equal(snap, rom.Data);
+    }
+
+    [Fact]
+    public void Rollback_RestoresBytes_FE7()
+    {
+        ROM rom = MakeRom();
+        CoreState.ROM = rom;
+        CoreState.Undo = new Undo();
+
+        var vm = new EventTalkGroupFE7ViewModel();
+        vm.LoadEntry(SlotAddr);
+        byte[] snap = (byte[])rom.Data.Clone();
+        var undoService = new UndoService();
+
+        undoService.Begin("Edit Talk Group (FE7)");
+        vm.TextId = NewTextId;
+        vm.Write();
+        Assert.Equal(NewTextId, rom.u32(SlotAddr)); // applied inside the scope
+        undoService.Rollback();
+
+        // Rollback discards the in-scope write -> byte identity restored.
+        Assert.Equal(OrigTextId, rom.u32(SlotAddr));
+        Assert.Equal(snap, rom.Data);
+    }
+
+    [Fact]
+    public void View_OnWrite_UsesUndoScope()
+    {
+        string repoRoot = FindRepoRoot();
+        string path = Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views",
+            "EventTalkGroupFE7View.axaml.cs");
+        Assert.True(File.Exists(path), $"{path} must exist");
+        string src = File.ReadAllText(path);
+
+        Assert.Contains("readonly UndoService _undoService", src);
+        Assert.Contains("_undoService.Begin(", src);
+        Assert.Contains("_undoService.Commit()", src);
+        Assert.Contains("_undoService.Rollback()", src);
+        Assert.Contains("_vm.MarkClean()", src);
+    }
+
+    // ================================================================
+    // Helpers
+    // ================================================================
+
+    /// <summary>
+    /// Synthetic FE7 ROM with a talk-group entry planted at <see cref="SlotAddr"/>
+    /// (u32 TextId = <see cref="OrigTextId"/> at offset 0). The VM's LoadEntry
+    /// reads the u32 directly, so no event-script table is needed.
+    /// </summary>
+    static ROM MakeRom()
+    {
+        var bytes = new byte[0x1100000];
+        var rom = new ROM();
+        rom.LoadLow("synth-AE7E01-1428.gba", bytes, "AE7E01");
+        PlantU32(bytes, SlotAddr, OrigTextId);
+        return rom;
+    }
+
+    static void PlantU32(byte[] bytes, uint addr, uint value)
+    {
+        int idx = (int)addr;
+        bytes[idx + 0] = (byte)(value & 0xFF);
+        bytes[idx + 1] = (byte)((value >> 8) & 0xFF);
+        bytes[idx + 2] = (byte)((value >> 16) & 0xFF);
+        bytes[idx + 3] = (byte)((value >> 24) & 0xFF);
+    }
+
+    static string FindRepoRoot()
+    {
+        string dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 12 && dir != null; i++)
+        {
+            if (File.Exists(Path.Combine(dir, "FEBuilderGBA.sln"))) return dir;
+            dir = Path.GetDirectoryName(dir)!;
+        }
+        return AppContext.BaseDirectory;
+    }
+}

--- a/FEBuilderGBA.Avalonia/Views/EventTalkGroupFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventTalkGroupFE7View.axaml.cs
@@ -10,6 +10,7 @@ namespace FEBuilderGBA.Avalonia.Views
     public partial class EventTalkGroupFE7View : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly EventTalkGroupFE7ViewModel _vm = new();
+        readonly UndoService _undoService = new();
 
         public string ViewTitle => "Talk Group (FE7)";
         public bool IsLoaded => _vm.IsLoaded;
@@ -67,14 +68,20 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void OnWrite(object? sender, RoutedEventArgs e)
         {
+            if (!_vm.IsLoaded) return;
+
+            _undoService.Begin(R._("Edit Talk Group (FE7)"));
             try
             {
                 _vm.TextId = (uint)(TextIdUpDown.Value ?? 0);
                 _vm.Write();
+                _undoService.Commit();
+                _vm.MarkClean();
             }
             catch (Exception ex)
             {
-                Log.Error("EventTalkGroupFE7View.OnWrite failed: {0}", ex.Message);
+                _undoService.Rollback();
+                Log.Error("EventTalkGroupFE7View.OnWrite failed: " + ex.ToString());
             }
         }
 


### PR DESCRIPTION
## Summary
Fixes #1428 — the Avalonia **Talk Group (FE7)** editor (`EventTalkGroupFE7View`) called `_vm.Write()` with no `UndoService` scope. The bare `WriteFields → rom.write_u32` recorded into a null ambient undo, so the write was committed but never captured: the global Undo could not revert it and the dirty indicator never flipped (bug class **C**, undo coverage).

Pure **View-layer fix**, no ViewModel/Core change, mirroring the merged canonical sibling **#1426** (`EventFunctionPointerFE7View`):
- add `readonly UndoService _undoService = new();`
- guard `if (!_vm.IsLoaded) return;`
- wrap `OnWrite`: `Begin(R._("Edit Talk Group (FE7)")) → set TextId → _vm.Write() → Commit() → _vm.MarkClean();` with `catch → Rollback() + Log.Error`.

The write runs synchronously on the UI thread, so `Begin` opens the ambient scope on the same thread that performs the write (no background-thread ambient-undo-NULL trap). `Commit()` fires `NotifyUnsavedChanges()` (global dirty flips); `MarkClean()` resets the per-VM `IsDirty`.

## Plan reference
Plan posted on #1428 and reviewed by Copilot CLI (no blocking concerns) before implementation.

## Scope
Closes #1428. View-layer only: `EventTalkGroupFE7View.axaml.cs` (1 file) + new test file.

## Test plan
- [x] `EventTalkGroupFE7UndoTests.Write_IsUndoable_FE7` — real `UndoService` round-trip: `Commit()` records into `CoreState.Undo` (`IsModified==true`), VM clean after save (`IsDirty==false`), `RunUndo()` restores byte-identity.
- [x] `EventTalkGroupFE7UndoTests.Rollback_RestoresBytes_FE7` — `Rollback()` discards the in-scope write, byte-identity restored.
- [x] `EventTalkGroupFE7UndoTests.View_OnWrite_UsesUndoScope` — source guard asserts the `.axaml.cs` carries the `Begin/Commit/Rollback/MarkClean` wiring.
- [x] FEBuilderGBA.Avalonia.Tests: 8608 passed, 0 failed (3 new tests included).
- [x] FEBuilderGBA.Tests (net9.0-windows): 1925 passed, 0 failed.
- [x] FEBuilderGBA.Core.Tests: 5769 passed; 10 failures are the KNOWN pre-existing worktree-env `Skill*` cases (unpopulated `config/patch2` submodule), unrelated to this change.

## Screenshots
The actual running Avalonia **Talk Group (FE7)** editor (FE7U.gba) with populated data (Address `0x00CA7A40`, Text ID `61`) — the editor whose Write is now undo-tracked:

![Talk Group (FE7) editor](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr1428-talkgroupfe7-undo.png)

## GUI Test Report
| Test | Result |
| --- | --- |
| Write records into global Undo (`IsModified`) | PASS |
| VM dirty flag clears after save (`IsDirty==false`) | PASS |
| Undo restores byte-identity | PASS |
| Rollback restores byte-identity | PASS |
| View carries Begin/Commit/Rollback/MarkClean wiring | PASS |

🤖 Generated with Claude Code (Opus 4.8, 1M context)
