### PR TITLE
fix(avalonia): port full 14-entry Talk Group (FE7) editor + repoint + NewAlloc (#1442)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/EventTalkGroupFE7ListTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EventTalkGroupFE7ListTests.cs
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1442 — Talk Group (FE7) editor was a single-auto-discovered-entry stub. WinForms
+// EventTalkGroupFE7Form is a 14-entry (i=0..0xD) stride-4 list editor with repoint
+// (JumpToAddr/ReInit) and NewAlloc (byte[4*0xE]). These headless tests prove the
+// ported ViewModel emits the full 14-row list at base+i*4, repoints onto an
+// arbitrary block base (raw offset OR 0x08...... pointer), and NewAlloc allocates
+// the correct 56-byte block.
+//
+// [Collection("SharedState")] because the tests mutate CoreState.ROM / .Undo.
+
+using System;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+[Collection("SharedState")]
+public class EventTalkGroupFE7ListTests : IDisposable
+{
+    const uint BlockA = 0x00900000u; // first synthetic talk-group block base
+    const uint BlockB = 0x00910000u; // second block base (repoint target)
+
+    readonly ROM? _savedRom;
+    readonly Undo? _savedUndo;
+
+    public EventTalkGroupFE7ListTests()
+    {
+        _savedRom = CoreState.ROM;
+        _savedUndo = CoreState.Undo;
+    }
+
+    public void Dispose()
+    {
+        CoreState.ROM = _savedRom;
+        CoreState.Undo = _savedUndo;
+    }
+
+    [Fact]
+    public void LoadList_Emits14StrideFourEntries_FE7()
+    {
+        ROM rom = MakeRom();
+        CoreState.ROM = rom;
+
+        var vm = new EventTalkGroupFE7ViewModel();
+        vm.SetBaseAddr(BlockA);
+        var list = vm.LoadList();
+
+        // 14 entries (i=0..0xD), stride 4.
+        Assert.Equal(EventTalkGroupFE7ViewModel.EntryCount, list.Count);
+        for (int i = 0; i < list.Count; i++)
+        {
+            Assert.Equal(BlockA + (uint)(i * EventTalkGroupFE7ViewModel.EntryStride), list[i].addr);
+            Assert.Equal((uint)i, list[i].tag);
+        }
+        // GetListCount mirrors the list length.
+        Assert.Equal(EventTalkGroupFE7ViewModel.EntryCount, vm.GetListCount());
+    }
+
+    [Fact]
+    public void LoadList_LabelReadsTextIdAsU16_FE7()
+    {
+        ROM rom = MakeRom();
+        // Entry 3 has a distinctive low u16; the upper u16 must be ignored by the label.
+        PlantU16(rom, BlockA + 3 * 4 + 0, 0xABCD);
+        PlantU16(rom, BlockA + 3 * 4 + 2, 0x1234);
+        CoreState.ROM = rom;
+
+        var vm = new EventTalkGroupFE7ViewModel();
+        vm.SetBaseAddr(BlockA);
+        var list = vm.LoadList();
+
+        // Label encodes the u16 text id (0xABCD), not the full u32.
+        Assert.Contains("0xABCD", list[3].name);
+        Assert.DoesNotContain("0x1234ABCD", list[3].name);
+    }
+
+    [Fact]
+    public void SetBaseAddr_AcceptsRawOffsetOrPointer_FE7()
+    {
+        ROM rom = MakeRom();
+        CoreState.ROM = rom;
+
+        var vm = new EventTalkGroupFE7ViewModel();
+
+        // Raw offset normalizes to itself.
+        vm.SetBaseAddr(BlockB);
+        Assert.Equal(BlockB, vm.BaseAddr);
+
+        // 0x08...... GBA pointer normalizes to the same offset (parity with ReInit).
+        vm.SetBaseAddr(U.toPointer(BlockB));
+        Assert.Equal(BlockB, vm.BaseAddr);
+
+        // Zero clears (re-auto-discover).
+        vm.SetBaseAddr(0);
+        Assert.Equal(0u, vm.BaseAddr);
+    }
+
+    [Fact]
+    public void Repoint_SwitchesListToDifferentBlock_FE7()
+    {
+        ROM rom = MakeRom();
+        CoreState.ROM = rom;
+
+        var vm = new EventTalkGroupFE7ViewModel();
+
+        vm.SetBaseAddr(BlockA);
+        var listA = vm.LoadList();
+        Assert.Equal(BlockA, listA[0].addr);
+
+        vm.SetBaseAddr(BlockB);
+        var listB = vm.LoadList();
+        Assert.Equal(BlockB, listB[0].addr);
+        Assert.Equal(EventTalkGroupFE7ViewModel.EntryCount, listB.Count);
+    }
+
+    [Fact]
+    public void NewAlloc_AppendsFiftySixByteBlockAndRepoints_FE7()
+    {
+        var savedAppend = CoreState.AppendBinaryData;
+        try
+        {
+            CoreState.AppendBinaryData = null; // headless free-space fallback
+
+            ROM rom = MakeRom();
+            CoreState.ROM = rom;
+            CoreState.Undo = new Undo();
+
+            var vm = new EventTalkGroupFE7ViewModel();
+            int before = rom.Data.Length;
+
+            uint addr;
+            using (ROM.BeginUndoScope(CoreState.Undo.NewUndoData("t")))
+            {
+                addr = vm.NewAlloc();
+            }
+
+            Assert.NotEqual(U.NOT_FOUND, addr);
+            Assert.Equal(addr, vm.BaseAddr);
+            // 14 × 4 = 56-byte block, zero-filled.
+            Assert.Equal(56, EventTalkGroupFE7ViewModel.NewAllocSize);
+            for (uint i = 0; i < EventTalkGroupFE7ViewModel.NewAllocSize; i++)
+            {
+                Assert.Equal(0u, rom.u8(addr + i));
+            }
+            // The new block lists 14 entries.
+            Assert.Equal(EventTalkGroupFE7ViewModel.EntryCount, vm.LoadList().Count);
+        }
+        finally
+        {
+            CoreState.AppendBinaryData = savedAppend;
+        }
+    }
+
+    // ================================================================
+    // Helpers
+    // ================================================================
+
+    static ROM MakeRom()
+    {
+        var bytes = new byte[0x1100000];
+        var rom = new ROM();
+        rom.LoadLow("synth-AE7E01-1442.gba", bytes, "AE7E01");
+        return rom;
+    }
+
+    static void PlantU16(ROM rom, uint addr, ushort value)
+    {
+        rom.Data[(int)addr + 0] = (byte)(value & 0xFF);
+        rom.Data[(int)addr + 1] = (byte)((value >> 8) & 0xFF);
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/EventTalkGroupFE7ListTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EventTalkGroupFE7ListTests.cs
@@ -128,7 +128,6 @@ public class EventTalkGroupFE7ListTests : IDisposable
             CoreState.Undo = new Undo();
 
             var vm = new EventTalkGroupFE7ViewModel();
-            int before = rom.Data.Length;
 
             uint addr;
             using (ROM.BeginUndoScope(CoreState.Undo.NewUndoData("t")))

--- a/FEBuilderGBA.Avalonia.Tests/EventTalkGroupFE7ScreenshotTest.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EventTalkGroupFE7ScreenshotTest.cs
@@ -1,0 +1,149 @@
+using System;
+using System.IO;
+using System.Reflection;
+using global::Avalonia;
+using global::Avalonia.Controls;
+using global::Avalonia.Headless.XUnit;
+using global::Avalonia.Media.Imaging;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Avalonia.Views;
+using FEBuilderGBA.SkiaSharp;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    /// <summary>
+    /// Issue #1442: render the Avalonia <see cref="EventTalkGroupFE7View"/> on a real
+    /// FE7 ROM and capture a PNG proving the editor is now a 14-entry stride-4 list
+    /// (was a single auto-discovered entry) with a repointable base and a "New Block"
+    /// button (NewAlloc parity with WinForms EventTalkGroupFE7Form).
+    ///
+    /// HEADLESS render (Avalonia.Headless + RenderTargetBitmap) — works even when the
+    /// desktop is locked. Output defaults to a per-test temp dir; set
+    /// FEBUILDERGBA_SCREENSHOT_DIR to the repo's pr-screenshots/ to regenerate the
+    /// canonical PR screenshot. Mirrors <see cref="EventBattleTalkFE7ScreenshotTest"/>.
+    /// The data-layer assertions (14 rows + New Block button present + populated detail
+    /// pane) remain the proof regardless of whether the headless raster pipeline succeeds.
+    /// </summary>
+    [Collection("SharedState")]
+    public class EventTalkGroupFE7ScreenshotTest
+    {
+        const uint BlockBase = 0x00900000u; // synthetic talk-group block when none auto-discovered
+
+        readonly ITestOutputHelper _output;
+
+        public EventTalkGroupFE7ScreenshotTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [AvaloniaFact]
+        public void TalkGroupFE7Editor_Lists14Entries_HasNewBlock_SavesScreenshot()
+        {
+            RomTestHelper.WithRom("FE7J", () =>
+            {
+                var prevImageService = CoreState.ImageService;
+                try
+                {
+                    if (CoreState.ImageService == null)
+                        CoreState.ImageService = new SkiaImageService();
+
+                    var view = new EventTalkGroupFE7View();
+
+                    // Drive the real Opened -> LoadList path. If the ROM has no
+                    // auto-discoverable talk-group block (event-script scan can be
+                    // gated headless), plant a deterministic 14×4 block and repoint.
+                    Invoke(view, "LoadList");
+                    var vm = (EventTalkGroupFE7ViewModel)view.DataViewModel!;
+                    var list = view.FindControl<global::FEBuilderGBA.Avalonia.Controls.AddressListControl>("EntryList");
+
+                    if (list!.GetItems().Count == 0)
+                    {
+                        PlantBlock(CoreState.ROM!, BlockBase);
+                        vm.SetBaseAddr(BlockBase);
+                        Invoke(view, "LoadList");
+                    }
+
+                    view.SelectFirstItem();
+
+                    var textIdBox = view.FindControl<NumericUpDown>("TextIdUpDown");
+                    var writeButton = view.FindControl<Button>("WriteButton");
+                    var newBlockButton = view.FindControl<Button>("NewBlockButton");
+                    var addrLabel = view.FindControl<TextBlock>("AddrLabel");
+
+                    // The ported surface must exist.
+                    Assert.NotNull(textIdBox);
+                    Assert.NotNull(writeButton);
+                    Assert.NotNull(newBlockButton); // NewAlloc parity
+                    Assert.Equal("New Block", newBlockButton!.Content);
+
+                    // 14 stride-4 entries are listed (was 1 in the stub).
+                    Assert.Equal(EventTalkGroupFE7ViewModel.EntryCount, list.GetItems().Count);
+
+                    // Selecting the first entry populates the address readout.
+                    Assert.False(string.IsNullOrEmpty(addrLabel?.Text));
+                    Assert.StartsWith("0x", addrLabel!.Text);
+
+                    _output.WriteLine($"Rows={list.GetItems().Count} Addr={addrLabel.Text} " +
+                                      $"Base=0x{vm.BaseAddr:X08} TextId={textIdBox!.Value}");
+
+                    string outDir = ResolveScreenshotOutputDir();
+                    Directory.CreateDirectory(outDir);
+                    SaveRender(view, 1100, 600, Path.Combine(outDir, "pr1442-talkgroup-fe7.png"));
+                }
+                finally
+                {
+                    CoreState.ImageService = prevImageService;
+                }
+            });
+        }
+
+        static void PlantBlock(ROM rom, uint baseAddr)
+        {
+            // 14 entries × 4 bytes, low u16 = a recognizable text id per entry.
+            for (int i = 0; i < EventTalkGroupFE7ViewModel.EntryCount; i++)
+            {
+                uint a = baseAddr + (uint)(i * 4);
+                ushort id = (ushort)(0x0100 + i);
+                rom.Data[(int)a + 0] = (byte)(id & 0xFF);
+                rom.Data[(int)a + 1] = (byte)((id >> 8) & 0xFF);
+            }
+        }
+
+        void SaveRender(Control view, int w, int h, string outPath)
+        {
+            try
+            {
+                view.Measure(new Size(w, h));
+                view.Arrange(new Rect(0, 0, w, h));
+                using var bitmap = new RenderTargetBitmap(new PixelSize(w, h), new Vector(96, 96));
+                bitmap.Render(view);
+                bitmap.Save(outPath);
+                _output.WriteLine($"Saved screenshot to: {outPath} ({new FileInfo(outPath).Length} bytes)");
+            }
+            catch (Exception ex)
+            {
+                _output.WriteLine($"Headless render failed (environment, not the #1442 fix): {ex.Message}");
+            }
+        }
+
+        static void Invoke(object target, string method, params object?[]? args)
+        {
+            var m = target.GetType().GetMethod(method,
+                BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
+            Assert.NotNull(m);
+            m!.Invoke(target, args);
+        }
+
+        static string ResolveScreenshotOutputDir()
+        {
+            string? overrideDir = Environment.GetEnvironmentVariable("FEBUILDERGBA_SCREENSHOT_DIR");
+            if (!string.IsNullOrEmpty(overrideDir))
+                return overrideDir;
+            return Path.Combine(Path.GetTempPath(), "FEBuilderGBA-screenshots");
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/EventTalkGroupFE7UndoTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EventTalkGroupFE7UndoTests.cs
@@ -124,6 +124,51 @@ public class EventTalkGroupFE7UndoTests : IDisposable
         Assert.Contains("_vm.MarkClean()", src);
     }
 
+    // #1442 — NewAlloc (new 14×4=56-byte block) must be undo-tracked through the
+    // UndoService scope, exactly like OnNewBlock in the view. Commit records the
+    // append (IsModified) and the editor repoints onto the new block; Undo restores
+    // byte identity.
+    [Fact]
+    public void NewAlloc_IsUndoable_FE7()
+    {
+        var savedAppend = CoreState.AppendBinaryData;
+        try
+        {
+            CoreState.AppendBinaryData = null; // force the headless free-space fallback
+
+            ROM rom = MakeRom();
+            CoreState.ROM = rom;
+            CoreState.Undo = new Undo();
+
+            var vm = new EventTalkGroupFE7ViewModel();
+            byte[] snap = (byte[])rom.Data.Clone();
+            var undoService = new UndoService();
+
+            // EXACT View OnNewBlock sequence (Begin -> NewAlloc -> Commit).
+            undoService.Begin("New Block Talk Group (FE7)");
+            uint newAddr = vm.NewAlloc();
+            Assert.NotEqual(U.NOT_FOUND, newAddr);
+            undoService.Commit();
+
+            // The 56-byte block was appended, the editor repointed onto it, and the
+            // append was captured by the undo buffer.
+            Assert.Equal(newAddr, vm.BaseAddr);
+            Assert.True(CoreState.Undo.IsModified);
+
+            // The new block lists 14 stride-4 entries.
+            var list = vm.LoadList();
+            Assert.Equal(EventTalkGroupFE7ViewModel.EntryCount, list.Count);
+
+            // Undo reverts byte-identity.
+            CoreState.Undo.RunUndo();
+            Assert.Equal(snap, rom.Data);
+        }
+        finally
+        {
+            CoreState.AppendBinaryData = savedAppend;
+        }
+    }
+
     // ================================================================
     // Helpers
     // ================================================================

--- a/FEBuilderGBA.Avalonia/ViewModels/EventTalkGroupFE7ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/EventTalkGroupFE7ViewModel.cs
@@ -3,34 +3,78 @@ using FEBuilderGBA.Avalonia.Services;
 
 namespace FEBuilderGBA.Avalonia.ViewModels
 {
+    // #1442 — Port of WinForms EventTalkGroupFE7Form (FE7 only).
+    // WinForms is an InputFormRef list: base 0, stride 4, IsDataExists "i <= 0xD"
+    // (14 entries, i=0..0xD). Each entry's editable cell is the named control "D0"
+    // (u32 at +0; EventTalkGroupFE7Form.Designer.cs); the list label reads the
+    // text id via u16 (EventTalkGroupFE7Form.MakeList). JumpToAddr/ReInit repoints
+    // the list onto an arbitrary block base (driven from POINTER_TALKGROUP).
+    // NewAlloc allocates byte[4*0xE] (= 56 bytes) via AppendBinaryData with undo.
     public class EventTalkGroupFE7ViewModel : ViewModelBase, IDataVerifiable
     {
         static readonly List<EditorFormRef.FieldDef> _fields =
             EditorFormRef.DetectFields(new[] { "D0" });
 
+        // Fixed list geometry (parity with WinForms InputFormRef base/stride/IsDataExists).
+        public const int EntryCount = 0xE;   // 14 entries (i=0..0xD)
+        public const uint EntryStride = 4;   // bytes per entry
+        public const int NewAllocSize = (int)(EntryStride * EntryCount); // 56 bytes
+
+        uint _baseAddr;
         uint _currentAddr;
         bool _isLoaded;
         uint _textId;
 
+        /// <summary>Base address (ROM offset) of the active talk-group block (repoint target).</summary>
+        public uint BaseAddr { get => _baseAddr; set => SetField(ref _baseAddr, value); }
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
         // D0: Text ID / dialogue pointer (u32 at offset 0)
         public uint TextId { get => _textId; set => SetField(ref _textId, value); }
+
+        /// <summary>
+        /// Repoint the editor onto a specific block base (parity with WinForms
+        /// JumpToAddr → InputFormRef.ReInit). Normalizes via <see cref="U.toOffset"/>
+        /// so both raw ROM offsets and 0x08...... GBA pointers work. Pass 0 to clear
+        /// and re-auto-discover on the next LoadList.
+        /// </summary>
+        public void SetBaseAddr(uint addr)
+        {
+            BaseAddr = addr == 0 ? 0 : U.toOffset(addr);
+        }
 
         public List<AddrResult> LoadList()
         {
             ROM rom = CoreState.ROM;
             if (rom?.RomInfo == null) return new List<AddrResult>();
 
-            // Find the first valid talk group address from event scripts
-            uint addr = EventSubEditorHelper.FindFirstTalkGroupAddr(rom);
-            if (addr != 0)
+            // Use the explicitly repointed base if set, otherwise auto-discover the
+            // first valid talk-group block from event scripts.
+            uint baseAddr = BaseAddr;
+            if (baseAddr == 0)
             {
-                LoadEntry(addr);
-                return new List<AddrResult> { new AddrResult(addr, "Talk Group (FE7)", 0) };
+                baseAddr = EventSubEditorHelper.FindFirstTalkGroupAddr(rom);
+                if (baseAddr == 0) return new List<AddrResult>();
+                BaseAddr = baseAddr;
             }
 
-            return new List<AddrResult>();
+            uint romLen = (uint)rom.Data.Length;
+            var result = new List<AddrResult>();
+            // 14 stride-4 entries (i=0..0xD), each labeled with its text id (u16,
+            // like WinForms MakeList).
+            for (int i = 0; i < EntryCount; i++)
+            {
+                uint addr = baseAddr + (uint)(i * EntryStride);
+                if (addr + EntryStride > romLen) break;
+
+                uint textid = rom.u16(addr);
+                string name = textid != 0 ? NameResolver.GetTextById(textid) : "";
+                string label = string.IsNullOrEmpty(name)
+                    ? $"0x{i:X} : 0x{textid:X04}"
+                    : $"0x{i:X} : 0x{textid:X04} {name}";
+                result.Add(new AddrResult(addr, label, (uint)i));
+            }
+            return result;
         }
 
         public void LoadEntry(uint addr)
@@ -49,17 +93,51 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         {
             ROM rom = CoreState.ROM;
             if (rom == null || CurrentAddr == 0) return;
+            if (CurrentAddr + 4 > (uint)rom.Data.Length) return;
             var values = new Dictionary<string, uint> { ["D0"] = TextId };
             EditorFormRef.WriteFields(rom, CurrentAddr, values, _fields);
         }
 
-        public int GetListCount() => IsLoaded && CurrentAddr != 0 ? 1 : 0;
+        /// <summary>
+        /// Allocate a fresh, zero-filled talk-group block (14 × 4 = 56 bytes) in ROM
+        /// free space and repoint the editor onto it. Parity with WinForms NewAlloc
+        /// (byte[4*0xE] via AppendBinaryData). The append is captured by the ambient
+        /// undo scope opened by the caller (UndoService.Begin). Returns the new block
+        /// base (ROM offset), or U.NOT_FOUND on failure (no mutation).
+        ///
+        /// NOTE: like WinForms <c>NewAlloc</c>, this only appends the block; it does
+        /// NOT write the new block's pointer back into any event script. The standalone
+        /// "New Block" button therefore creates an as-yet-unreferenced block — wire it
+        /// into an event (the POINTER_TALKGROUP arg) so it is reachable. WinForms reuses
+        /// the same append in <c>AllocIfNeed</c>, which is the only path that does the
+        /// <c>U.toPointer(newAddr)</c> writeback (when launched from a 0/NOT_FOUND
+        /// pointer source); the Avalonia editor opens standalone, so no writeback applies.
+        /// </summary>
+        public uint NewAlloc()
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null) return U.NOT_FOUND;
+
+            byte[] alloc = new byte[NewAllocSize];
+            // The caller (View "New Block" button) opens a UndoService.Begin scope
+            // before calling, so the ambient UndoData is non-null and captures the
+            // append (mirrors EventCondViewModel.AppendBinaryDataHeadless).
+            Undo.UndoData ambient = ROM.GetAmbientUndoData();
+            uint addr = MapEventUnitCore.AppendBinaryDataHeadless(rom, alloc, ambient);
+            if (addr == U.NOT_FOUND) return U.NOT_FOUND;
+
+            SetBaseAddr(addr);
+            return addr;
+        }
+
+        public int GetListCount() => LoadList().Count;
 
         public Dictionary<string, string> GetDataReport()
         {
             return new Dictionary<string, string>
             {
                 ["addr"] = $"0x{CurrentAddr:X08}",
+                ["base"] = $"0x{BaseAddr:X08}",
                 ["TextId"] = $"0x{TextId:X08}",
             };
         }

--- a/FEBuilderGBA.Avalonia/ViewModels/EventTalkGroupFE7ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/EventTalkGroupFE7ViewModel.cs
@@ -122,7 +122,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             // The caller (View "New Block" button) opens a UndoService.Begin scope
             // before calling, so the ambient UndoData is non-null and captures the
             // append (mirrors EventCondViewModel.AppendBinaryDataHeadless).
-            Undo.UndoData ambient = ROM.GetAmbientUndoData();
+            Undo.UndoData? ambient = ROM.GetAmbientUndoData();
             uint addr = MapEventUnitCore.AppendBinaryDataHeadless(rom, alloc, ambient);
             if (addr == U.NOT_FOUND) return U.NOT_FOUND;
 

--- a/FEBuilderGBA.Avalonia/ViewModels/EventTalkGroupFE7ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/EventTalkGroupFE7ViewModel.cs
@@ -152,6 +152,9 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             {
                 ["addr"] = $"0x{a:X08}",
                 ["u32@0x00_TextId"] = $"0x{rom.u32(a + 0):X08}",
+                // The list label reads the text id via u16 (parity with WinForms
+                // MakeList); surface it so data-verify cross-checks that read too.
+                ["u16@0x00_TextIdLow"] = $"0x{rom.u16(a + 0):X04}",
             };
         }
 

--- a/FEBuilderGBA.Avalonia/Views/EventTalkGroupFE7View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EventTalkGroupFE7View.axaml
@@ -25,7 +25,10 @@
           </StackPanel>
         </Grid>
 
-        <Button AutomationProperties.AutomationId="EventTalkGroupFE7_Write_Button" Name="WriteButton" Content="Write" HorizontalAlignment="Left" Margin="0,8" />
+        <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,8">
+          <Button AutomationProperties.AutomationId="EventTalkGroupFE7_Write_Button" Name="WriteButton" Content="Write" />
+          <Button AutomationProperties.AutomationId="EventTalkGroupFE7_NewBlock_Button" Name="NewBlockButton" Content="New Block" />
+        </StackPanel>
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/FEBuilderGBA.Avalonia/Views/EventTalkGroupFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventTalkGroupFE7View.axaml.cs
@@ -21,6 +21,7 @@ namespace FEBuilderGBA.Avalonia.Views
             EntryList.SelectedAddressChanged += OnSelected;
             TextIdUpDown.ValueChanged += OnTextIdChanged;
             WriteButton.Click += OnWrite;
+            NewBlockButton.Click += OnNewBlock;
             Opened += (_, _) => LoadList();
         }
 
@@ -85,7 +86,60 @@ namespace FEBuilderGBA.Avalonia.Views
             }
         }
 
-        public void NavigateTo(uint address) => EntryList.SelectAddress(address);
+        // #1442 — "New Block" allocates a fresh 14×4=56-byte talk-group block in ROM
+        // free space and repoints the editor onto it (parity with WinForms NewAlloc).
+        // The append is undo-tracked via the UndoService scope (#1428 pattern).
+        void OnNewBlock(object? sender, RoutedEventArgs e)
+        {
+            _undoService.Begin(R._("New Block Talk Group (FE7)"));
+            try
+            {
+                uint addr = _vm.NewAlloc();
+                if (addr == U.NOT_FOUND)
+                {
+                    _undoService.Rollback();
+                    Log.Error("EventTalkGroupFE7View.OnNewBlock: allocation failed (no free space)");
+                    return;
+                }
+                _undoService.Commit();
+
+                // Reload the list onto the new block and select its first entry.
+                LoadList();
+                EntryList.SelectFirst();
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.Error("EventTalkGroupFE7View.OnNewBlock failed: " + ex.ToString());
+            }
+        }
+
+        // #1442 — Repoint onto an arbitrary block base (parity with WinForms
+        // JumpToAddr → ReInit) so the editor can be driven from a POINTER_TALKGROUP
+        // arg. If the target address is not inside the currently loaded block,
+        // repoint the VM to that block's base and reload before selecting.
+        public void NavigateTo(uint address)
+        {
+            if (address == 0 || address == U.NOT_FOUND)
+            {
+                EntryList.SelectAddress(address);
+                return;
+            }
+
+            uint offset = U.toOffset(address);
+            if (!EntryList.SelectAddress(offset))
+            {
+                // Out-of-range: treat the navigated address as the block base and
+                // repoint the list onto it.
+                _vm.SetBaseAddr(offset);
+                LoadList();
+                if (!EntryList.SelectAddress(offset))
+                {
+                    EntryList.SelectFirst();
+                }
+            }
+        }
+
         public void SelectFirstItem() => EntryList.SelectFirst();
         public ViewModelBase? DataViewModel => _vm;
     }

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -4430,6 +4430,8 @@ W92: D ヘクトル 困難
 
 :Write
 書き込み
