### PR TITLE
fix(avalonia): FE7 Battle Dialogue editor — add input fields + Write button (#1437)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/EventBattleTalkFE7ScreenshotTest.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EventBattleTalkFE7ScreenshotTest.cs
@@ -1,0 +1,127 @@
+using System;
+using System.IO;
+using System.Reflection;
+using global::Avalonia;
+using global::Avalonia.Controls;
+using global::Avalonia.Headless.XUnit;
+using global::Avalonia.Media.Imaging;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.Views;
+using FEBuilderGBA.SkiaSharp;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    /// <summary>
+    /// Issue #1437: render the Avalonia <see cref="EventBattleTalkFE7View"/> on a
+    /// real FE7J ROM, select the first Main (16-byte) battle-talk entry, and
+    /// capture a PNG proving the editor is no longer display-only — the detail
+    /// pane now shows populated input fields (attacker/defender units, text,
+    /// event pointer, achievement flag) + a Write button.
+    ///
+    /// HEADLESS render (Avalonia.Headless + RenderTargetBitmap) — works even when
+    /// the desktop is locked. Output defaults to a per-test temp dir; set
+    /// FEBUILDERGBA_SCREENSHOT_DIR to the repo's pr-screenshots/ to regenerate the
+    /// canonical PR screenshot. Mirrors <see cref="ItemNewAllocScreenshotTest"/>.
+    /// The data-layer assertions (inputs populated + Write button present) remain
+    /// the proof regardless of whether the headless raster pipeline succeeds.
+    /// </summary>
+    [Collection("SharedState")]
+    public class EventBattleTalkFE7ScreenshotTest
+    {
+        readonly ITestOutputHelper _output;
+
+        public EventBattleTalkFE7ScreenshotTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [AvaloniaFact]
+        public void BattleTalkFE7Editor_SelectFirst_PopulatesInputs_SavesScreenshot()
+        {
+            RomTestHelper.WithRom("FE7J", () =>
+            {
+                var prevImageService = CoreState.ImageService;
+                try
+                {
+                    if (CoreState.ImageService == null)
+                        CoreState.ImageService = new SkiaImageService();
+
+                    var view = new EventBattleTalkFE7View();
+                    // Drive the real Opened -> LoadList path, then select the
+                    // first row through the production selection handler so the
+                    // VM + inputs populate exactly as in the running app.
+                    Invoke(view, "LoadList");
+                    view.SelectFirstItem();
+
+                    var attackerBox = view.FindControl<NumericUpDown>("AttackerUnitBox");
+                    var defenderBox = view.FindControl<NumericUpDown>("DefenderUnitBox");
+                    var textBox = view.FindControl<NumericUpDown>("TextIdBox");
+                    var eventPtrBox = view.FindControl<NumericUpDown>("EventPointerBox");
+                    var writeButton = view.FindControl<Button>("WriteButton");
+                    var addrLabel = view.FindControl<TextBlock>("AddrLabel");
+
+                    // The new editable surface must exist and be wired.
+                    Assert.NotNull(attackerBox);
+                    Assert.NotNull(defenderBox);
+                    Assert.NotNull(textBox);
+                    Assert.NotNull(eventPtrBox);
+                    Assert.NotNull(writeButton);
+
+                    // Selecting the first entry must populate the address readout
+                    // (proving the detail pane is no longer empty/display-only).
+                    Assert.False(string.IsNullOrEmpty(addrLabel?.Text));
+                    Assert.StartsWith("0x", addrLabel!.Text);
+                    // Main schema → Event Pointer input is enabled.
+                    Assert.True(eventPtrBox!.IsEnabled);
+
+                    _output.WriteLine($"Addr={addrLabel.Text} Attacker={attackerBox!.Value} " +
+                                      $"Defender={defenderBox!.Value} Text={textBox!.Value} EventPtr={eventPtrBox.Value}");
+
+                    string outDir = ResolveScreenshotOutputDir();
+                    Directory.CreateDirectory(outDir);
+                    SaveRender(view, 1100, 820, Path.Combine(outDir, "pr1437-battletalk-fe7.png"));
+                }
+                finally
+                {
+                    CoreState.ImageService = prevImageService;
+                }
+            });
+        }
+
+        void SaveRender(Control view, int w, int h, string outPath)
+        {
+            try
+            {
+                view.Measure(new Size(w, h));
+                view.Arrange(new Rect(0, 0, w, h));
+                using var bitmap = new RenderTargetBitmap(new PixelSize(w, h), new Vector(96, 96));
+                bitmap.Render(view);
+                bitmap.Save(outPath);
+                _output.WriteLine($"Saved screenshot to: {outPath} ({new FileInfo(outPath).Length} bytes)");
+            }
+            catch (Exception ex)
+            {
+                _output.WriteLine($"Headless render failed (environment, not the #1437 fix): {ex.Message}");
+            }
+        }
+
+        static void Invoke(object target, string method, params object?[]? args)
+        {
+            var m = target.GetType().GetMethod(method,
+                BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
+            Assert.NotNull(m);
+            m!.Invoke(target, args);
+        }
+
+        static string ResolveScreenshotOutputDir()
+        {
+            string? overrideDir = Environment.GetEnvironmentVariable("FEBUILDERGBA_SCREENSHOT_DIR");
+            if (!string.IsNullOrEmpty(overrideDir))
+                return overrideDir;
+            return Path.Combine(Path.GetTempPath(), "FEBuilderGBA-screenshots");
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/EventFE7SecondaryTableParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EventFE7SecondaryTableParityTests.cs
@@ -357,6 +357,157 @@ public class EventFE7SecondaryTableParityTests
     }
 
     [Fact]
+    public void BattleTalk_Main_LoadEntry_DecodesEventPointerAt0x08()
+    {
+        // #1437 plan review: offset 0x08 in the 16-byte MAIN schema is a P
+        // (pointer) field — LoadEntry must p32-DECODE it (strip 0x08000000), not
+        // read a raw u32. Plant a real GBA pointer and assert the decoded offset.
+        var rom = MakeSyntheticFE7J();
+        var prev = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            // Overwrite row 0's event-pointer slot with a real GBA pointer.
+            WriteU32(rom.Data, BtMainBase + 0 * 16 + 8, 0x08D88DBCu);
+
+            var vm = new EventBattleTalkFE7ViewModel();
+            vm.LoadList(EventBattleTalkFE7ViewModel.BattleTalkTable.Main);
+            vm.LoadEntry(BtMainBase);
+
+            // Decoded (0x08000000 stripped), NOT the raw 0x08D88DBC.
+            Assert.Equal(0x00D88DBCu, vm.EventPointer);
+        }
+        finally { CoreState.ROM = prev; }
+    }
+
+    [Fact]
+    public void BattleTalk_Main_Write_RoundTrips16ByteSchema_WithPointerEncoding()
+    {
+        // #1437: round-trip the MAIN 16-byte schema. The event pointer (offset
+        // 0x08) must be POINTER-ENCODED on write (0x08000000 re-added), the flag
+        // lives at 0x0C (u16), and the trailing bytes at 0x0E/0x0F. The next
+        // 16-byte row must stay untouched (stride correctness).
+        var rom = MakeSyntheticFE7J();
+        var prev = CoreState.ROM;
+        try
+        {
+            CoreState.ROM = rom;
+            var vm = new EventBattleTalkFE7ViewModel();
+            vm.LoadList(EventBattleTalkFE7ViewModel.BattleTalkTable.Main);
+            vm.LoadEntry(BtMainBase);
+
+            vm.AttackerUnit = 0x8E;
+            vm.DefenderUnit = 0x03;
+            vm.Unknown02 = 0x45;
+            vm.Unknown03 = 0x11;
+            vm.Text = 0x08E5;
+            vm.Unknown06 = 0x22;
+            vm.Unknown07 = 0x33;
+            vm.EventPointer = 0x00D88DBCu; // decoded offset; Write must re-encode
+            vm.AchievementFlag = 0x0006;
+            vm.Unknown0E = 0xAA;
+            vm.Unknown0F = 0xBB;
+            vm.Write();
+
+            Assert.Equal(0x8Eu, rom.u8(BtMainBase + 0));
+            Assert.Equal(0x03u, rom.u8(BtMainBase + 1));
+            Assert.Equal(0x45u, rom.u8(BtMainBase + 2));
+            Assert.Equal(0x11u, rom.u8(BtMainBase + 3));
+            Assert.Equal(0x08E5u, rom.u16(BtMainBase + 4));
+            Assert.Equal(0x22u, rom.u8(BtMainBase + 6));
+            Assert.Equal(0x33u, rom.u8(BtMainBase + 7));
+            // Pointer-ENCODED on the raw bytes (0x08000000 re-added).
+            Assert.Equal(0x08D88DBCu, rom.u32(BtMainBase + 8));
+            Assert.Equal(0x0006u, rom.u16(BtMainBase + 12)); // flag at 0x0C, not 0x08
+            Assert.Equal(0xAAu, rom.u8(BtMainBase + 14));
+            Assert.Equal(0xBBu, rom.u8(BtMainBase + 15));
+
+            // Re-loading must decode the pointer back to the offset.
+            var vm2 = new EventBattleTalkFE7ViewModel();
+            vm2.LoadList(EventBattleTalkFE7ViewModel.BattleTalkTable.Main);
+            vm2.LoadEntry(BtMainBase);
+            Assert.Equal(0x00D88DBCu, vm2.EventPointer);
+
+            // Next 16-byte row untouched (the second planted row's attacker byte).
+            Assert.Equal(0x8Eu, rom.u8(BtMainBase + 16 + 0));
+            Assert.Equal(0x1Du, rom.u8(BtMainBase + 16 + 1));
+        }
+        finally { CoreState.ROM = prev; }
+    }
+
+    [Fact]
+    public void BattleTalkView_HasFullInputSurfaceAndWriteButton()
+    {
+        // #1437: the FE7 Battle Dialogue editor must expose real input fields +
+        // a Write button (previously display-only — Table/Address labels only).
+        string axaml = ReadAxaml("EventBattleTalkFE7View.axaml");
+        foreach (string id in new[]
+                 {
+                     "EventBattleTalkFE7_AttackerUnit_Input",
+                     "EventBattleTalkFE7_DefenderUnit_Input",
+                     "EventBattleTalkFE7_Unknown02_Input",
+                     "EventBattleTalkFE7_Unknown03_Input",
+                     "EventBattleTalkFE7_Text_Input",
+                     "EventBattleTalkFE7_Unknown06_Input",
+                     "EventBattleTalkFE7_Unknown07_Input",
+                     "EventBattleTalkFE7_EventPointer_Input",
+                     "EventBattleTalkFE7_AchievementFlag_Input",
+                     "EventBattleTalkFE7_Unknown0E_Input",
+                     "EventBattleTalkFE7_Unknown0F_Input",
+                     "EventBattleTalkFE7_Write_Button",
+                 })
+            Assert.Contains("AutomationId=\"" + id + "\"", axaml);
+
+        // The Write button must route through the VM under an UndoService scope.
+        string cs = ReadAxaml("EventBattleTalkFE7View.axaml.cs");
+        Assert.Contains("UndoService", cs);
+        Assert.Contains("_undoService.Begin", cs);
+        Assert.Contains("_undoService.Commit", cs);
+        Assert.Contains("_undoService.Rollback", cs);
+        Assert.Contains("_vm.Write()", cs);
+    }
+
+    [Fact]
+    public void BattleTalkView_TrailingUnknownAndDefenderLabels_RelabelPerActiveTable()
+    {
+        // #1437 plan review: offset 0x01 is the Defender Unit in the 16-byte MAIN
+        // schema but a chapter/map id in the 12-byte SECONDARY schema (WinForms
+        // N1_J_1_MAP); the trailing bytes sit at 0x0E/0x0F (MAIN) vs 0x0A/0x0B
+        // (SECONDARY). All three labels must be named + relabeled per table via R._().
+        string axaml = ReadAxaml("EventBattleTalkFE7View.axaml");
+        Assert.Contains("Name=\"DefenderOrMapLabel\"", axaml);
+        Assert.Contains("Name=\"UnknownTrailing0Label\"", axaml);
+        Assert.Contains("Name=\"UnknownTrailing1Label\"", axaml);
+
+        string cs = ReadAxaml("EventBattleTalkFE7View.axaml.cs");
+        Assert.Contains("DefenderOrMapLabel.Text = R._(secondary ? \"Chapter/Map ID:\" : \"Defender Unit:\")", cs);
+        Assert.Contains("UnknownTrailing0Label.Text = R._(secondary ? \"Unknown (0x0A):\" : \"Unknown (0x0E):\")", cs);
+        Assert.Contains("UnknownTrailing1Label.Text = R._(secondary ? \"Unknown (0x0B):\" : \"Unknown (0x0F):\")", cs);
+        // Secondary schema has no event pointer — the input must be disabled there.
+        Assert.Contains("EventPointerBox.IsEnabled = !secondary", cs);
+    }
+
+    [Fact]
+    public void BattleTalkView_RelabelStrings_HaveJaAndZhTranslations()
+    {
+        // The relabel + undo-scope strings the view toggles between must already
+        // have ja AND zh entries so the L10n gate stays green (#958 review).
+        string repoRoot = RepoRoot();
+        foreach (string lang in new[] { "ja", "zh" })
+        {
+            string txt = "\n" + File.ReadAllText(Path.Combine(repoRoot, "config", "translate", lang + ".txt")).Replace("\r\n", "\n");
+            foreach (string key in new[]
+                     {
+                         "Defender Unit:", "Chapter/Map ID:",
+                         "Unknown (0x0E):", "Unknown (0x0F):",
+                         "Unknown (0x0A):", "Unknown (0x0B):",
+                         "Edit Battle Dialogue (FE7)",
+                     })
+                Assert.Contains("\n:" + key + "\n", txt);
+        }
+    }
+
+    [Fact]
     public void BattleTalk_Secondary_GoldenBuilder_Lockstep()
     {
         var rom = MakeSyntheticFE7J();

--- a/FEBuilderGBA.Avalonia/ViewModels/EventBattleTalkFE7ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/EventBattleTalkFE7ViewModel.cs
@@ -21,9 +21,14 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         }
 
         // Main (16-byte) schema — matches WinForms EventBattleTalkFE7Form.Init.
-        // [B0 atk][B1 def][B2][B3][W4 text][B6][B7][D8 event ptr][W12 flag][B14][B15]
+        // [B0 atk][B1 def][B2][B3][W4 text][B6][B7][P8 event ptr][W12 flag][B14][B15]
+        // Offset 0x08 is a P (pointer) field, matching the WinForms Designer control
+        // named "P8" (Hexadecimal NumericUpDown) + "L_8_EVENT" event-address box: it
+        // must read via rom.p32 (strip 0x08000000) and write via rom.write_p32
+        // (re-add 0x08000000), NOT a raw u32 — otherwise a nonzero event pointer
+        // round-trips as a bare offset (#1437 plan review).
         static readonly List<EditorFormRef.FieldDef> _fieldsMain =
-            EditorFormRef.DetectFields(new[] { "B0", "B1", "B2", "B3", "W4", "B6", "B7", "D8", "W12", "B14", "B15" });
+            EditorFormRef.DetectFields(new[] { "B0", "B1", "B2", "B3", "W4", "B6", "B7", "P8", "W12", "B14", "B15" });
 
         // Secondary (12-byte) schema — matches WinForms EventBattleTalkFE7Form
         // N1_Init designer controls (N1_B0/B1/B2/B3, N1_W4 text, N1_B6/B7,
@@ -187,7 +192,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 Text = v["W4"];
                 Unknown06 = v["B6"];
                 Unknown07 = v["B7"];
-                EventPointer = v["D8"];
+                EventPointer = v["P8"]; // p32-decoded offset (0x08000000 stripped)
                 AchievementFlag = v["W12"];
                 Unknown0E = v["B14"];
                 Unknown0F = v["B15"];
@@ -219,7 +224,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                     ["B0"] = AttackerUnit, ["B1"] = DefenderUnit,
                     ["B2"] = Unknown02, ["B3"] = Unknown03,
                     ["W4"] = Text, ["B6"] = Unknown06, ["B7"] = Unknown07,
-                    ["D8"] = EventPointer, ["W12"] = AchievementFlag,
+                    ["P8"] = EventPointer, ["W12"] = AchievementFlag,
                     ["B14"] = Unknown0E, ["B15"] = Unknown0F,
                 };
                 EditorFormRef.WriteFields(rom, a, values, _fieldsMain);

--- a/FEBuilderGBA.Avalonia/Views/EventBattleTalkFE7View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EventBattleTalkFE7View.axaml
@@ -27,12 +27,70 @@
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="Battle Dialogue (FE7)" FontSize="18" FontWeight="Bold" />
 
-        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto,Auto">
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="Table:" VerticalAlignment="Center" />
-          <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE7_Table_Label" Grid.Row="0" Grid.Column="1" Name="TableLabel" VerticalAlignment="Center" Foreground="Gray" />
-          <TextBlock Grid.Row="1" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
-          <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE7_Addr_Label" Grid.Row="1" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
+        <!-- Header: current table + record address (mirrors the WinForms
+             N1_FilterComboBox selection + the per-list Address readout). -->
+        <Grid ColumnDefinitions="180,140,*" RowDefinitions="Auto,Auto">
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="Table:" VerticalAlignment="Center" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE7_Table_Label" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" Name="TableLabel" VerticalAlignment="Center" Foreground="Gray" Margin="0,4" />
+          <TextBlock Grid.Row="1" Grid.Column="0" Text="Address:" VerticalAlignment="Center" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE7_Addr_Label" Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" Name="AddrLabel" VerticalAlignment="Center" Margin="0,4" />
         </Grid>
+
+        <Grid ColumnDefinitions="180,140,*"
+              RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+          <!-- Attacker Unit (offset +0, 1-based id) — unit-name preview. -->
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="Attacker Unit:" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE7_AttackerUnit_Input" FormatString="0" Grid.Row="0" Grid.Column="1" Name="AttackerUnitBox" Minimum="0" Maximum="255" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE7_AttackerName_Label" Grid.Row="0" Grid.Column="2" Name="AttackerNameLabel" VerticalAlignment="Center" TextWrapping="Wrap" Foreground="Gray" Margin="8,4" />
+
+          <!-- Offset +1 — Defender Unit in the 16-byte MAIN schema, but the
+               chapter/map id in the 12-byte SECONDARY schema (WinForms
+               N1_J_1_MAP / N1_L_1_MAP_ANYFF). The code-behind relabels this row
+               and swaps the inline preview (unit name vs FE7 ANYFF chapter name)
+               per active table. -->
+          <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE7_DefenderOrMap_Label" Grid.Row="1" Grid.Column="0" Name="DefenderOrMapLabel" Text="Defender Unit:" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE7_DefenderUnit_Input" FormatString="0" Grid.Row="1" Grid.Column="1" Name="DefenderUnitBox" Minimum="0" Maximum="255" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE7_DefenderName_Label" Grid.Row="1" Grid.Column="2" Name="DefenderNameLabel" VerticalAlignment="Center" TextWrapping="Wrap" Foreground="Gray" Margin="8,4" />
+
+          <TextBlock Grid.Row="2" Grid.Column="0" Text="Unknown (0x02):" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE7_Unknown02_Input" FormatString="0" Grid.Row="2" Grid.Column="1" Name="Unknown02Box" Minimum="0" Maximum="255" Margin="0,4" />
+
+          <TextBlock Grid.Row="3" Grid.Column="0" Text="Unknown (0x03):" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE7_Unknown03_Input" FormatString="0" Grid.Row="3" Grid.Column="1" Name="Unknown03Box" Minimum="0" Maximum="255" Margin="0,4" />
+
+          <!-- Text (offset +4, u16) — inline text preview (both schemas). -->
+          <TextBlock Grid.Row="4" Grid.Column="0" Text="Text:" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE7_Text_Input" FormatString="0" Grid.Row="4" Grid.Column="1" Name="TextIdBox" Minimum="0" Maximum="65535" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE7_TextPreview_Label" Grid.Row="4" Grid.Column="2" Name="TextPreviewLabel" VerticalAlignment="Center" TextWrapping="Wrap" Foreground="Gray" Margin="8,4" />
+
+          <TextBlock Grid.Row="5" Grid.Column="0" Text="Unknown (0x06):" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE7_Unknown06_Input" FormatString="0" Grid.Row="5" Grid.Column="1" Name="Unknown06Box" Minimum="0" Maximum="255" Margin="0,4" />
+
+          <TextBlock Grid.Row="6" Grid.Column="0" Text="Unknown (0x07):" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE7_Unknown07_Input" FormatString="0" Grid.Row="6" Grid.Column="1" Name="Unknown07Box" Minimum="0" Maximum="255" Margin="0,4" />
+
+          <!-- Event Pointer (offset +8, u32 pointer) — MAIN schema only; disabled
+               in the 12-byte SECONDARY schema (no event pointer slot). -->
+          <TextBlock Grid.Row="7" Grid.Column="0" Text="Event Pointer:" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE7_EventPointer_Input" FormatString="0" Grid.Row="7" Grid.Column="1" Grid.ColumnSpan="2" Name="EventPointerBox" Minimum="0" Maximum="4294967295" HorizontalAlignment="Left" Width="200" Margin="0,4" />
+
+          <!-- Achievement Flag — offset 0x0C (u16) in MAIN, 0x08 (u16) in SECONDARY. -->
+          <TextBlock Grid.Row="8" Grid.Column="0" Text="Achievement Flag:" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE7_AchievementFlag_Input" FormatString="0" Grid.Row="8" Grid.Column="1" Name="AchievementFlagBox" Minimum="0" Maximum="65535" Margin="0,4" />
+
+          <!-- The two trailing bytes are at 0x0E/0x0F in the 16-byte MAIN schema
+               but 0x0A/0x0B in the 12-byte SECONDARY schema; UpdateUI() relabels
+               them per active table (routed through R._() for ja/zh; #958). -->
+          <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE7_UnknownTrailing0_Label" Grid.Row="9" Grid.Column="0" Name="UnknownTrailing0Label" Text="Unknown (0x0E):" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE7_Unknown0E_Input" FormatString="0" Grid.Row="9" Grid.Column="1" Name="Unknown0EBox" Minimum="0" Maximum="255" Margin="0,4" />
+
+          <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE7_UnknownTrailing1_Label" Grid.Row="10" Grid.Column="0" Name="UnknownTrailing1Label" Text="Unknown (0x0F):" VerticalAlignment="Center" Margin="0,4" />
+          <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE7_Unknown0F_Input" FormatString="0" Grid.Row="10" Grid.Column="1" Name="Unknown0FBox" Minimum="0" Maximum="255" Margin="0,4" />
+        </Grid>
+
+        <TextBlock Text="A mid-battle conversation triggered when the attacker and defender units fight." TextWrapping="Wrap" Foreground="Gray" Margin="0,8" />
+
+        <Button AutomationProperties.AutomationId="EventBattleTalkFE7_Write_Button" Name="WriteButton" Content="Write" HorizontalAlignment="Left" Margin="0,8" />
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/FEBuilderGBA.Avalonia/Views/EventBattleTalkFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventBattleTalkFE7View.axaml.cs
@@ -50,7 +50,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventBattleTalkFE7View.LoadList failed: {0}", ex.Message);
+                Log.Error("EventBattleTalkFE7View.LoadList failed: " + ex.ToString());
             }
             finally
             {
@@ -69,7 +69,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventBattleTalkFE7View.OnSelected failed: {0}", ex.Message);
+                Log.Error("EventBattleTalkFE7View.OnSelected failed: " + ex.ToString());
             }
             finally
             {
@@ -188,7 +188,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EventBattleTalkFE7View.OnWrite failed: {0}", ex.Message);
+                Log.Error("EventBattleTalkFE7View.OnWrite failed: " + ex.ToString());
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/EventBattleTalkFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventBattleTalkFE7View.axaml.cs
@@ -3,12 +3,14 @@ using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Core;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
     public partial class EventBattleTalkFE7View : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly EventBattleTalkFE7ViewModel _vm = new();
+        readonly UndoService _undoService = new();
 
         public string ViewTitle => "Battle Dialogue (FE7)";
         public bool IsLoaded => _vm.IsLoaded;
@@ -17,7 +19,14 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
+            WriteButton.Click += OnWrite;
             TableFilter.SelectionChanged += TableFilter_SelectionChanged;
+
+            // Live name/text previews while editing.
+            AttackerUnitBox.ValueChanged += (_, _) => AttackerNameLabel.Text = UnitName(AttackerUnitBox);
+            DefenderUnitBox.ValueChanged += (_, _) => UpdateDefenderPreview();
+            TextIdBox.ValueChanged += (_, _) => TextPreviewLabel.Text = TextPreview(TextIdBox);
+
             Opened += (_, _) => LoadList();
         }
 
@@ -35,6 +44,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
+                _vm.IsLoading = true;
                 var items = _vm.LoadList(SelectedTable);
                 EntryList.SetItemsWithIcons(items, i => ListIconLoaders.UnitPortraitFromAddrU8Loader(items, i));
             }
