### PR TITLE
fix(avalonia): make EventBattleDataFE7 editor editable + undo-tracked Write (#1436)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/EventBattleDataFE7ViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EventBattleDataFE7ViewModelTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reflection;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
@@ -11,108 +12,104 @@ using Xunit.Abstractions;
 namespace FEBuilderGBA.Avalonia.Tests;
 
 /// <summary>
-/// Headless ROM-backed tests for the FE7 event battle-data editor (issue #1436 —
-/// the Avalonia <see cref="EventBattleDataFE7View"/> was display-only; this verifies the
-/// editable W0/B2/B3 NumericUpDowns + undo-tracked Write button, matching WinForms
+/// Tests for the FE7 event battle-data editor (issue #1436 — the Avalonia
+/// <see cref="EventBattleDataFE7View"/> was display-only; this verifies the editable
+/// W0/B2/B3 NumericUpDowns + undo-tracked Write button, matching WinForms
 /// <c>EventBattleDataFE7Form</c>).
 ///
 /// Battle-data struct = 4-byte entry:
 ///   W0 = u16 attack type @ +0x00, B2 = u8 attacker/side @ +0x02, B3 = u8 damage @ +0x03.
+///
+/// The LoadEntry/Write/undo tests build a deterministic SYNTHETIC ROM with a known
+/// battle-data entry, so they run identically with or without a real ROM checkout
+/// (the scan-based LoadList path needs real event scripts and is a separate
+/// SkippableFact gated on <see cref="RomFixture"/>).
 /// </summary>
 [Collection("SharedState")]
-public class EventBattleDataFE7ViewModelTests : IClassFixture<RomFixture>
+public class EventBattleDataFE7ViewModelTests : IClassFixture<RomFixture>, IDisposable
 {
     private readonly RomFixture _fixture;
     private readonly ITestOutputHelper _output;
+    private readonly ROM? _savedRom;
+    private readonly Undo? _savedUndo;
+
+    // Fixed address of the synthetic battle-data entry.
+    const uint EntryAddr = 0x1000;
 
     public EventBattleDataFE7ViewModelTests(RomFixture fixture, ITestOutputHelper output)
     {
         _fixture = fixture;
         _output = output;
+        _savedRom = CoreState.ROM;
+        _savedUndo = CoreState.Undo;
     }
 
-    // The battle-data scan only finds entries inside FE7-family event scripts.
-    bool Skip(out uint addr)
+    public void Dispose()
     {
-        addr = 0;
-        if (!_fixture.IsAvailable || CoreState.ROM?.RomInfo == null)
-        {
-            _output.WriteLine("ROM not available — skipping.");
-            return true;
-        }
-        addr = EventSubEditorHelper.FindFirstBattleDataAddr(CoreState.ROM);
-        if (addr == 0)
-        {
-            _output.WriteLine($"No FE7 battle-data address found (version {_fixture.Version}) — skipping.");
-            return true;
-        }
-        return false;
+        CoreState.ROM = _savedRom;
+        CoreState.Undo = _savedUndo;
+    }
+
+    /// <summary>
+    /// Install a deterministic synthetic ROM with one 4-byte battle-data entry at
+    /// <see cref="EntryAddr"/> (W0=0x0123, B2=0x45, B3=0x67) and a fresh undo buffer.
+    /// </summary>
+    static ROM MakeSyntheticRom()
+    {
+        var rom = new ROM();
+        rom.LoadLow("battledata-1436.gba", new byte[0x200000], "NAZO");
+        rom.Data[EntryAddr + 0] = 0x23; // W0 low
+        rom.Data[EntryAddr + 1] = 0x01; // W0 high
+        rom.Data[EntryAddr + 2] = 0x45; // B2
+        rom.Data[EntryAddr + 3] = 0x67; // B3
+        CoreState.ROM = rom;
+        CoreState.Undo = new Undo();
+        return rom;
     }
 
     // ====================================================================
-    // ViewModel: read / write round-trip
+    // ViewModel: read / write round-trip (deterministic synthetic ROM)
     // ====================================================================
-
-    [Fact]
-    public void LoadList_ReturnsBattleDataEntry()
-    {
-        if (Skip(out uint addr)) return;
-
-        var vm = new EventBattleDataFE7ViewModel();
-        var list = vm.LoadList();
-
-        Assert.NotEmpty(list);
-        Assert.Equal(addr, list[0].addr);
-        Assert.Equal(1, vm.GetListCount());
-    }
 
     [Fact]
     public void LoadEntry_ReadsStructFields()
     {
-        if (Skip(out uint addr)) return;
+        MakeSyntheticRom();
 
         var vm = new EventBattleDataFE7ViewModel();
-        vm.LoadEntry(addr);
+        vm.LoadEntry(EntryAddr);
 
         Assert.True(vm.IsLoaded);
-        Assert.Equal(addr, vm.CurrentAddr);
-        Assert.Equal((uint)CoreState.ROM.u16(addr + 0), vm.AttackType);
-        Assert.Equal((uint)CoreState.ROM.u8(addr + 2), vm.Attacker);
-        Assert.Equal((uint)CoreState.ROM.u8(addr + 3), vm.Damage);
+        Assert.Equal(EntryAddr, vm.CurrentAddr);
+        Assert.Equal(0x0123u, vm.AttackType);
+        Assert.Equal(0x45u, vm.Attacker);
+        Assert.Equal(0x67u, vm.Damage);
     }
 
     [Fact]
     public void Write_RoundTripsAllFields()
     {
-        if (Skip(out uint addr)) return;
+        var rom = MakeSyntheticRom();
 
         var vm = new EventBattleDataFE7ViewModel();
-        vm.LoadEntry(addr);
+        vm.LoadEntry(EntryAddr);
 
-        uint w0 = vm.AttackType, b2 = vm.Attacker, b3 = vm.Damage;
-        try
-        {
-            vm.AttackType = 0x0123;
-            vm.Attacker = 0x45;
-            vm.Damage = 0x67;
-            vm.Write();
+        vm.AttackType = 0x0ABC;
+        vm.Attacker = 0x12;
+        vm.Damage = 0x34;
+        vm.Write();
 
-            var vm2 = new EventBattleDataFE7ViewModel();
-            vm2.LoadEntry(addr);
-            Assert.Equal(0x0123u, vm2.AttackType);
-            Assert.Equal(0x45u, vm2.Attacker);
-            Assert.Equal(0x67u, vm2.Damage);
+        // Raw ROM bytes match the written values (little-endian u16 + two bytes).
+        Assert.Equal((ushort)0x0ABC, rom.u16(EntryAddr + 0));
+        Assert.Equal((byte)0x12, rom.u8(EntryAddr + 2));
+        Assert.Equal((byte)0x34, rom.u8(EntryAddr + 3));
 
-            // Raw ROM bytes match the written values.
-            Assert.Equal((ushort)0x0123, CoreState.ROM.u16(addr + 0));
-            Assert.Equal((byte)0x45, CoreState.ROM.u8(addr + 2));
-            Assert.Equal((byte)0x67, CoreState.ROM.u8(addr + 3));
-        }
-        finally
-        {
-            vm.AttackType = w0; vm.Attacker = b2; vm.Damage = b3;
-            vm.Write();
-        }
+        // A fresh VM reads the persisted values back.
+        var vm2 = new EventBattleDataFE7ViewModel();
+        vm2.LoadEntry(EntryAddr);
+        Assert.Equal(0x0ABCu, vm2.AttackType);
+        Assert.Equal(0x12u, vm2.Attacker);
+        Assert.Equal(0x34u, vm2.Damage);
     }
 
     // ====================================================================
@@ -134,49 +131,68 @@ public class EventBattleDataFE7ViewModelTests : IClassFixture<RomFixture>
     [AvaloniaFact]
     public void View_WriteButton_PersistsEdits_AndUndoRestores()
     {
-        if (Skip(out uint addr)) return;
+        var rom = MakeSyntheticRom();
+        byte[] original = rom.getBinaryData(EntryAddr, 4);
 
-        Undo? prevUndo = CoreState.Undo;
-        CoreState.Undo = new Undo();
-        try
-        {
-            var view = new EventBattleDataFE7View();
+        var view = new EventBattleDataFE7View();
 
-            // Reach the private VM and load the resolved entry (drives the same
-            // path OnSelected would, without needing the window Opened event).
-            var vmField = typeof(EventBattleDataFE7View).GetField(
-                "_vm", BindingFlags.Instance | BindingFlags.NonPublic);
-            Assert.NotNull(vmField);
-            var vm = (EventBattleDataFE7ViewModel)vmField!.GetValue(view)!;
-            vm.LoadEntry(addr);
-            Assert.True(vm.IsLoaded);
+        // Reach the private VM and load the synthetic entry (drives the same path
+        // OnSelected would, without needing the window Opened event).
+        var vmField = typeof(EventBattleDataFE7View).GetField(
+            "_vm", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(vmField);
+        var vm = (EventBattleDataFE7ViewModel)vmField!.GetValue(view)!;
+        vm.LoadEntry(EntryAddr);
+        Assert.True(vm.IsLoaded);
 
-            byte[] original = CoreState.ROM.getBinaryData(addr, 4);
+        // Populate the editable controls (as UpdateUI would), then drive the real
+        // Write button through its Click handler.
+        var attackType = view.FindControl<NumericUpDown>("AttackTypeUpDown")!;
+        var attacker = view.FindControl<NumericUpDown>("AttackerUpDown")!;
+        var damage = view.FindControl<NumericUpDown>("DamageUpDown")!;
+        attackType.Value = 0x0DEF;
+        attacker.Value = 0x21;
+        damage.Value = 0x43;
 
-            // Populate the editable controls (as UpdateUI would), then drive the
-            // real Write button through its Click handler.
-            var attackType = view.FindControl<NumericUpDown>("AttackTypeUpDown")!;
-            var attacker = view.FindControl<NumericUpDown>("AttackerUpDown")!;
-            var damage = view.FindControl<NumericUpDown>("DamageUpDown")!;
-            attackType.Value = 0x0ABC;
-            attacker.Value = 0x12;
-            damage.Value = 0x34;
+        var writeButton = view.FindControl<Button>("WriteButton")!;
+        writeButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
 
-            var writeButton = view.FindControl<Button>("WriteButton")!;
-            writeButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+        // The edit is persisted to ROM.
+        Assert.Equal((ushort)0x0DEF, rom.u16(EntryAddr + 0));
+        Assert.Equal((byte)0x21, rom.u8(EntryAddr + 2));
+        Assert.Equal((byte)0x43, rom.u8(EntryAddr + 3));
 
-            // The edit is persisted to ROM.
-            Assert.Equal((ushort)0x0ABC, CoreState.ROM.u16(addr + 0));
-            Assert.Equal((byte)0x12, CoreState.ROM.u8(addr + 2));
-            Assert.Equal((byte)0x34, CoreState.ROM.u8(addr + 3));
+        // Undo-tracked (the OnWrite handler wraps Write in UndoService.Begin/Commit):
+        // rolling back restores the original four bytes byte-identically.
+        CoreState.Undo!.RunUndo();
+        Assert.Equal(original, rom.getBinaryData(EntryAddr, 4));
+    }
 
-            // Undo-tracked: rolling back restores the original four bytes.
-            CoreState.Undo!.RunUndo();
-            Assert.Equal(original, CoreState.ROM.getBinaryData(addr, 4));
-        }
-        finally
-        {
-            CoreState.Undo = prevUndo;
-        }
+    // ====================================================================
+    // Real-ROM scan path (LoadList needs real FE7 event scripts) — a true
+    // SKIP (not a silent pass) when no battle-data address resolves.
+    // ====================================================================
+
+    [SkippableFact]
+    public void LoadList_ReturnsBattleDataEntry_OnRealRom()
+    {
+        Skip.IfNot(_fixture.IsAvailable && CoreState.ROM?.RomInfo != null,
+            "No ROM available for the LoadList scan path.");
+
+        uint addr = EventSubEditorHelper.FindFirstBattleDataAddr(CoreState.ROM);
+        Skip.If(addr == 0,
+            $"No FE7 battle-data address found (version {_fixture.Version}).");
+
+        var vm = new EventBattleDataFE7ViewModel();
+        var list = vm.LoadList();
+
+        Assert.NotEmpty(list);
+        Assert.Equal(addr, list[0].addr);
+        Assert.Equal(1, vm.GetListCount());
+
+        // LoadList resolves and loads the entry; its fields match raw ROM.
+        Assert.Equal((uint)CoreState.ROM.u16(addr + 0), vm.AttackType);
+        Assert.Equal((uint)CoreState.ROM.u8(addr + 2), vm.Attacker);
+        Assert.Equal((uint)CoreState.ROM.u8(addr + 3), vm.Damage);
     }
 }

--- a/FEBuilderGBA.Avalonia.Tests/EventBattleDataFE7ViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EventBattleDataFE7ViewModelTests.cs
@@ -1,0 +1,182 @@
+using System.Reflection;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Interactivity;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+/// <summary>
+/// Headless ROM-backed tests for the FE7 event battle-data editor (issue #1436 —
+/// the Avalonia <see cref="EventBattleDataFE7View"/> was display-only; this verifies the
+/// editable W0/B2/B3 NumericUpDowns + undo-tracked Write button, matching WinForms
+/// <c>EventBattleDataFE7Form</c>).
+///
+/// Battle-data struct = 4-byte entry:
+///   W0 = u16 attack type @ +0x00, B2 = u8 attacker/side @ +0x02, B3 = u8 damage @ +0x03.
+/// </summary>
+[Collection("SharedState")]
+public class EventBattleDataFE7ViewModelTests : IClassFixture<RomFixture>
+{
+    private readonly RomFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public EventBattleDataFE7ViewModelTests(RomFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    // The battle-data scan only finds entries inside FE7-family event scripts.
+    bool Skip(out uint addr)
+    {
+        addr = 0;
+        if (!_fixture.IsAvailable || CoreState.ROM?.RomInfo == null)
+        {
+            _output.WriteLine("ROM not available — skipping.");
+            return true;
+        }
+        addr = EventSubEditorHelper.FindFirstBattleDataAddr(CoreState.ROM);
+        if (addr == 0)
+        {
+            _output.WriteLine($"No FE7 battle-data address found (version {_fixture.Version}) — skipping.");
+            return true;
+        }
+        return false;
+    }
+
+    // ====================================================================
+    // ViewModel: read / write round-trip
+    // ====================================================================
+
+    [Fact]
+    public void LoadList_ReturnsBattleDataEntry()
+    {
+        if (Skip(out uint addr)) return;
+
+        var vm = new EventBattleDataFE7ViewModel();
+        var list = vm.LoadList();
+
+        Assert.NotEmpty(list);
+        Assert.Equal(addr, list[0].addr);
+        Assert.Equal(1, vm.GetListCount());
+    }
+
+    [Fact]
+    public void LoadEntry_ReadsStructFields()
+    {
+        if (Skip(out uint addr)) return;
+
+        var vm = new EventBattleDataFE7ViewModel();
+        vm.LoadEntry(addr);
+
+        Assert.True(vm.IsLoaded);
+        Assert.Equal(addr, vm.CurrentAddr);
+        Assert.Equal((uint)CoreState.ROM.u16(addr + 0), vm.AttackType);
+        Assert.Equal((uint)CoreState.ROM.u8(addr + 2), vm.Attacker);
+        Assert.Equal((uint)CoreState.ROM.u8(addr + 3), vm.Damage);
+    }
+
+    [Fact]
+    public void Write_RoundTripsAllFields()
+    {
+        if (Skip(out uint addr)) return;
+
+        var vm = new EventBattleDataFE7ViewModel();
+        vm.LoadEntry(addr);
+
+        uint w0 = vm.AttackType, b2 = vm.Attacker, b3 = vm.Damage;
+        try
+        {
+            vm.AttackType = 0x0123;
+            vm.Attacker = 0x45;
+            vm.Damage = 0x67;
+            vm.Write();
+
+            var vm2 = new EventBattleDataFE7ViewModel();
+            vm2.LoadEntry(addr);
+            Assert.Equal(0x0123u, vm2.AttackType);
+            Assert.Equal(0x45u, vm2.Attacker);
+            Assert.Equal(0x67u, vm2.Damage);
+
+            // Raw ROM bytes match the written values.
+            Assert.Equal((ushort)0x0123, CoreState.ROM.u16(addr + 0));
+            Assert.Equal((byte)0x45, CoreState.ROM.u8(addr + 2));
+            Assert.Equal((byte)0x67, CoreState.ROM.u8(addr + 3));
+        }
+        finally
+        {
+            vm.AttackType = w0; vm.Attacker = b2; vm.Damage = b3;
+            vm.Write();
+        }
+    }
+
+    // ====================================================================
+    // View-level regression test (the actual #1436 bug was in the View):
+    // controls exist, Write button persists edits, undo restores bytes.
+    // ====================================================================
+
+    [AvaloniaFact]
+    public void View_HasEditableControlsAndWriteButton()
+    {
+        var view = new EventBattleDataFE7View();
+
+        Assert.NotNull(view.FindControl<NumericUpDown>("AttackTypeUpDown"));
+        Assert.NotNull(view.FindControl<NumericUpDown>("AttackerUpDown"));
+        Assert.NotNull(view.FindControl<NumericUpDown>("DamageUpDown"));
+        Assert.NotNull(view.FindControl<Button>("WriteButton"));
+    }
+
+    [AvaloniaFact]
+    public void View_WriteButton_PersistsEdits_AndUndoRestores()
+    {
+        if (Skip(out uint addr)) return;
+
+        Undo? prevUndo = CoreState.Undo;
+        CoreState.Undo = new Undo();
+        try
+        {
+            var view = new EventBattleDataFE7View();
+
+            // Reach the private VM and load the resolved entry (drives the same
+            // path OnSelected would, without needing the window Opened event).
+            var vmField = typeof(EventBattleDataFE7View).GetField(
+                "_vm", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(vmField);
+            var vm = (EventBattleDataFE7ViewModel)vmField!.GetValue(view)!;
+            vm.LoadEntry(addr);
+            Assert.True(vm.IsLoaded);
+
+            byte[] original = CoreState.ROM.getBinaryData(addr, 4);
+
+            // Populate the editable controls (as UpdateUI would), then drive the
+            // real Write button through its Click handler.
+            var attackType = view.FindControl<NumericUpDown>("AttackTypeUpDown")!;
+            var attacker = view.FindControl<NumericUpDown>("AttackerUpDown")!;
+            var damage = view.FindControl<NumericUpDown>("DamageUpDown")!;
+            attackType.Value = 0x0ABC;
+            attacker.Value = 0x12;
+            damage.Value = 0x34;
+
+            var writeButton = view.FindControl<Button>("WriteButton")!;
+            writeButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+            // The edit is persisted to ROM.
+            Assert.Equal((ushort)0x0ABC, CoreState.ROM.u16(addr + 0));
+            Assert.Equal((byte)0x12, CoreState.ROM.u8(addr + 2));
+            Assert.Equal((byte)0x34, CoreState.ROM.u8(addr + 3));
+
+            // Undo-tracked: rolling back restores the original four bytes.
+            CoreState.Undo!.RunUndo();
+            Assert.Equal(original, CoreState.ROM.getBinaryData(addr, 4));
+        }
+        finally
+        {
+            CoreState.Undo = prevUndo;
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/EventBattleDataFE7ViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EventBattleDataFE7ViewModelTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Interactivity;
@@ -136,12 +135,9 @@ public class EventBattleDataFE7ViewModelTests : IClassFixture<RomFixture>, IDisp
 
         var view = new EventBattleDataFE7View();
 
-        // Reach the private VM and load the synthetic entry (drives the same path
-        // OnSelected would, without needing the window Opened event).
-        var vmField = typeof(EventBattleDataFE7View).GetField(
-            "_vm", BindingFlags.Instance | BindingFlags.NonPublic);
-        Assert.NotNull(vmField);
-        var vm = (EventBattleDataFE7ViewModel)vmField!.GetValue(view)!;
+        // Load the synthetic entry via the view's real VM (exposed as DataViewModel),
+        // driving the same path OnSelected would, without needing the window Opened event.
+        var vm = Assert.IsType<EventBattleDataFE7ViewModel>(view.DataViewModel);
         vm.LoadEntry(EntryAddr);
         Assert.True(vm.IsLoaded);
 

--- a/FEBuilderGBA.Avalonia/Views/EventBattleDataFE7View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EventBattleDataFE7View.axaml
@@ -11,10 +11,29 @@
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="Battle Data (FE7)" FontSize="18" FontWeight="Bold" />
 
-        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto">
+        <Grid ColumnDefinitions="160,200" RowDefinitions="Auto,Auto,Auto,Auto">
           <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
           <TextBlock AutomationProperties.AutomationId="EventBattleDataFE7_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
+
+          <TextBlock Grid.Row="1" Grid.Column="0" Text="Attack Type (W0):" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleDataFE7_AttackTypeUpDown_Input" FormatString="0" Grid.Row="1" Grid.Column="1" Name="AttackTypeUpDown" Minimum="0" Maximum="65535"
+                         Margin="0,4" />
+
+          <TextBlock Grid.Row="2" Grid.Column="0" Text="Attacker / Side (B2):" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleDataFE7_AttackerUpDown_Input" FormatString="0" Grid.Row="2" Grid.Column="1" Name="AttackerUpDown" Minimum="0" Maximum="255"
+                         Margin="0,4" />
+
+          <TextBlock Grid.Row="3" Grid.Column="0" Text="Damage (B3):" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleDataFE7_DamageUpDown_Input" FormatString="0" Grid.Row="3" Grid.Column="1" Name="DamageUpDown" Minimum="0" Maximum="255"
+                         Margin="0,4" />
         </Grid>
+
+        <TextBlock Text="Attack Type (W0, decimal input; reference hex values): 0x0000=Attack, 0x0001=Critical, 0x0002=Miss, 0x0040=Poison, 0x0080=Devil Axe, 0x0100=HP Restoring, 0x0200=HP Halving, 0x0800=Instant kill"
+                   FontSize="11" Foreground="Gray" TextWrapping="Wrap" Margin="0,4" />
+        <TextBlock Text="Attacker / Side (B2, decimal input; reference hex values): 0x00=Attacker starts, 0x01=Attacker starts (counter next), 0x08=Counter starts, 0x09=Counter starts (counter next), 0x0A=Counter starts 2, 0x80=Battle end"
+                   FontSize="11" Foreground="Gray" TextWrapping="Wrap" Margin="0,4" />
+
+        <Button AutomationProperties.AutomationId="EventBattleDataFE7_Write_Button" Name="WriteButton" Content="Write" HorizontalAlignment="Left" Margin="0,8" />
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/FEBuilderGBA.Avalonia/Views/EventBattleDataFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventBattleDataFE7View.axaml.cs
@@ -39,12 +39,18 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
+                _vm.IsLoading = true;
                 _vm.LoadEntry(addr);
                 UpdateUI();
             }
             catch (Exception ex)
             {
                 Log.Error("EventBattleDataFE7View.OnSelected failed: " + ex.ToString());
+            }
+            finally
+            {
+                _vm.IsLoading = false;
+                _vm.MarkClean();
             }
         }
 
@@ -68,6 +74,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.Damage = (uint)(DamageUpDown.Value ?? 0);
                 _vm.Write();
                 _undoService.Commit();
+                _vm.MarkClean();
             }
             catch (Exception ex)
             {

--- a/FEBuilderGBA.Avalonia/Views/EventBattleDataFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventBattleDataFE7View.axaml.cs
@@ -9,6 +9,7 @@ namespace FEBuilderGBA.Avalonia.Views
     public partial class EventBattleDataFE7View : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly EventBattleDataFE7ViewModel _vm = new();
+        readonly UndoService _undoService = new();
 
         public string ViewTitle => "Battle Data (FE7)";
         public bool IsLoaded => _vm.IsLoaded;
@@ -17,6 +18,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
+            WriteButton.Click += OnWrite;
             Opened += (_, _) => LoadList();
         }
 
@@ -49,6 +51,29 @@ namespace FEBuilderGBA.Avalonia.Views
         void UpdateUI()
         {
             AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+            AttackTypeUpDown.Value = _vm.AttackType;
+            AttackerUpDown.Value = _vm.Attacker;
+            DamageUpDown.Value = _vm.Damage;
+        }
+
+        void OnWrite(object? sender, RoutedEventArgs e)
+        {
+            if (!_vm.IsLoaded) return;
+
+            _undoService.Begin(R._("Edit Battle Data (FE7)"));
+            try
+            {
+                _vm.AttackType = (uint)(AttackTypeUpDown.Value ?? 0);
+                _vm.Attacker = (uint)(AttackerUpDown.Value ?? 0);
+                _vm.Damage = (uint)(DamageUpDown.Value ?? 0);
+                _vm.Write();
+                _undoService.Commit();
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.Error("EventBattleDataFE7View.OnWrite failed: {0}", ex.Message);
+            }
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/FEBuilderGBA.Avalonia/Views/EventBattleDataFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventBattleDataFE7View.axaml.cs
@@ -31,7 +31,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventBattleDataFE7View.LoadList failed: {0}", ex.Message);
+                Log.Error("EventBattleDataFE7View.LoadList failed: " + ex.ToString());
             }
         }
 
@@ -44,7 +44,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventBattleDataFE7View.OnSelected failed: {0}", ex.Message);
+                Log.Error("EventBattleDataFE7View.OnSelected failed: " + ex.ToString());
             }
         }
 
@@ -72,7 +72,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EventBattleDataFE7View.OnWrite failed: {0}", ex.Message);
+                Log.Error("EventBattleDataFE7View.OnWrite failed: " + ex.ToString());
             }
         }
 

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -12286,3 +12286,18 @@ PLISTテーブルを分割しました。
 
 :Template config file not found.
 テンプレート設定ファイルが見つかりません。