+:New Block
+新規ブロック
 
 :W40: Prologue BGM (Eliwood)
 W40: Prologue BGM (エリウッド)

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -20711,6 +20711,8 @@ ID=00 Empty 已预留为空数据。\r\n请勿设置 0x0 之外的值。
 
 :Write
 写入
+:New Block
+新建块
 
 :Open Source Folder
 打开源文件夹

--- a/docs/avalonia-forms.md
+++ b/docs/avalonia-forms.md
@@ -214,7 +214,7 @@ Editors for event scripts, conditions, units, templates, and related data.
 | 113 | EventAssemblerView | EventAssemblerViewModel | Event assembler integration |
 | 114 | EventFinalSerifFE7View | EventFinalSerifFE7ViewModel | Final chapter serif (FE7) |
 | 115 | EventMoveDataFE7View | EventMoveDataFE7ViewModel | Unit move data events (FE7) |
-| 116 | EventTalkGroupFE7View | EventTalkGroupFE7ViewModel | Talk group events (FE7) |
+| 116 | EventTalkGroupFE7View | EventTalkGroupFE7ViewModel | Talk group events (FE7) — 14-entry stride-4 list + repoint + NewAlloc (#1442) |
 | 117 | EventTemplate1View | EventTemplate1ViewModel | Event template 1 |
 | 118 | EventTemplate2View | EventTemplate2ViewModel | Event template 2 |
 | 119 | EventTemplate3View | EventTemplate3ViewModel | Event template 3 |

--- a/docs/field-completeness-report.txt
+++ b/docs/field-completeness-report.txt
@@ -1,6 +1,6 @@
 === Field Completeness Report ===
 Total WinForms fields: 1563
-Total Avalonia fields: 1810
+Total Avalonia fields: 1813
 Total missing: 0
 Forms with gaps: 0 / 180
 


### PR DESCRIPTION
## Summary
Ports the full WinForms `EventTalkGroupFE7Form` into the Avalonia **Talk Group (FE7)** editor. Previously the Avalonia editor auto-discovered a single talk-group block and exposed exactly ONE entry (first u32). It is now a **14-entry (i=0..0xD) stride-4 list** with **repoint** and **NewAlloc**, matching the WinForms ground truth.

Plan: https://github.com/laqieer/FEBuilderGBA/issues/1442#issuecomment-4802103133 (Copilot-reviewed; both adjustments applied — `U.toOffset` base normalization + documented orphan-block note).

## WinForms ground truth (`EventTalkGroupFE7Form.cs`)
- InputFormRef base 0, **stride 4**, `IsDataExists` `i <= 0xD` → **14 entries**; each editable as the `D0` (u32) text-id cell; list label reads the id via `u16` (`MakeList`).
- `JumpToAddr` → `ReInit` repoints onto an arbitrary block base (driven from `POINTER_TALKGROUP`).
- `NewAlloc` appends `byte[4*0xE]` (= 56 bytes) via `AppendBinaryData` with undo.

## Changes
- **`EventTalkGroupFE7ViewModel.cs`**: `LoadList` emits 14 stride-4 rows at `base+i*4`, each labeled `0xI : 0xTTTT name` (u16 read). `SetBaseAddr` repoint (normalized via `U.toOffset` → raw offsets AND `0x08...` pointers). `NewAlloc` → `MapEventUnitCore.AppendBinaryDataHeadless` (56-byte zero block) + repoint; ambient-undo captured. `GetListCount` returns the real count. `GetRawRomReport` also surfaces the u16 text-id read.
- **`EventTalkGroupFE7View.axaml(.cs)`**: "New Block" button (undo-tracked via the #1428 `UndoService` scope); `NavigateTo` repoints onto an out-of-range block. Existing #1428 undo-tracked OnWrite preserved.
- Docs: `docs/avalonia-forms.md` + `docs/field-completeness-report.txt`. l10n: `New Block` (ja/zh).

## Test plan
- [x] `EventTalkGroupFE7ListTests` — 14-row stride-4 list; u16 label; repoint via raw offset and `0x08` pointer; switch between blocks; NewAlloc appends a 56-byte zero block.
- [x] `EventTalkGroupFE7UndoTests` — `NewAlloc_IsUndoable_FE7` (append captured + Undo restores byte identity); existing 3 undo tests pass.
- [x] `EventTalkGroupFE7ScreenshotTest` — real FE7J ROM; auto-discovers a block, lists 14 rows, New Block button present (data assertions pass; headless raster is env-gated).
- [x] `FEBuilderGBA.Avalonia.Tests` full run — 8699 passed, 0 failed.
- [x] `FEBuilderGBA.Core.Tests` — 5883 passed; only the 10 known SkillSystems/SkillConfig patch2-submodule worktree-env failures (unrelated to this change).
- [x] `FEBuilderGBA.Tests` (net9.0-windows) field-completeness + trimming/editor tests for this view pass.

## Screenshots
Real FE7J ROM, Talk Group (FE7) editor — 14 stride-4 entries listed with decoded text-id names, populated detail pane, and the new **New Block** (NewAlloc) button:

![Talk Group (FE7) editor — 14-entry list + New Block](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr1442-talkgroup-fe7.png)

## GUI Test Report
| Scenario | Result |
| --- | --- |
| Editor opens on FE7J, 14 stride-4 rows listed | PASS (screenshot + unit) |
| Each row labeled with its u16 text id + decoded name | PASS (screenshot + unit) |
| Repoint onto another block base (offset + pointer) | PASS (unit) |
| New Block appends 56-byte zero block + repoints, undo-tracked | PASS (unit) |
| Edit Text ID writes undo-tracked (#1428 preserved) | PASS (unit) |

🤖 Generated with Claude Code (Opus 4.8, 1M context)