@@ -42,12 +52,18 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 Log.Error("EventBattleTalkFE7View.LoadList failed: {0}", ex.Message);
             }
+            finally
+            {
+                _vm.IsLoading = false;
+                _vm.MarkClean();
+            }
         }
 
         void OnSelected(uint addr)
         {
             try
             {
+                _vm.IsLoading = true;
                 _vm.LoadEntry(addr);
                 UpdateUI();
             }
@@ -55,15 +71,125 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 Log.Error("EventBattleTalkFE7View.OnSelected failed: {0}", ex.Message);
             }
+            finally
+            {
+                _vm.IsLoading = false;
+                _vm.MarkClean();
+            }
         }
 
         void UpdateUI()
         {
+            bool secondary = _vm.IsSecondaryTable;
+
             // Route through R._() at assignment time — TranslatedWindow.TranslateAll()
             // runs once at window open, so values assigned afterward must be
             // localized explicitly to apply in ja/zh (#958 review).
-            TableLabel.Text = R._(_vm.IsSecondaryTable ? "Secondary (12-byte)" : "Main (16-byte)");
+            TableLabel.Text = R._(secondary ? "Secondary (12-byte)" : "Main (16-byte)");
             AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
+
+            AttackerUnitBox.Value = _vm.AttackerUnit;
+            DefenderUnitBox.Value = _vm.DefenderUnit;
+            Unknown02Box.Value = _vm.Unknown02;
+            Unknown03Box.Value = _vm.Unknown03;
+            TextIdBox.Value = _vm.Text;
+            Unknown06Box.Value = _vm.Unknown06;
+            Unknown07Box.Value = _vm.Unknown07;
+            EventPointerBox.Value = _vm.EventPointer;
+            AchievementFlagBox.Value = _vm.AchievementFlag;
+            Unknown0EBox.Value = _vm.Unknown0E;
+            Unknown0FBox.Value = _vm.Unknown0F;
+
+            // Offset 0x01 is the Defender Unit in the 16-byte MAIN schema but the
+            // chapter/map id in the 12-byte SECONDARY schema (WinForms N1_J_1_MAP /
+            // N1_L_1_MAP_ANYFF). Relabel the row + swap the inline preview so the
+            // map id isn't shown with unit-name semantics. Route through R._() at
+            // assignment time (TranslateAll() ran once at open).
+            DefenderOrMapLabel.Text = R._(secondary ? "Chapter/Map ID:" : "Defender Unit:");
+
+            AttackerNameLabel.Text = UnitName(AttackerUnitBox);
+            UpdateDefenderPreview();
+            TextPreviewLabel.Text = TextPreview(TextIdBox);
+
+            // The secondary 12-byte schema carries no event pointer (flag lives at
+            // 0x08, not 0x0C). Disable the input so the user can't edit a byte that
+            // won't be written back (mirrors EventHaikuFE7View's per-schema gating).
+            EventPointerBox.IsEnabled = !secondary;
+
+            // The two trailing Unknown bytes sit at 0x0E/0x0F in the 16-byte MAIN
+            // schema but at 0x0A/0x0B in the 12-byte SECONDARY schema — relabel them
+            // per active table so the offsets aren't misleading. The 0x0A/0x0B/
+            // 0x0E/0x0F label strings already have ja/zh entries (#958 review).
+            UnknownTrailing0Label.Text = R._(secondary ? "Unknown (0x0A):" : "Unknown (0x0E):");
+            UnknownTrailing1Label.Text = R._(secondary ? "Unknown (0x0B):" : "Unknown (0x0F):");
+        }
+
+        // Offset 0x01 preview: unit name (Main) vs FE7 ANYFF chapter/map name
+        // (Secondary). Mirrors EventHaikuFE7View.ResolveChapterName for the map id.
+        void UpdateDefenderPreview()
+        {
+            DefenderNameLabel.Text = _vm.IsSecondaryTable
+                ? ResolveChapterName((uint)(DefenderUnitBox.Value ?? 0))
+                : UnitName(DefenderUnitBox);
+        }
+
+        static string UnitName(NumericUpDown box)
+        {
+            try { return NameResolver.GetUnitNameByOneBasedId((uint)(box.Value ?? 0)); }
+            catch { return ""; }
+        }
+
+        static string TextPreview(NumericUpDown box)
+        {
+            uint id = (uint)(box.Value ?? 0);
+            if (id == 0) return "";
+            try { return NameResolver.GetTextById(id); }
+            catch { return ""; }
+        }
+
+        // FE7 ANYFF semantics: 0x45 is the "ANY" map/chapter sentinel
+        // (WinForms MapSettingForm.GetMapNameAndANYFF), matching
+        // EventHaikuFE7View.ResolveChapterName.
+        static string ResolveChapterName(uint chapterId)
+        {
+            var rom = CoreState.ROM;
+            if (rom?.RomInfo == null) return "";
+            if (chapterId == 0x45) return "ANY";
+            try
+            {
+                string name = MapSettingCore.GetMapNameById(chapterId);
+                return string.IsNullOrEmpty(name) ? "" : name;
+            }
+            catch { return ""; }
+        }
+
+        void OnWrite(object? sender, RoutedEventArgs e)
+        {
+            if (!_vm.IsLoaded) return;
+
+            _undoService.Begin(R._("Edit Battle Dialogue (FE7)"));
+            try
+            {
+                _vm.AttackerUnit = (uint)(AttackerUnitBox.Value ?? 0);
+                _vm.DefenderUnit = (uint)(DefenderUnitBox.Value ?? 0);
+                _vm.Unknown02 = (uint)(Unknown02Box.Value ?? 0);
+                _vm.Unknown03 = (uint)(Unknown03Box.Value ?? 0);
+                _vm.Text = (uint)(TextIdBox.Value ?? 0);
+                _vm.Unknown06 = (uint)(Unknown06Box.Value ?? 0);
+                _vm.Unknown07 = (uint)(Unknown07Box.Value ?? 0);
+                _vm.EventPointer = (uint)(EventPointerBox.Value ?? 0);
+                _vm.AchievementFlag = (uint)(AchievementFlagBox.Value ?? 0);
+                _vm.Unknown0E = (uint)(Unknown0EBox.Value ?? 0);
+                _vm.Unknown0F = (uint)(Unknown0FBox.Value ?? 0);
+                _vm.Write();
+                _undoService.Commit();
+                _vm.MarkClean();
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.Error("EventBattleTalkFE7View.OnWrite failed: {0}", ex.Message);
+            }
         }
 
         /// <summary>

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -20841,3 +20841,8 @@ PLIST tables split.
 
 :Template config file not found.
 Template config file not found.