+
+:Attack Type (W0):
+攻撃方法 (W0):
+
+:Attacker / Side (B2):
+攻撃側 (B2):
+
+:Damage (B3):
+ダメージ (B3):
+
+:Attack Type (W0, decimal input; reference hex values): 0x0000=Attack, 0x0001=Critical, 0x0002=Miss, 0x0040=Poison, 0x0080=Devil Axe, 0x0100=HP Restoring, 0x0200=HP Halving, 0x0800=Instant kill
+攻撃方法 (W0、10進数で入力; 参考の16進値): 0x0000=攻撃, 0x0001=必殺, 0x0002=ミス, 0x0040=毒, 0x0080=デビルアクス, 0x0100=HP回復, 0x0200=HP半減, 0x0800=瞬殺
+
+:Attacker / Side (B2, decimal input; reference hex values): 0x00=Attacker starts, 0x01=Attacker starts (counter next), 0x08=Counter starts, 0x09=Counter starts (counter next), 0x0A=Counter starts 2, 0x80=Battle end
+攻撃側 (B2、10進数で入力; 参考の16進値): 0x00=攻撃側から攻撃開始, 0x01=攻撃側から攻撃開始(次は相手), 0x08=反撃側から攻撃開始, 0x09=反撃側から攻撃開始(次は相手), 0x0A=反撃側から攻撃開始2, 0x80=戦闘終端

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -26130,3 +26130,18 @@ PLIST 表已分割。
 
 :Template config file not found.
 找不到模板配置文件。
