### PR TITLE
fix(avalonia): Force Sortie (FE7) editor loads inner unit-list + undo-tracked writes (#1439)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/EventForceSortieFE7InnerListTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EventForceSortieFE7InnerListTests.cs
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1439 — the Avalonia Force Sortie (FE7) editor never loaded the inner
+// unit-list (the D0-dereferenced 4-byte sub-entry list), so Unit ID /
+// Unknown 1-3 always read 0 and never saved. These headless tests drive the
+// ported EventForceSortieFE7ViewModel against SYNTHETIC ROMs and prove:
+//   * LoadSubList dereferences D0 and walks 4-byte sub-entries.
+//   * The two WinForms terminators are honored: id == 0x00 AND byte3 == 0xD1.
+//   * An invalid / non-pointer D0 yields an empty list.
+//   * A pointer near EOF does NOT over-read the terminator byte at addr+3.
+//   * ResetSubEntry clears SubAddr + fields so a stale sub-entry can't be
+//     written after switching to an invalid/empty outer entry.
+//   * The combined undo round-trip: mutate BOTH the outer D0 field and a
+//     selected sub-entry in one UndoService scope, then RunUndo restores both
+//     byte ranges byte-identical.
+//
+// [Collection("SharedState")] because the tests mutate CoreState.ROM / .Undo.
+
+using System;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+[Collection("SharedState")]
+public class EventForceSortieFE7InnerListTests : IDisposable
+{
+    readonly ROM? _savedRom;
+    readonly Undo? _savedUndo;
+
+    public EventForceSortieFE7InnerListTests()
+    {
+        _savedRom = CoreState.ROM;
+        _savedUndo = CoreState.Undo;
+    }
+
+    public void Dispose()
+    {
+        CoreState.ROM = _savedRom;
+        CoreState.Undo = _savedUndo;
+    }
+
+    static ROM MakeRom(int size = 0x40000)
+    {
+        var rom = new ROM();
+        rom.LoadLow("force-sortie-fe7-1439.gba", new byte[size], "NAZO");
+        return rom;
+    }
+
+    static void WriteSubEntry(ROM rom, uint addr, byte id, byte b1, byte b2, byte b3)
+    {
+        rom.Data[addr + 0] = id;
+        rom.Data[addr + 1] = b1;
+        rom.Data[addr + 2] = b2;
+        rom.Data[addr + 3] = b3;
+    }
+
+    // Make the VM point its outer entry's D0 at the given ROM offset by setting
+    // UnitListPointer directly (the property the view-bound NumericUpDown sets,
+    // and the value LoadSubList dereferences).
+    static EventForceSortieFE7ViewModel VmWithUnitList(ROM rom, uint listOffset)
+    {
+        CoreState.ROM = rom;
+        var vm = new EventForceSortieFE7ViewModel();
+        vm.UnitListPointer = listOffset + 0x08000000u;
+        return vm;
+    }
+
+    // ----------------------------------------------------------------------
+    // Walk + terminators
+    // ----------------------------------------------------------------------
+
+    [Fact]
+    public void LoadSubList_WalksEntries_UntilIdZeroTerminator()
+    {
+        var rom = MakeRom();
+        uint list = 0x1000;
+        WriteSubEntry(rom, list + 0, 0x05, 0x11, 0x22, 0x33);
+        WriteSubEntry(rom, list + 4, 0x06, 0x44, 0x55, 0x66);
+        WriteSubEntry(rom, list + 8, 0x00, 0x00, 0x00, 0x00); // id == 0x00 -> stop
+
+        var vm = VmWithUnitList(rom, list);
+        var sub = vm.LoadSubList();
+
+        Assert.Equal(2, sub.Count);
+        Assert.Equal(list + 0, sub[0].addr);
+        Assert.Equal(list + 4, sub[1].addr);
+        Assert.Equal(0x05u, sub[0].tag);
+        Assert.Equal(0x06u, sub[1].tag);
+    }
+
+    [Fact]
+    public void LoadSubList_Stops_OnByte3IsD1Terminator()
+    {
+        var rom = MakeRom();
+        uint list = 0x1000;
+        WriteSubEntry(rom, list + 0, 0x05, 0x11, 0x22, 0x33);
+        // Second entry has a non-zero id but byte3 == 0xD1 -> terminator,
+        // so this row is NOT included (WF predicate continues only while
+        // id != 0x00 && term != 0xD1).
+        WriteSubEntry(rom, list + 4, 0x07, 0x44, 0x55, 0xD1);
+        WriteSubEntry(rom, list + 8, 0x08, 0x00, 0x00, 0x00);
+
+        var vm = VmWithUnitList(rom, list);
+        var sub = vm.LoadSubList();
+
+        Assert.Single(sub);
+        Assert.Equal(list + 0, sub[0].addr);
+    }
+
+    [Fact]
+    public void LoadSubList_InvalidPointer_ReturnsEmpty()
+    {
+        var rom = MakeRom();
+        var vm = new EventForceSortieFE7ViewModel();
+        CoreState.ROM = rom;
+
+        // Not a GBA pointer (< 0x08000000).
+        vm.UnitListPointer = 0x12345;
+        Assert.Empty(vm.LoadSubList());
+
+        // Zero pointer.
+        vm.UnitListPointer = 0;
+        Assert.Empty(vm.LoadSubList());
+    }
+
+    [Fact]
+    public void LoadSubList_PointerNearEof_DoesNotOverReadByte3()
+    {
+        int size = 0x40000;
+        var rom = MakeRom(size);
+        // Point the list so only 2 bytes remain (addr+3 would be out of bounds).
+        uint list = (uint)size - 2;
+        var vm = VmWithUnitList(rom, list);
+
+        // Must not throw and must stop immediately (the 4-byte read is out of
+        // range, so the bounded guard breaks before touching addr+3).
+        var sub = vm.LoadSubList();
+        Assert.Empty(sub);
+    }
+
+    [Fact]
+    public void LoadSubList_PointerExactlyOneEntryBeforeEof_ReadsThatEntryThenStops()
+    {
+        int size = 0x40000;
+        var rom = MakeRom(size);
+        // Exactly one 4-byte entry fits at the very end. It is a valid (non
+        // terminator) entry; the next read is past EOF so the walk stops with
+        // no over-read.
+        uint list = (uint)size - 4;
+        WriteSubEntry(rom, list, 0x09, 0x01, 0x02, 0x03);
+        var vm = VmWithUnitList(rom, list);
+
+        var sub = vm.LoadSubList();
+        Assert.Single(sub);
+        Assert.Equal(list, sub[0].addr);
+    }
+
+    // ----------------------------------------------------------------------
+    // Sub-entry load + reset
+    // ----------------------------------------------------------------------
+
+    [Fact]
+    public void LoadSubEntry_PopulatesUnitIdAndUnknowns()
+    {
+        var rom = MakeRom();
+        uint list = 0x1000;
+        WriteSubEntry(rom, list, 0x05, 0x11, 0x22, 0x33);
+        var vm = VmWithUnitList(rom, list);
+
+        vm.LoadSubEntry(list);
+
+        Assert.Equal(list, vm.SubAddr);
+        Assert.Equal(0x05u, vm.UnitId);
+        Assert.Equal(0x11u, vm.Unknown1);
+        Assert.Equal(0x22u, vm.Unknown2);
+        Assert.Equal(0x33u, vm.Unknown3);
+    }
+
+    [Fact]
+    public void ResetSubEntry_ClearsSubAddrAndFields_PreventsStaleWrite()
+    {
+        var rom = MakeRom();
+        uint list = 0x1000;
+        WriteSubEntry(rom, list, 0x05, 0x11, 0x22, 0x33);
+        var vm = VmWithUnitList(rom, list);
+
+        vm.LoadSubEntry(list);
+        Assert.NotEqual(0u, vm.SubAddr);
+
+        vm.ResetSubEntry();
+        Assert.Equal(0u, vm.SubAddr);
+        Assert.Equal(0u, vm.UnitId);
+        Assert.Equal(0u, vm.Unknown1);
+        Assert.Equal(0u, vm.Unknown2);
+        Assert.Equal(0u, vm.Unknown3);
+
+        // After reset WriteSubEntry must no-op (SubAddr==0 guard): mutate the
+        // field, call Write, assert ROM bytes unchanged.
+        rom.Data[list + 0] = 0x05;
+        vm.UnitId = 0x77;
+        vm.WriteSubEntry();
+        Assert.Equal(0x05, rom.Data[list + 0]); // unchanged — no stale write
+    }
+
+    // ----------------------------------------------------------------------
+    // Combined undo round-trip (outer D0 + inner sub-entry in one scope)
+    // ----------------------------------------------------------------------
+
+    [Fact]
+    public void Write_BothOuterAndSubEntry_UnderOneScope_RevertedByUndo()
+    {
+        var rom = MakeRom();
+        CoreState.ROM = rom;
+        CoreState.Undo = new Undo();
+
+        uint outerAddr = 0x800;  // outer entry holds the D0 pointer
+        uint list = 0x1000;      // inner unit list
+        WriteSubEntry(rom, list, 0x05, 0x11, 0x22, 0x33);
+        // Outer D0 initially points at the list.
+        uint listPtr = list + 0x08000000u;
+        rom.Data[outerAddr + 0] = (byte)(listPtr & 0xFF);
+        rom.Data[outerAddr + 1] = (byte)((listPtr >> 8) & 0xFF);
+        rom.Data[outerAddr + 2] = (byte)((listPtr >> 16) & 0xFF);
+        rom.Data[outerAddr + 3] = (byte)((listPtr >> 24) & 0xFF);
+
+        var vm = new EventForceSortieFE7ViewModel();
+        vm.LoadEntry(outerAddr);
+        Assert.Equal(listPtr, vm.UnitListPointer);
+        vm.LoadSubEntry(list);
+
+        byte[] outerSnap = new byte[4];
+        byte[] subSnap = new byte[4];
+        Array.Copy(rom.Data, (int)outerAddr, outerSnap, 0, 4);
+        Array.Copy(rom.Data, (int)list, subSnap, 0, 4);
+
+        try
+        {
+            uint newPtr = (list + 0x100) + 0x08000000u; // a different valid pointer
+            var svc = new UndoService();
+            svc.Begin("test-fe7-sortie");
+            vm.UnitListPointer = newPtr;
+            vm.UnitId = 0x09;
+            vm.Unknown1 = 0xAA;
+            vm.Write();
+            vm.WriteSubEntry();
+            svc.Commit();
+
+            try
+            {
+                Assert.Equal(newPtr, rom.u32(outerAddr));
+                Assert.Equal(0x09, rom.Data[list + 0]);
+                Assert.Equal(0xAA, rom.Data[list + 1]);
+            }
+            finally
+            {
+                CoreState.Undo.RunUndo();
+            }
+
+            // Undo must restore BOTH byte ranges byte-identical.
+            for (int i = 0; i < 4; i++)
+                Assert.Equal(outerSnap[i], rom.Data[(int)outerAddr + i]);
+            for (int i = 0; i < 4; i++)
+                Assert.Equal(subSnap[i], rom.Data[(int)list + i]);
+        }
+        finally
+        {
+            Array.Copy(outerSnap, 0, rom.Data, (int)outerAddr, 4);
+            Array.Copy(subSnap, 0, rom.Data, (int)list, 4);
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/EventForceSortieFE7InnerListTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EventForceSortieFE7InnerListTests.cs
@@ -110,6 +110,29 @@ public class EventForceSortieFE7InnerListTests : IDisposable
     }
 
     [Fact]
+    public void LoadSubList_Label_UsesOneBasedUnitNameResolver()
+    {
+        // WF UnitForm.GetUnitName(uid) is 1-based (it does uid--), and the row's
+        // portrait icon loader (UnitPortraitByIdLoader) is also 1-based off the
+        // leading hex id. The label must therefore resolve names via the 1-based
+        // NameResolver.GetUnitNameByOneBasedId, NOT the 0-based GetUnitName.
+        var rom = MakeRom();
+        uint list = 0x1000;
+        byte id = 0x05;
+        WriteSubEntry(rom, list, id, 0x11, 0x22, 0x33);
+        var vm = VmWithUnitList(rom, list);
+
+        var sub = vm.LoadSubList();
+        Assert.Single(sub);
+
+        string expected = U.ToHexString(id) + " " + NameResolver.GetUnitNameByOneBasedId(id);
+        Assert.Equal(expected, sub[0].name);
+        // The leading hex id is preserved so UnitPortraitByIdLoader's U.atoh(name)
+        // parses the same 1-based id for the portrait icon.
+        Assert.StartsWith(U.ToHexString(id), sub[0].name);
+    }
+
+    [Fact]
     public void LoadSubList_InvalidPointer_ReturnsEmpty()
     {
         var rom = MakeRom();

--- a/FEBuilderGBA.Avalonia.Tests/EventForceSortieFE7UndoCoverageTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EventForceSortieFE7UndoCoverageTests.cs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Regression tests for #1439 — the Avalonia Force Sortie (FE7) editor
+// (EventForceSortieFE7View) must wrap BOTH _vm.Write() (outer D0 pointer) and
+// _vm.WriteSubEntry() (inner unit-list sub-entry) in a single UndoService scope
+// so Edit > Undo can revert them together. Before the fix OnWrite called
+// _vm.Write()/_vm.WriteSubEntry() with no Begin/Commit, so the bare
+// EditorFormRef.WriteFields path recorded nothing into the undo buffer (the
+// known sibling gap from #1427).
+//
+// Static-analysis guard (DiscoverViewCoveredVmMethods over the live
+// EventForceSortieFE7View.axaml.cs) — FAILS pre-fix, PASSES post-fix, proving
+// the view-level scope exists around both writes. Mirrors the canary pattern in
+// EventForceSortieUndoCoverageTests (#1427) / UndoCoverageScannerTests.
+using System;
+using System.IO;
+using FEBuilderGBA.Avalonia.GapSweep;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    public class EventForceSortieFE7UndoCoverageTests
+    {
+        /// <summary>
+        /// The View must register BOTH EventForceSortieFE7ViewModel.Write and
+        /// .WriteSubEntry as undo-covered: OnWrite wraps both calls in
+        /// _undoService.Begin / try-Commit / catch-Rollback.
+        /// FAILS before the #1439 fix (no Begin/Commit), PASSES after.
+        /// </summary>
+        [SkippableFact]
+        public void EventForceSortieFE7View_WrapsBothWrites_InUndoScope()
+        {
+            string? repoRoot = FindRepoRoot();
+            Skip.If(repoRoot == null,
+                "Repo root (FEBuilderGBA.sln) not found — running from a published binary outside the source tree.");
+
+            string viewPath = Path.Combine(repoRoot!,
+                "FEBuilderGBA.Avalonia", "Views", "EventForceSortieFE7View.axaml.cs");
+            Assert.True(File.Exists(viewPath), $"View source not found at {viewPath}");
+
+            var covered = UndoCoverageScanner.DiscoverViewCoveredVmMethods(new[] { viewPath });
+            Assert.Contains(("EventForceSortieFE7ViewModel", "Write"), covered);
+            Assert.Contains(("EventForceSortieFE7ViewModel", "WriteSubEntry"), covered);
+        }
+
+        /// <summary>
+        /// Walk up from the test binary's base directory looking for
+        /// FEBuilderGBA.sln. Returns null when running outside the source tree.
+        /// </summary>
+        static string? FindRepoRoot()
+        {
+            string start = AppDomain.CurrentDomain.BaseDirectory;
+            for (DirectoryInfo? dir = new DirectoryInfo(start); dir != null; dir = dir.Parent)
+            {
+                if (File.Exists(Path.Combine(dir.FullName, "FEBuilderGBA.sln")))
+                    return dir.FullName;
+            }
+            return null;
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/ViewModels/EventForceSortieFE7ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/EventForceSortieFE7ViewModel.cs
@@ -72,6 +72,71 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             IsLoaded = true;
         }
 
+        /// <summary>
+        /// Build the inner unit-list pointed to by the outer entry's D0
+        /// pointer (<see cref="UnitListPointer"/>). Faithful port of the
+        /// WinForms <c>EventForceSortieFE7Form.N_Init</c> list: dereference D0
+        /// (<c>u32 -&gt; toOffset</c>), then walk 4-byte sub-entries terminated
+        /// when <c>u8(addr) == 0x00</c> OR <c>u8(addr+3) == 0xD1</c>.
+        /// <para>
+        /// Each 4-byte read is bounded by an explicit <c>addr + 4 &lt;= Data.Length</c>
+        /// guard so a malformed pointer near EOF cannot over-read the
+        /// terminator byte at <c>addr+3</c> (Copilot CLI plan-review #1).
+        /// </para>
+        /// Returns an empty list (no rows) when D0 is not a valid pointer.
+        /// </summary>
+        public List<AddrResult> LoadSubList()
+        {
+            var result = new List<AddrResult>();
+            ROM rom = CoreState.ROM;
+            if (rom == null) return result;
+
+            uint ptr = UnitListPointer;
+            if (!U.isPointer(ptr)) return result;
+            uint addr = U.toOffset(ptr);
+            if (!U.isSafetyOffset(addr, rom)) return result;
+
+            const uint blockSize = 4;
+            // Hard cap so a corrupt list without a terminator cannot loop the
+            // whole ROM; WF relies on InputFormRef's DataCount scan but a
+            // generous bound keeps us safe and matches other Avalonia walks.
+            for (int i = 0; i < 1024; i++, addr += blockSize)
+            {
+                // Bound the full 4-byte sub-entry before reading either the
+                // id byte or the terminator byte at +3.
+                if (addr + blockSize > (uint)rom.Data.Length) break;
+
+                uint id = rom.u8(addr);
+                uint term = rom.u8(addr + 3);
+                // WF predicate: continue while (id != 0x00 && term != 0xD1).
+                if (id == 0x00 || term == 0xD1) break;
+
+                // WF label: U.ToHexString(uid) + " " + UnitForm.GetUnitName(uid).
+                // UnitForm.GetUnitName is the Core NameResolver.GetUnitName alias
+                // (0-based table index), so the raw u8 maps directly.
+                string unitName = NameResolver.GetUnitName(id);
+                result.Add(new AddrResult(addr, U.ToHexString(id) + " " + unitName, id));
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Clear the selected sub-entry. After this call <see cref="SubAddr"/>
+        /// is 0 (so <see cref="WriteSubEntry"/> no-ops via its guard) and the
+        /// Unit ID / Unknown fields read 0. Called when the outer entry's D0
+        /// pointer is invalid or the inner list is empty so a stale sub-entry
+        /// from a previous outer selection cannot be written (Copilot CLI
+        /// plan-review #2).
+        /// </summary>
+        public void ResetSubEntry()
+        {
+            SubAddr = 0;
+            UnitId = 0;
+            Unknown1 = 0;
+            Unknown2 = 0;
+            Unknown3 = 0;
+        }
+
         public void LoadSubEntry(uint addr)
         {
             ROM rom = CoreState.ROM;

--- a/FEBuilderGBA.Avalonia/ViewModels/EventForceSortieFE7ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/EventForceSortieFE7ViewModel.cs
@@ -112,9 +112,13 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 if (id == 0x00 || term == 0xD1) break;
 
                 // WF label: U.ToHexString(uid) + " " + UnitForm.GetUnitName(uid).
-                // UnitForm.GetUnitName is the Core NameResolver.GetUnitName alias
-                // (0-based table index), so the raw u8 maps directly.
-                string unitName = NameResolver.GetUnitName(id);
+                // WF UnitForm.GetUnitName is 1-BASED (it does `uid--` then resolves
+                // table row uid-1, returning "" for uid==0), so use the 1-based
+                // resolver here — NOT the 0-based NameResolver.GetUnitName. This
+                // also keeps the name in sync with the row's portrait icon, which
+                // is loaded by UnitPortraitByIdLoader (also 1-based) off the same
+                // leading hex id. (Copilot PR #1517 review.)
+                string unitName = NameResolver.GetUnitNameByOneBasedId(id);
                 result.Add(new AddrResult(addr, U.ToHexString(id) + " " + unitName, id));
             }
             return result;

--- a/FEBuilderGBA.Avalonia/Views/EventForceSortieFE7View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EventForceSortieFE7View.axaml
@@ -4,10 +4,12 @@
         x:Class="FEBuilderGBA.Avalonia.Views.EventForceSortieFE7View"
         Title="Force Sortie (FE7)" Width="1296" Height="450"
         SizeToContent="WidthAndHeight">
-  <Grid ColumnDefinitions="250,*">
+  <Grid ColumnDefinitions="250,250,*">
     <controls:AddressListControl AutomationProperties.AutomationId="EventForceSortieFE7_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
 
-    <ScrollViewer Grid.Column="1" Margin="4">
+    <controls:AddressListControl AutomationProperties.AutomationId="EventForceSortieFE7_SubEntry_List" Grid.Column="1" Name="SubEntryList" Margin="4" />
+
+    <ScrollViewer Grid.Column="2" Margin="4">
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="Force Sortie (FE7)" FontSize="18" FontWeight="Bold" />
 

--- a/FEBuilderGBA.Avalonia/Views/EventForceSortieFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventForceSortieFE7View.axaml.cs
@@ -32,7 +32,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventForceSortieFE7View.LoadList failed: {0}", ex.Message);
+                Log.Error($"EventForceSortieFE7View.LoadList failed: {ex}");
             }
         }
 
@@ -46,7 +46,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventForceSortieFE7View.OnSelected failed: {0}", ex.Message);
+                Log.Error($"EventForceSortieFE7View.OnSelected failed: {ex}");
             }
         }
 
@@ -78,7 +78,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventForceSortieFE7View.LoadSubList failed: {0}", ex.Message);
+                Log.Error($"EventForceSortieFE7View.LoadSubList failed: {ex}");
             }
         }
 
@@ -91,7 +91,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventForceSortieFE7View.OnSubSelected failed: {0}", ex.Message);
+                Log.Error($"EventForceSortieFE7View.OnSubSelected failed: {ex}");
             }
         }
 
