### PR TITLE
fix(avalonia): add Write button to TextCharCode editor so Char Code/Terminator edits persist (#1446)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/TextCharCodeScreenshotTest.cs
+++ b/FEBuilderGBA.Avalonia.Tests/TextCharCodeScreenshotTest.cs
@@ -1,0 +1,199 @@
+// #1446 PR proof — render the real TextCharCodeView with a loaded char-code entry
+// so the screenshot shows the editable Char Code / Terminator spinners AND the new
+// Write button (previously the editor had only a Close button, so edits never
+// persisted).
+//
+// The PNG is captured via the Avalonia headless software framebuffer
+// (HeadlessWindowExtensions.CaptureRenderedFrame) and written with a dependency-free
+// PNG encoder (no SkiaSharp native PNG encoder). The shared TestApp uses
+// UseHeadlessDrawing in some CI/locked environments, so the frame may be blank/null
+// there — the render is wrapped in try/catch and the FUNCTIONAL assertions (Write
+// button present + populated entry) are the authoritative proof. Set
+// FEBUILDERGBA_SCREENSHOT_DIR to regenerate the canonical PR screenshot.
+using System;
+using System.IO;
+using global::Avalonia;
+using global::Avalonia.Controls;
+using global::Avalonia.Headless;
+using global::Avalonia.Headless.XUnit;
+using global::Avalonia.Media.Imaging;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    [Collection("SharedState")]
+    public class TextCharCodeScreenshotTest
+    {
+        readonly ITestOutputHelper _output;
+
+        public TextCharCodeScreenshotTest(ITestOutputHelper output) => _output = output;
+
+        [AvaloniaFact]
+        public void TextCharCodeView_HasWriteButton_SavesScreenshot()
+        {
+            bool ran = false;
+            RomTestHelper.WithRom("FE8U", () =>
+            {
+                ran = true;
+
+                var view = new TextCharCodeView();
+                // The ctor selects the first entry, so the editor panel is populated.
+
+                // FUNCTIONAL proof (authoritative regardless of rasteriser):
+                // the Write button exists and the editor is loaded with an entry.
+                var write = view.FindControl<Button>("WriteButton");
+                Assert.NotNull(write);
+                Assert.True(view.IsLoaded, "editor must have a selected char-code entry");
+
+                const int W = 1172;
+                const int H = 519;
+                view.Measure(new Size(W, H));
+                view.Arrange(new Rect(0, 0, W, H));
+
+                string outDir = ResolveScreenshotOutputDir();
+                Directory.CreateDirectory(outDir);
+                string outPath = Path.Combine(outDir, "pr1446-textcharcode-fe8u.png");
+
+                try
+                {
+                    view.Show();
+                    global::Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+                    using var frame = view.CaptureRenderedFrame();
+                    Assert.NotNull(frame);
+                    SavePng(frame!, outPath);
+                    _output.WriteLine($"Saved screenshot to: {outPath} ({new FileInfo(outPath).Length} bytes)");
+                }
+                catch (Exception ex)
+                {
+                    _output.WriteLine($"Headless capture no-op (environment, not the #1446 fix): {ex.Message}");
+                }
+            });
+
+            if (!ran)
+                _output.WriteLine("SKIP: FE8U ROM not available (set ROMS_DIR or place roms/FE8U.gba)");
+        }
+
+        // ---- dependency-free BGRA8888 WriteableBitmap -> PNG encoder ----
+
+        static void SavePng(WriteableBitmap bmp, string path)
+        {
+            int w = bmp.PixelSize.Width;
+            int h = bmp.PixelSize.Height;
+            int stride = w * 4;
+            byte[] bgra = new byte[stride * h];
+            using (var fb = bmp.Lock())
+            {
+                int srcStride = fb.RowBytes;
+                IntPtr basePtr = fb.Address;
+                for (int y = 0; y < h; y++)
+                {
+                    IntPtr rowPtr = IntPtr.Add(basePtr, y * srcStride);
+                    System.Runtime.InteropServices.Marshal.Copy(rowPtr, bgra, y * stride, stride);
+                }
+            }
+
+            byte[] raw = new byte[(stride + 1) * h];
+            int o = 0;
+            for (int y = 0; y < h; y++)
+            {
+                raw[o++] = 0; // filter: none
+                int rowStart = y * stride;
+                for (int x = 0; x < w; x++)
+                {
+                    int i = rowStart + x * 4;
+                    raw[o++] = bgra[i + 2]; // R
+                    raw[o++] = bgra[i + 1]; // G
+                    raw[o++] = bgra[i + 0]; // B
+                    raw[o++] = bgra[i + 3]; // A
+                }
+            }
+
+            using var ms = new MemoryStream();
+            WriteBytes(ms, new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A });
+            byte[] ihdr = new byte[13];
+            WriteBe(ihdr, 0, (uint)w);
+            WriteBe(ihdr, 4, (uint)h);
+            ihdr[8] = 8;  // bit depth
+            ihdr[9] = 6;  // color type RGBA
+            WriteChunk(ms, "IHDR", ihdr);
+            byte[] compressed = ZlibCompress(raw);
+            WriteChunk(ms, "IDAT", compressed);
+            WriteChunk(ms, "IEND", Array.Empty<byte>());
+            File.WriteAllBytes(path, ms.ToArray());
+        }
+
+        static byte[] ZlibCompress(byte[] data)
+        {
+            using var outMs = new MemoryStream();
+            outMs.WriteByte(0x78);
+            outMs.WriteByte(0x01);
+            using (var ds = new System.IO.Compression.DeflateStream(outMs, System.IO.Compression.CompressionLevel.Fastest, true))
+            {
+                ds.Write(data, 0, data.Length);
+            }
+            uint a = 1, b = 0;
+            foreach (byte by in data) { a = (a + by) % 65521; b = (b + a) % 65521; }
+            uint adler = (b << 16) | a;
+            outMs.WriteByte((byte)(adler >> 24));
+            outMs.WriteByte((byte)(adler >> 16));
+            outMs.WriteByte((byte)(adler >> 8));
+            outMs.WriteByte((byte)adler);
+            return outMs.ToArray();
+        }
+
+        static void WriteChunk(Stream s, string type, byte[] data)
+        {
+            byte[] len = new byte[4];
+            WriteBe(len, 0, (uint)data.Length);
+            s.Write(len, 0, 4);
+            byte[] typeBytes = System.Text.Encoding.ASCII.GetBytes(type);
+            s.Write(typeBytes, 0, 4);
+            s.Write(data, 0, data.Length);
+            uint crc = Crc32(typeBytes, data);
+            byte[] crcb = new byte[4];
+            WriteBe(crcb, 0, crc);
+            s.Write(crcb, 0, 4);
+        }
+
+        static uint[]? _crcTable;
+        static uint Crc32(byte[] type, byte[] data)
+        {
+            if (_crcTable == null)
+            {
+                _crcTable = new uint[256];
+                for (uint n = 0; n < 256; n++)
+                {
+                    uint c = n;
+                    for (int k = 0; k < 8; k++)
+                        c = ((c & 1) != 0) ? (0xEDB88320 ^ (c >> 1)) : (c >> 1);
+                    _crcTable[n] = c;
+                }
+            }
+            uint crc = 0xFFFFFFFF;
+            foreach (byte by in type) crc = _crcTable[(crc ^ by) & 0xFF] ^ (crc >> 8);
+            foreach (byte by in data) crc = _crcTable[(crc ^ by) & 0xFF] ^ (crc >> 8);
+            return crc ^ 0xFFFFFFFF;
+        }
+
+        static void WriteBe(byte[] buf, int off, uint val)
+        {
+            buf[off] = (byte)(val >> 24);
+            buf[off + 1] = (byte)(val >> 16);
+            buf[off + 2] = (byte)(val >> 8);
+            buf[off + 3] = (byte)val;
+        }
+
+        static void WriteBytes(Stream s, byte[] b) => s.Write(b, 0, b.Length);
+
+        static string ResolveScreenshotOutputDir()
+        {
+            string? overrideDir = Environment.GetEnvironmentVariable("FEBUILDERGBA_SCREENSHOT_DIR");
+            if (!string.IsNullOrEmpty(overrideDir))
+                return overrideDir;
+            return Path.Combine(Path.GetTempPath(), "FEBuilderGBA-screenshots");
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/TextCharCodeWriteTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/TextCharCodeWriteTests.cs
@@ -1,0 +1,141 @@
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Avalonia.Views;
+using global::Avalonia.Controls;
+using global::Avalonia.Headless.XUnit;
+using global::Avalonia.Interactivity;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+/// <summary>
+/// Tests for the Text Character Code editor Write button + persistence (issue #1446).
+///
+/// The Avalonia editor exposed editable Char Code (u16@0) and Terminator (u16@2)
+/// NumericUpDowns but had no Write button, so <see cref="TextCharCodeViewModel.Write"/>
+/// was never invoked and edits silently never persisted. WinForms <c>TextCharCodeForm</c>
+/// persists via an InputFormRef write button + PostWriteHandler. These tests verify the
+/// added Write button exists and that clicking it (and calling Write directly) round-trips
+/// the two u16 values to the ROM.
+///
+/// Ref #404: serialize against `SharedState` because <see cref="TextCharCodeView"/>
+/// reads `rom.getString` via `CoreState.SystemTextEncoder` during construction, which
+/// races with other test classes holding a live `CoreState.ROM`.
+/// </summary>
+[Collection("SharedState")]
+public class TextCharCodeWriteTests : IClassFixture<RomFixture>
+{
+    private readonly RomFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public TextCharCodeWriteTests(RomFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    bool Skip()
+    {
+        if (!_fixture.IsAvailable)
+        {
+            _output.WriteLine("RomFixture not available — skipping ROM-backed assertions.");
+            return true;
+        }
+        return false;
+    }
+
+    [Fact]
+    public void Write_RoundTripsCharCodeAndTerminator()
+    {
+        if (Skip()) return;
+
+        var vm = new TextCharCodeViewModel();
+        vm.Initialize();
+        Assert.True(vm.GetListCount() > 0, "expected at least one char-code entry");
+
+        vm.SelectIndex(0);
+        uint addr = vm.CurrentAddr;
+        Assert.NotEqual(0u, addr);
+
+        uint origCode = CoreState.ROM.u16(addr + 0);
+        uint origTerm = CoreState.ROM.u16(addr + 2);
+
+        try
+        {
+            vm.CharCode = 0x1234;
+            vm.TerminatorValue = 0xABCD;
+            vm.Write();
+
+            // Re-read from a fresh VM at the same address.
+            var vm2 = new TextCharCodeViewModel();
+            vm2.LoadEntry(addr);
+            Assert.Equal(0x1234u, vm2.CharCode);
+            Assert.Equal(0xABCDu, vm2.TerminatorValue);
+
+            // And confirm the raw ROM bytes match.
+            Assert.Equal(0x1234u, CoreState.ROM.u16(addr + 0));
+            Assert.Equal(0xABCDu, CoreState.ROM.u16(addr + 2));
+        }
+        finally
+        {
+            vm.CharCode = origCode;
+            vm.TerminatorValue = origTerm;
+            vm.Write();
+        }
+    }
+
+    [AvaloniaFact]
+    public void View_HasWriteButton()
+    {
+        var view = new TextCharCodeView();
+        var write = view.FindControl<Button>("WriteButton");
+        Assert.NotNull(write);
+        _output.WriteLine("WriteButton present (OK)");
+    }
+
+    [AvaloniaFact]
+    public void WriteButton_Click_PersistsBoxValues()
+    {
+        if (Skip()) return;
+
+        var view = new TextCharCodeView();
+
+        var list = view.FindControl<ListBox>("CharCodeList");
+        var charBox = view.FindControl<NumericUpDown>("CharCodeBox");
+        var termBox = view.FindControl<NumericUpDown>("TerminatorBox");
+        var write = view.FindControl<Button>("WriteButton");
+        Assert.NotNull(list);
+        Assert.NotNull(charBox);
+        Assert.NotNull(termBox);
+        Assert.NotNull(write);
+
+        // Select the first entry so CurrentAddr is populated.
+        list!.SelectedIndex = 0;
+        if (view.DataViewModel is not TextCharCodeViewModel vm || vm.CurrentAddr == 0)
+        {
+            _output.WriteLine("No entry selected — skipping.");
+            return;
+        }
+
+        uint addr = vm.CurrentAddr;
+        uint origCode = CoreState.ROM.u16(addr + 0);
+        uint origTerm = CoreState.ROM.u16(addr + 2);
+
+        try
+        {
+            charBox!.Value = (decimal)0x4321;
+            termBox!.Value = (decimal)0xBEEF;
+            write!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+            Assert.Equal(0x4321u, CoreState.ROM.u16(addr + 0));
+            Assert.Equal(0xBEEFu, CoreState.ROM.u16(addr + 2));
+        }
+        finally
+        {
+            charBox!.Value = (decimal)origCode;
+            termBox!.Value = (decimal)origTerm;
+            write!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/TextCharCodeWriteTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/TextCharCodeWriteTests.cs
@@ -110,13 +110,12 @@ public class TextCharCodeWriteTests : IClassFixture<RomFixture>
         Assert.NotNull(termBox);
         Assert.NotNull(write);
 
-        // Select the first entry so CurrentAddr is populated.
+        // Select the first entry so CurrentAddr is populated. This is ROM-backed
+        // (guarded by Skip() above), so assert — don't silently return — to avoid
+        // turning a real regression (failed load / unselected entry) into a false pass.
         list!.SelectedIndex = 0;
-        if (view.DataViewModel is not TextCharCodeViewModel vm || vm.CurrentAddr == 0)
-        {
-            _output.WriteLine("No entry selected — skipping.");
-            return;
-        }
+        var vm = Assert.IsType<TextCharCodeViewModel>(view.DataViewModel);
+        Assert.NotEqual(0u, vm.CurrentAddr);
 
         uint addr = vm.CurrentAddr;
         uint origCode = CoreState.ROM.u16(addr + 0);
@@ -130,6 +129,12 @@ public class TextCharCodeWriteTests : IClassFixture<RomFixture>
 
             Assert.Equal(0x4321u, CoreState.ROM.u16(addr + 0));
             Assert.Equal(0xBEEFu, CoreState.ROM.u16(addr + 2));
+
+            // After a successful Write the editor must be clean — UpdateFontPreview()
+            // re-marks the VM dirty (it sets ItemFontWidth/SerifFontWidth), so the
+            // handler must run it BEFORE MarkClean(). A dirty VM here means the editor
+            // would wrongly show unsaved changes right after saving.
+            Assert.False(vm.IsDirty, "VM must be clean after a successful Write");
         }
         finally
         {

--- a/FEBuilderGBA.Avalonia/Views/TextCharCodeView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/TextCharCodeView.axaml
@@ -40,6 +40,7 @@
     </StackPanel>
 
     <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Spacing="8" Margin="0,8,0,0" HorizontalAlignment="Right">
+      <Button AutomationProperties.AutomationId="TextCharCode_Write_Button" Name="WriteButton" Content="Write" Width="80" />
       <Button AutomationProperties.AutomationId="TextCharCode_Close_Button" Content="Close" Width="80" Click="Close_Click" />
     </StackPanel>
     <ListBox AutomationProperties.AutomationId="TextCharCode_CharCode_List" Name="CharCodeList" />

--- a/FEBuilderGBA.Avalonia/Views/TextCharCodeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/TextCharCodeView.axaml.cs
@@ -11,6 +11,7 @@ namespace FEBuilderGBA.Avalonia.Views
     public partial class TextCharCodeView : TranslatedWindow, IEditorView, IDataVerifiableView
     {
         readonly TextCharCodeViewModel _vm = new();
+        readonly UndoService _undoService = new();
 
         public string ViewTitle => "Text Character Code";
         public bool IsLoaded => _vm.IsLoaded;
@@ -21,6 +22,7 @@ namespace FEBuilderGBA.Avalonia.Views
             InitializeComponent();
             CharCodeList.ItemsSource = _vm.CharCodes;
             CharCodeList.SelectionChanged += CharCodeList_SelectionChanged;
+            WriteButton.Click += OnWrite;
             _vm.Initialize();
             if (_vm.CharCodes.Count > 0)
             {
@@ -29,6 +31,49 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         void Close_Click(object? sender, RoutedEventArgs e) => Close();
+
+        /// <summary>
+        /// Persist the edited Char Code (u16@0) and Terminator (u16@2) to the ROM under an
+        /// ambient undo scope, then rebuild the Huffman text encoder so the change takes
+        /// effect immediately. Mirrors WinForms <c>TextCharCodeForm</c>'s InputFormRef write
+        /// button + <c>PostWriteHandler → Program.ReBuildFETextEncoder()</c> (#1446).
+        /// </summary>
+        void OnWrite(object? sender, RoutedEventArgs e)
+        {
+            // No entry selected → nothing to persist. _vm.Write() also guards on
+            // CurrentAddr == 0, but bail early so we don't open an empty undo scope.
+            if (_vm.CurrentAddr == 0)
+            {
+                return;
+            }
+
+            _undoService.Begin("Edit Char Code");
+            try
+            {
+                _vm.CharCode = (uint)(CharCodeBox.Value ?? 0);
+                _vm.TerminatorValue = (uint)(TerminatorBox.Value ?? 0);
+                _vm.Write();
+
+                // Equivalent to WinForms Program.ReBuildFETextEncoder(): rebuild the Huffman
+                // text encoder so the encoding table change is picked up. Non-fatal if it
+                // fails (matches MainWindow/RomFixture init pattern).
+                try { CoreState.FETextEncoder = new FETextEncode(); }
+                catch (Exception ex) { Log.Error("TextCharCodeView: FETextEncode rebuild failed: {0}", ex.Message); }
+
+                _undoService.Commit();
+                _vm.MarkClean();
+
+                // _vm.Write() refreshed the list label + CharacterDisplay; push the new
+                // values back into the editor controls.
+                UpdateUI();
+                UpdateFontPreview();
+            }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.Error("TextCharCodeView.OnWrite failed: {0}", ex.Message);
+            }
+        }
 
         public void NavigateTo(uint address)
         {

--- a/FEBuilderGBA.Avalonia/Views/TextCharCodeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/TextCharCodeView.axaml.cs
@@ -61,12 +61,15 @@ namespace FEBuilderGBA.Avalonia.Views
                 catch (Exception ex) { Log.Error($"TextCharCodeView: FETextEncode rebuild failed: {ex}"); }
 
                 _undoService.Commit();
-                _vm.MarkClean();
 
                 // _vm.Write() refreshed the list label + CharacterDisplay; push the new
-                // values back into the editor controls.
+                // values back into the editor controls. UpdateFontPreview() sets
+                // _vm.ItemFontWidth/SerifFontWidth via SetField (which re-marks the VM
+                // dirty), so refresh the UI BEFORE MarkClean() — otherwise the editor
+                // would show unsaved changes immediately after a successful Write.
                 UpdateUI();
                 UpdateFontPreview();
+                _vm.MarkClean();
             }
             catch (Exception ex)
             {

--- a/FEBuilderGBA.Avalonia/Views/TextCharCodeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/TextCharCodeView.axaml.cs
@@ -58,7 +58,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // text encoder so the encoding table change is picked up. Non-fatal if it
                 // fails (matches MainWindow/RomFixture init pattern).
                 try { CoreState.FETextEncoder = new FETextEncode(); }
-                catch (Exception ex) { Log.Error("TextCharCodeView: FETextEncode rebuild failed: {0}", ex.Message); }
+                catch (Exception ex) { Log.Error($"TextCharCodeView: FETextEncode rebuild failed: {ex}"); }
 
                 _undoService.Commit();
                 _vm.MarkClean();
@@ -71,7 +71,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("TextCharCodeView.OnWrite failed: {0}", ex.Message);
+                Log.Error($"TextCharCodeView.OnWrite failed: {ex}");
             }
         }
 

--- a/docs/avalonia-forms.md
+++ b/docs/avalonia-forms.md
@@ -348,7 +348,7 @@ Editors for game text, fonts, translation, and text utilities.
 | 205 | TextEscapeEditorView | TextEscapeEditorViewModel | Text escape code editor |
 | 206 | TextScriptCategorySelectView | TextScriptCategorySelectViewModel | Text script category picker |
 | 207 | TextDicView | TextDicViewModel | Text dictionary editor |
-| 208 | TextCharCodeView | TextCharCodeViewModel | Character code table viewer |
+| 208 | TextCharCodeView | TextCharCodeViewModel | Character code table editor (Write button persists Char Code/Terminator + rebuilds text encoder) |
 | 209 | TextBadCharPopupView | TextBadCharPopupViewModel | Invalid character warning popup |
 | 210 | TextRefAddDialogView | TextRefAddDialogViewModel | Text reference addition dialog |
 | 211 | TextToSpeechView | TextToSpeechViewModel | Text-to-speech preview tool |


### PR DESCRIPTION
## Summary
The Avalonia Text Character Code editor exposed editable **Char Code** (u16@0) and **Terminator** (u16@2) NumericUpDowns but had only a **Close** button, so `TextCharCodeViewModel.Write()` (which already writes both u16 values) was never invoked and edits silently never persisted — effectively read-only while WinForms persists.

This adds a **Write** button mirroring the sibling `AIMapSettingView` pattern:
- New `WriteButton` (AutomationId `TextCharCode_Write_Button`) next to Close in `TextCharCodeView.axaml`.
- `OnWrite` handler: pushes the box values into the VM, runs `_vm.Write()` under an ambient `UndoService` scope (undo-tracked), then rebuilds the Huffman text encoder (`CoreState.FETextEncoder = new FETextEncode()` — the Avalonia equivalent of WinForms `Program.ReBuildFETextEncoder()`, called via `TextCharCodeForm`'s `PostWriteHandler`). Refreshes the editor UI + glyph preview after the write. Early-returns when no entry is selected; rolls back + logs on exception.

## Plan Reference
Implements the accepted plan: https://github.com/laqieer/FEBuilderGBA/issues/1446#issuecomment-4802911940 (both Copilot plan-review findings addressed).

## Scope
Closes #1446

## Screenshots
Real headless-Skia render of the TextCharCodeView showing the editable spinners, the populated char-code list (FE8U), and the new **Write** button (bottom-right):

![TextCharCode editor with Write button](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr1446-textcharcode-fe8u.png)

(Hosted on master via #1532.)

## GUI Test Report

### Environment
- ROM: roms/FE8U.gba
- Editor/View: TextCharCodeView (Avalonia)

### Steps Performed
1. Rendered the real `TextCharCodeView` with a loaded char-code entry (first list row selected).
2. Verified the new `WriteButton` control exists and the editor is populated.
3. Set Char Code + Terminator box values, raised the Write button Click, re-read the ROM bytes.

### Test Results
| Test | Expected | Actual | Status |
|------|----------|--------|--------|
| Write button present | `WriteButton` control exists | Present (AutomationId `TextCharCode_Write_Button`) | PASS |
| VM Write round-trip | CharCode/Terminator u16 persist to ROM | Both u16 values persisted; restored | PASS |
| Button click persists | Clicking Write writes the box values to ROM | ROM u16@0/u16@2 updated to the box values | PASS |
| Existing stretch/automation tests | Still pass | 45 related tests pass, no regression | PASS |

### Verdict
PASS — the editor now persists Char Code/Terminator edits (undo-tracked) and rebuilds the text encoder, matching WinForms.

## Test plan
- [x] `TextCharCodeWriteTests.Write_RoundTripsCharCodeAndTerminator` (ROM-backed) — VM `Write()` round-trips both u16 values to the ROM; originals restored.
- [x] `TextCharCodeWriteTests.View_HasWriteButton` (headless) — `WriteButton` control exists.
- [x] `TextCharCodeWriteTests.WriteButton_Click_PersistsBoxValues` (ROM-backed headless) — clicking the button persists the edited box values to the ROM bytes; originals restored.
- [x] `TextCharCodeScreenshotTest` — renders the real view, asserts Write button + populated entry (functional proof; PNG capture best-effort).
- [x] `ControlPropertyTests` + `AutomationIdTests` (45 related tests) still pass — no regression.
- [x] Avalonia + Avalonia.Tests projects build clean (0 errors).

## Known limitations
- The headless screenshot test's PNG capture is a no-op under the shared `UseHeadlessDrawing` TestApp; the functional assertions are authoritative. The canonical PR PNG was rendered via a Skia-enabled headless pass.

Generated with Claude Code (Opus 4.8, 1M context)