+:Chapter/Map ID:
+Chapter/Map ID:
+
+:Edit Battle Dialogue (FE7)
+Edit Battle Dialogue (FE7)

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -12301,3 +12301,8 @@ PLISTテーブルを分割しました。
 
 :Attacker / Side (B2, decimal input; reference hex values): 0x00=Attacker starts, 0x01=Attacker starts (counter next), 0x08=Counter starts, 0x09=Counter starts (counter next), 0x0A=Counter starts 2, 0x80=Battle end
 攻撃側 (B2、10進数で入力; 参考の16進値): 0x00=攻撃側から攻撃開始, 0x01=攻撃側から攻撃開始(次は相手), 0x08=反撃側から攻撃開始, 0x09=反撃側から攻撃開始(次は相手), 0x0A=反撃側から攻撃開始2, 0x80=戦闘終端
+:Chapter/Map ID:
+章/マップID:
+
+:Edit Battle Dialogue (FE7)
+戦闘会話の編集 (FE7)

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -26145,3 +26145,8 @@ PLIST 表已分割。
 
 :Attacker / Side (B2, decimal input; reference hex values): 0x00=Attacker starts, 0x01=Attacker starts (counter next), 0x08=Counter starts, 0x09=Counter starts (counter next), 0x0A=Counter starts 2, 0x80=Battle end
 攻击方 (B2，十进制输入; 参考十六进制值): 0x00=攻击方先攻, 0x01=攻击方先攻(下次反击), 0x08=反击方先攻, 0x09=反击方先攻(下次反击), 0x0A=反击方先攻2, 0x80=战斗结束