@@ -134,7 +134,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EventForceSortieFE7View.OnWrite failed: {0}", ex.Message);
+                Log.Error($"EventForceSortieFE7View.OnWrite failed: {ex}");
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/EventForceSortieFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventForceSortieFE7View.axaml.cs
@@ -9,6 +9,7 @@ namespace FEBuilderGBA.Avalonia.Views
     public partial class EventForceSortieFE7View : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly EventForceSortieFE7ViewModel _vm = new();
+        readonly UndoService _undoService = new();
 
         public string ViewTitle => "Force Sortie (FE7)";
         public bool IsLoaded => _vm.IsLoaded;
@@ -17,6 +18,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
+            SubEntryList.SelectedAddressChanged += OnSubSelected;
             WriteButton.Click += OnWrite;
             Opened += (_, _) => LoadList();
         }
@@ -40,6 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 _vm.LoadEntry(addr);
                 UpdateUI();
+                LoadSubList();
             }
             catch (Exception ex)
             {
@@ -47,10 +50,59 @@ namespace FEBuilderGBA.Avalonia.Views
             }
         }
 
+        // Rebuild the inner unit-list from the outer entry's D0 pointer. When
+        // D0 is invalid / the list is empty we explicitly reset the sub-entry
+        // (SubAddr=0 + zero fields) and clear the sub-fields UI so a stale
+        // sub-entry from a previous outer selection cannot be written — we do
+        // NOT rely on SetItemsWithIcons' SelectFirst() firing a fresh
+        // SelectionChanged (it may not when the list was already at index 0).
+        // Copilot CLI plan-review #2.
+        void LoadSubList()
+        {
+            try
+            {
+                var sub = _vm.LoadSubList();
+                if (sub.Count == 0)
+                {
+                    SubEntryList.SetItems(sub);
+                    _vm.ResetSubEntry();
+                    UpdateSubUI();
+                    return;
+                }
+
+                SubEntryList.SetItemsWithIcons(sub, i => ListIconLoaders.UnitPortraitByIdLoader(sub, i));
+                // Explicitly load the first sub-row rather than depending on the
+                // selection-changed event firing.
+                _vm.LoadSubEntry(sub[0].addr);
+                UpdateSubUI();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("EventForceSortieFE7View.LoadSubList failed: {0}", ex.Message);
+            }
+        }
+
+        void OnSubSelected(uint addr)
+        {
+            try
+            {
+                _vm.LoadSubEntry(addr);
+                UpdateSubUI();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("EventForceSortieFE7View.OnSubSelected failed: {0}", ex.Message);
+            }
+        }
+
         void UpdateUI()
         {
             AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
             UnitListPointerUpDown.Value = _vm.UnitListPointer;
+        }
+
+        void UpdateSubUI()
+        {
             UnitIdUpDown.Value = _vm.UnitId;
             Unknown1UpDown.Value = _vm.Unknown1;
             Unknown2UpDown.Value = _vm.Unknown2;
@@ -59,6 +111,15 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void OnWrite(object? sender, RoutedEventArgs e)
         {
+            // Wrap BOTH ROM writes (outer D0 pointer + inner sub-entry) in a
+            // single UndoService scope so Edit > Undo reverts them together —
+            // _vm.Write()/_vm.WriteSubEntry() funnel into the bare
+            // EditorFormRef.WriteFields overload, which only records undo when an
+            // ambient ROM.BeginUndoScope is active (#1427 sibling fix). Both
+            // calls live in the same try block so a fault rolls both back.
+            // Runs on the UI thread (button Click), so the ambient undo is
+            // non-null.
+            _undoService.Begin("Edit Force Sortie FE7");
             try
             {
                 _vm.UnitListPointer = (uint)(UnitListPointerUpDown.Value ?? 0);
@@ -68,9 +129,11 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.Unknown3 = (uint)(Unknown3UpDown.Value ?? 0);
                 _vm.Write();
                 _vm.WriteSubEntry();
+                _undoService.Commit();
             }
             catch (Exception ex)
             {
+                _undoService.Rollback();
                 Log.Error("EventForceSortieFE7View.OnWrite failed: {0}", ex.Message);
             }
         }

--- a/docs/avalonia-gap-analysis.md
+++ b/docs/avalonia-gap-analysis.md
@@ -255,7 +255,7 @@ Map Editor is no longer read-only: current code supports map rendering, tile sel
 | EventBattleTalkFE6/FE7 | **55%** | ~~List stub~~ **FIXED** — list from event_ballte_talk_pointer (FE6: 12-byte, FE7: 16-byte blocks) + unit names |
 | EventHaikuForm / EventHaikuVM | **55%** | ~~Auto-populated list~~ **FIXED** — list from event_haiku_pointer with unit name resolution. Missing: patch detection |
 | EventHaikuFE6/FE7 | **55%** | ~~List stub~~ **FIXED** — list from event_haiku_pointer (16-byte blocks) + unit names. Missing: chapter filter |
-| EventForceSortie/FE7 | **55%** | ~~List stub~~ **FIXED** — list from event_force_sortie_pointer with unit name resolution. Missing: AllocIfNeed |
+| EventForceSortie/FE7 | **55%** | ~~List stub~~ **FIXED** — list from event_force_sortie_pointer with unit name resolution. FE7 (#1439): inner unit-list now loaded — outer D0 pointer is dereferenced and the 4-byte sub-entries (UnitId + Unknown 1-3) are walked (terminator `id==0x00 || byte3==0xD1`), editable and undo-tracked. Missing: AllocIfNeed |
 | EventFunctionPointer/FE7 | **45%** | ~~List stub~~ **FIXED** — list from event_function_pointer_table_pointer. Missing: filter combo |
 | EventTalkGroupFE7 | 30% | AllocIfNeed, RecycleOldData |
 | EventMoveDataFE7 | 25% | Variable-size records, direction types |


### PR DESCRIPTION
## Summary
Closes #1439. The Avalonia **Force Sortie (FE7)** editor never ported the inner unit-list (the D0-dereferenced 4-byte sub-entry list), so **Unit ID / Unknown 1-3 always read 0 and edits silently no-op'd** (the `SubAddr==0` guard). This ports the inner list, faithful to WinForms `EventForceSortieFE7Form`, and makes the fields editable + persistable.

Also folds in the known **sibling gap from #1427**: `OnWrite` now wraps the ROM writes in an `UndoService` scope so Edit > Undo can revert the editor's writes.

## What changed
- **ViewModel `LoadSubList()`** — dereference the outer entry's D0 pointer (`u32 -> toOffset`), walk 4-byte sub-entries, terminate on `id==0x00 || u8(addr+3)==0xD1` (verbatim WF `N_Init` predicate). Each 4-byte read is bounded by an explicit `addr+4 <= Data.Length` guard so a malformed pointer near EOF cannot over-read the terminator byte at `addr+3`. Rows labeled via `NameResolver.GetUnitName` (the Core alias for WF `UnitForm.GetUnitName`).
- **ViewModel `ResetSubEntry()`** — clears `SubAddr` + fields so a stale sub-entry can't be written after switching to an invalid/empty outer entry.
- **View** — second `AddressListControl` (`SubEntryList`); outer selection rebuilds the inner list and **explicitly loads the first sub-row** (does not rely on `SetItemsWithIcons`' `SelectFirst()` firing a selection event); inner selection loads the sub-entry.
- **Undo (#1427 sibling)** — `OnWrite` wraps **both** `_vm.Write()` (outer D0) and `_vm.WriteSubEntry()` (inner sub-entry) in **one** `UndoService.Begin/try-Commit/catch-Rollback` scope, in the same try block so a fault rolls both back.

All four Copilot CLI plan-review findings folded in (bounded `addr+3` read; explicit first-row load + reset; both-writes-in-one-scope + static guard for both; deterministic terminator/reset coverage).

## Screenshot — inner unit-list now populated
The inner list (column 2) shows the dereferenced D0 sub-entries with unit names + portraits ("2D Wil", "01 Hector") — previously empty.

![Force Sortie FE7 inner list](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr1439-forcesortiefe7-innerlist-fe7u.png)

## GUI Test Report
| Test | Result |
|------|--------|
| Headless `--screenshot-all` render of `EventForceSortieFE7View` (FE7U.gba) | PASS — inner unit-list populated with names + portrait icons (see screenshot) |
| Inner list loads on outer selection | PASS (deterministic + ROM render) |
| Unit ID / Unknown 1-3 read non-zero from a populated sub-entry | PASS (`LoadSubEntry_PopulatesUnitIdAndUnknowns`) |
| Write persists + is undo-revertible (combined outer D0 + sub-entry) | PASS (`Write_BothOuterAndSubEntry_UnderOneScope_RevertedByUndo`) |

## Test plan
- [x] `LoadSubList` walks until `id==0x00` terminator (`LoadSubList_WalksEntries_UntilIdZeroTerminator`)
- [x] `LoadSubList` stops on `byte3==0xD1` terminator (`LoadSubList_Stops_OnByte3IsD1Terminator`)
- [x] Invalid / non-pointer D0 -> empty list (`LoadSubList_InvalidPointer_ReturnsEmpty`)
- [x] Pointer near EOF does not over-read `addr+3` (`LoadSubList_PointerNearEof_DoesNotOverReadByte3`)
- [x] Exactly one entry before EOF reads then stops (`LoadSubList_PointerExactlyOneEntryBeforeEof_ReadsThatEntryThenStops`)
- [x] Inner-list label uses the 1-based unit-name resolver + preserves leading hex id for the portrait icon (`LoadSubList_Label_UsesOneBasedUnitNameResolver`)
- [x] Sub-entry populates Unit ID + Unknowns (`LoadSubEntry_PopulatesUnitIdAndUnknowns`)
- [x] `ResetSubEntry` clears `SubAddr`/fields + prevents stale write (`ResetSubEntry_ClearsSubAddrAndFields_PreventsStaleWrite`)
- [x] Combined undo round-trip restores both byte ranges (`Write_BothOuterAndSubEntry_UnderOneScope_RevertedByUndo`)
- [x] Static guard: view registers BOTH `Write` and `WriteSubEntry` as undo-covered (`EventForceSortieFE7View_WrapsBothWrites_InUndoScope`)
- [x] Full `FEBuilderGBA.Avalonia.Tests` suite green
- [x] `FEBuilderGBA.Core.Tests` green (pre-existing Skill* worktree-env skips aside)
- [x] `FEBuilderGBA.Tests` (net9.0-windows) green

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.8, 1M context)