+
+:Attack Type (W0):
+攻击方法 (W0):
+
+:Attacker / Side (B2):
+攻击方 (B2):
+
+:Damage (B3):
+伤害 (B3):
+
+:Attack Type (W0, decimal input; reference hex values): 0x0000=Attack, 0x0001=Critical, 0x0002=Miss, 0x0040=Poison, 0x0080=Devil Axe, 0x0100=HP Restoring, 0x0200=HP Halving, 0x0800=Instant kill
+攻击方法 (W0，十进制输入; 参考十六进制值): 0x0000=攻击, 0x0001=必杀, 0x0002=未命中, 0x0040=中毒, 0x0080=魔斧, 0x0100=回复HP, 0x0200=减半HP, 0x0800=秒杀
+
+:Attacker / Side (B2, decimal input; reference hex values): 0x00=Attacker starts, 0x01=Attacker starts (counter next), 0x08=Counter starts, 0x09=Counter starts (counter next), 0x0A=Counter starts 2, 0x80=Battle end
+攻击方 (B2，十进制输入; 参考十六进制值): 0x00=攻击方先攻, 0x01=攻击方先攻(下次反击), 0x08=反击方先攻, 0x09=反击方先攻(下次反击), 0x0A=反击方先攻2, 0x80=战斗结束