+:Chapter/Map ID:
+章节/地图ID:
+
+:Edit Battle Dialogue (FE7)
+编辑战斗对话 (FE7)

--- a/docs/avalonia-forms.md
+++ b/docs/avalonia-forms.md
@@ -201,7 +201,7 @@ Editors for event scripts, conditions, units, templates, and related data.
 | 100 | EventBattleTalkView | EventBattleTalkViewModel | Battle conversation editor |
 | 101 | EventBattleTalkMainView | EventBattleTalkMainViewModel | Nested sub-view for battle talk |
 | 102 | EventBattleTalkFE6View | EventBattleTalkFE6ViewModel | Battle conversation (FE6) |
-| 103 | EventBattleTalkFE7View | EventBattleTalkFE7ViewModel | Battle conversation (FE7) |
+| 103 | EventBattleTalkFE7View | EventBattleTalkFE7ViewModel | Battle conversation (FE7) — full editor: per-schema input fields (attacker/defender, text, event pointer, achievement flag) + undo-tracked Write; Main 16-byte / Secondary 12-byte tables (#1437) |
 | 104 | EventBattleDataFE7View | EventBattleDataFE7ViewModel | Battle data editor (FE7) — editable AttackType/Attacker/Damage + undo-tracked Write (#1436) |
 | 105 | EventHaikuView | EventHaikuViewModel | Haiku/death quote editor |
 | 106 | EventHaikuFE6View | EventHaikuFE6ViewModel | Death quotes (FE6) |


### PR DESCRIPTION
## Summary
The Avalonia **FE7 Battle Dialogue** editor (`EventBattleTalkFE7View`) was display-only — the detail pane rendered only Table/Address labels, so the user could not edit or write any field, even though the ViewModel already had full `LoadEntry`/`Write` logic for both schemas (it was unreachable dead code). FE6/FE8 already had full editors; FE7 was the outlier.

This PR ports the editable surface (mirroring the sibling FE7 **Haiku** two-schema editor + FE6 Battle Dialogue) so FE7 users can finally edit battle dialogue in the Avalonia GUI.

Closes #1437.

## Changes
- **`EventBattleTalkFE7View.axaml`** — `NumericUpDown` inputs for every field of the active schema (attacker/defender, unknowns, text, event pointer, achievement flag, trailing bytes) + inline unit-name / text previews + a **Write** button.
- **`EventBattleTalkFE7View.axaml.cs`** — `UpdateUI` populates inputs and per-table relabels offset 0x01 (**Defender Unit** for Main / **Chapter/Map ID** for Secondary) and the trailing 0x0E/0x0F vs 0x0A/0x0B labels; disables the Event Pointer input in the secondary (no-event-ptr) schema. `OnWrite` pushes inputs into the VM and calls `_vm.Write()` inside an `UndoService` Begin/Commit scope (Rollback on exception) — **undo-tracked**.
- Two correctness fixes from the plan review, verified against WinForms `EventBattleTalkFE7Form` ground truth:
  1. **Main offset 0x08 is a POINTER field** (WinForms `P8` + `L_8_EVENT`), not raw `D8`. Changed the VM `_fieldsMain` schema `D8`→`P8` so the event pointer reads via `rom.p32` (strip `0x08000000`) and writes via `rom.write_p32` (re-add) instead of a raw `u32` offset — previously a nonzero event pointer would round-trip as a bare offset.
  2. **Secondary offset 0x01 is a chapter/map id** (WinForms `N1_J_1_MAP` / `N1_L_1_MAP_ANYFF`), not a defender unit — relabel + FE7 ANYFF chapter-name preview per active table.
- **Localization** — added `Chapter/Map ID:` + `Edit Battle Dialogue (FE7)` to ja/zh/en translate files (all other labels already had ja+zh entries).

## Test plan
- [x] `BattleTalk_Main_LoadEntry_DecodesEventPointerAt0x08` — Main 0x08 p32-decodes (strips 0x08000000)
- [x] `BattleTalk_Main_Write_RoundTrips16ByteSchema_WithPointerEncoding` — Write pointer-ENCODES at 0x08; flag at 0x0C; next 16-byte row untouched; re-load decodes back
- [x] `BattleTalkView_HasFullInputSurfaceAndWriteButton` — all input AutomationIds + Write button present; `_vm.Write()` called via `UndoService` Begin/Commit/Rollback
- [x] `BattleTalkView_TrailingUnknownAndDefenderLabels_RelabelPerActiveTable` — Defender/Map + trailing-unknown labels relabel per table; EventPointer disabled in Secondary
- [x] `BattleTalkView_RelabelStrings_HaveJaAndZhTranslations` — all relabel + undo strings have ja+zh entries
- [x] `BattleTalkFE7Editor_SelectFirst_PopulatesInputs_SavesScreenshot` — real FE7J ROM: selecting the first entry populates the inputs (Attacker/Defender/Text/EventPtr) and the address readout
- [x] Existing `EventFE7SecondaryTableParityTests` (Secondary list/load/write + golden lockstep) still pass
- [x] Ran all three test projects (Core.Tests, Avalonia.Tests, FEBuilderGBA.Tests net9.0-windows) — results in the GUI Test Report below
- [x] GUI validated on a real FE7J ROM via the Avalonia `--screenshot-all` runner (real rendering backend)

## GUI Test Report

| Area | Test | Result |
|------|------|--------|
| FE7 Battle Dialogue editor | Open on FE7J, select first Main entry → inputs populate (Attacker 142 "ミガル", Defender 3 "リン", Text 2277 + dialogue preview) | PASS |
| FE7 Battle Dialogue editor | Write button present + undo-scoped `_vm.Write()` | PASS |
| FE7 Battle Dialogue editor | Main schema → Event Pointer input enabled | PASS |
| Avalonia.Tests | `EventFE7SecondaryTableParityTests` (21 tests, incl. 5 new) | PASS |
| Avalonia.Tests | `EventBattleTalkFE7ScreenshotTest` | PASS |

## Screenshot
FE7 Battle Dialogue editor on FE7J — fully populated input fields (Attacker/Defender units with name previews, Text id with dialogue preview), no longer display-only:

![FE7 Battle Dialogue editor](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr1437-battletalk-fe7.png)

🤖 Generated with Claude Code (Opus 4.8, 1M context)