--- a/docs/avalonia-forms.md
+++ b/docs/avalonia-forms.md
@@ -202,7 +202,7 @@ Editors for event scripts, conditions, units, templates, and related data.
 | 101 | EventBattleTalkMainView | EventBattleTalkMainViewModel | Nested sub-view for battle talk |
 | 102 | EventBattleTalkFE6View | EventBattleTalkFE6ViewModel | Battle conversation (FE6) |
 | 103 | EventBattleTalkFE7View | EventBattleTalkFE7ViewModel | Battle conversation (FE7) |
-| 104 | EventBattleDataFE7View | EventBattleDataFE7ViewModel | Battle data editor (FE7) |
+| 104 | EventBattleDataFE7View | EventBattleDataFE7ViewModel | Battle data editor (FE7) — editable AttackType/Attacker/Damage + undo-tracked Write (#1436) |
 | 105 | EventHaikuView | EventHaikuViewModel | Haiku/death quote editor |
 | 106 | EventHaikuFE6View | EventHaikuFE6ViewModel | Death quotes (FE6) |
 | 107 | EventHaikuFE7View | EventHaikuFE7ViewModel | Death quotes (FE7) |


### PR DESCRIPTION
## Summary
Closes #1436. The Avalonia `EventBattleDataFE7View` was display-only — it surfaced only a read-only Address label and never bound or wrote the FE7 event battle-data fields. The ViewModel already fully implemented `AttackType (W0)/Attacker (B2)/Damage (B3)` + `Write()`, but the View never referenced them.

This wires the View to match WinForms `EventBattleDataFE7Form`, mirroring the sibling `EventBattleTalkView` edit+Write pattern:
- Add `NumericUpDown`s for **AttackType** (W0, u16 @0x00), **Attacker/Side** (B2, u8 @0x02), **Damage** (B3, u8 @0x03) + reference hint labels (ported from the WinForms combo item lists) + a **Write** button.
- `UpdateUI` populates the three NumericUpDowns.
- `OnWrite` is **undo-tracked** via `UndoService.Begin/Commit/Rollback` (`IsLoaded` guard; commit only after `Write()` succeeds; rollback on exception) — stronger than the bare `_vm.Write()` in `EventMoveDataFE7View`.

Plan + Copilot CLI plan-review: https://github.com/laqieer/FEBuilderGBA/issues/1436#issuecomment-4799950453

## Scope
- Closes #1436.
- Makes the resolved battle-data entry editable + writable. `NewAlloc`/`AllocIfNeed` (list allocation/expansion) are intentionally out of scope for this stub fix — not claimed as full WinForms parity.

## GUI Test Report
| # | Test | Result |
|---|------|--------|
| 1 | `View_HasEditableControlsAndWriteButton` — AttackType/Attacker/Damage NumericUpDowns + Write button exist | PASS |
| 2 | `View_WriteButton_PersistsEdits_AndUndoRestores` — driving the real `WriteButton.Click` persists ROM bytes @ `addr+0..3`; `Undo.RunUndo()` restores the original 4 bytes | PASS |
| 3 | `LoadList_ReturnsBattleDataEntry` | PASS |
| 4 | `LoadEntry_ReadsStructFields` — W0/B2/B3 match raw ROM | PASS |
| 5 | `Write_RoundTripsAllFields` — VM Write round-trips all three fields | PASS |

Screenshot below shows the editor with a real FE7U battle-data entry loaded (Address `0x00CA7A40`, Attack Type `61`), the editable spinners, reference hints, and the Write button.

## Screenshots
![EventBattleDataFE7 editor (FE7U) — editable AttackType/Attacker/Damage + Write](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr1436-eventbattledatafe7-fe7u.png)

## Test plan
- [x] `dotnet build FEBuilderGBA.Avalonia` — 0 errors
- [x] New `EventBattleDataFE7ViewModelTests` (5 tests) all PASS, incl. the View-level Write+undo regression
- [x] Full `FEBuilderGBA.Avalonia.Tests` suite run (known pre-existing SkiaSharp-env failures excluded)
- [x] `FEBuilderGBA.Core.Tests` run (known pre-existing Skill* worktree-env failures excluded)
- [x] `FEBuilderGBA.Tests` (net9.0-windows) run
- [x] Headless real-rasterizer screenshot of the editor with populated FE7U data
- [x] Docs updated (`docs/avalonia-forms.md`)

🤖 Generated with Claude Code (Opus 4.8, 1M context)
