### PR TITLE
fix(avalonia): TSA Animation Editor v2 expose full per-category 12-byte entry list (#1456)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/ImageTSAAnime2EntryListTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ImageTSAAnime2EntryListTests.cs
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1456: the TSA Animation Editor v2 must expose the FULL per-category 12-byte
+// entry list (the WinForms ImageTSAAnime2Form second-level list), not just the
+// first entry of each category. WinForms walks 12-byte strides from dataAddr+20,
+// counting entry i while isPointer(u32(addr+8)) is true (ROM.getBlockDataCount).
+//
+// These tests lock:
+//  - CountCategoryEntries matches the WinForms stop condition (pointer SHAPE at
+//    addr+8, EOF-hard-bound).
+//  - LoadList emits one AddrResult per entry, stride 12 == loader record size.
+//  - HeaderBase resolves the SHARED category header for entry[i>0] (so the
+//    coupled IMAGE/PALETTE pointers don't drift), keyed on CurrentAddr so a
+//    stale/raw-navigation address falls back to the entry[0] formula.
+using System;
+using System.Collections.Generic;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    [Collection("SharedState")]
+    public class ImageTSAAnime2EntryListTests
+    {
+        readonly ITestOutputHelper _output;
+        public ImageTSAAnime2EntryListTests(ITestOutputHelper output) { _output = output; }
+
+        const uint SIZE = 12;
+        const uint HEADER = ImageTSAAnime2ViewModel.HEADER_SIZE; // 20
+
+        // Build a synthetic ROM with one category header at baseGba (GBA addr),
+        // and K consecutive 12-byte entries each carrying a pointer-shaped value
+        // at +8, followed by a non-pointer terminator entry.
+        static ROM MakeRomWithCategory(uint headerBaseGba, int entryCount, out uint headerBaseOff)
+        {
+            var bytes = new byte[0x1000000];
+            var rom = new ROM();
+            rom.LoadLow("test.gba", bytes, "BE8E01"); // FE8U signature
+            headerBaseOff = U.toOffset(headerBaseGba);
+
+            // shared header: palette @ +4, image @ +16 (values not exercised here)
+            uint entry0Off = headerBaseOff + HEADER;
+            for (int i = 0; i < entryCount; i++)
+            {
+                uint e = entry0Off + (uint)i * SIZE;
+                // a pointer-shaped TSA value at +8 keeps the walk going
+                rom.write_u32(e + 8, 0x08C00000u + (uint)i * 0x100u);
+            }
+            // terminator entry: +8 is NOT pointer-shaped
+            uint term = entry0Off + (uint)entryCount * SIZE;
+            rom.write_u32(term + 8, 0x00000000u);
+            return rom;
+        }
+
+        [Fact]
+        public void CountCategoryEntries_StopsAtFirstNonPointer()
+        {
+            var rom = MakeRomWithCategory(0x08500000u, 14, out uint baseOff);
+            uint entry0 = baseOff + HEADER;
+            Assert.Equal(14u, ImageTSAAnime2ViewModel.CountCategoryEntries(rom, entry0));
+        }
+
+        [Fact]
+        public void CountCategoryEntries_ZeroWhenEntry0NotPointer()
+        {
+            var rom = MakeRomWithCategory(0x08500000u, 0, out uint baseOff);
+            uint entry0 = baseOff + HEADER;
+            Assert.Equal(0u, ImageTSAAnime2ViewModel.CountCategoryEntries(rom, entry0));
+        }
+
+        [Fact]
+        public void CountCategoryEntries_EofHardBound_DoesNotRunPastEnd()
+        {
+            // Place entry0 within 12 bytes of EOF: the walk must not read past it.
+            var bytes = new byte[0x1000000];
+            var rom = new ROM();
+            rom.LoadLow("test.gba", bytes, "BE8E01");
+            uint len = (uint)rom.Data.Length;
+            uint entry0 = len - 8; // entry0 + SIZE(12) > len -> immediate stop
+            Assert.Equal(0u, ImageTSAAnime2ViewModel.CountCategoryEntries(rom, entry0));
+        }
+
+        [Fact]
+        public void LoadList_SyntheticCategory_EmitsEveryEntry_AndHeaderBaseStaysShared()
+        {
+            // Drive the REAL LoadList path on a synthetic ROM + crafted config so
+            // the map population and per-entry HeaderBase resolution are proven
+            // deterministically (no real ROM required). Without the #1456 fix,
+            // LoadList emits one row per category and HeaderBase for entry[i>0]
+            // would be (addr-20), pointing INTO the entry list, not the header.
+            const int K = 6;                       // entries in the category
+            uint headerBaseGba = 0x08500000u;      // category data address (GBA)
+            // category pointer slot: pick a stable, in-range offset to hold the
+            // GBA pointer to the header base.
+            uint catPointerGba = 0x08010000u;
+
+            var rom = MakeRomWithCategory(headerBaseGba, K, out uint headerBaseOff);
+            // Seed the category pointer slot so p32(catPointerOff) == headerBaseGba.
+            uint catPointerOff = U.toOffset(catPointerGba);
+            rom.write_u32(catPointerOff, headerBaseGba);
+
+            var prevRom = CoreState.ROM;
+            var prevBase = CoreState.BaseDirectory;
+            var prevLang = CoreState.Language;
+            string tmp = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(), "tsaanime2_test_" + Guid.NewGuid().ToString("N"));
+            try
+            {
+                CoreState.ROM = rom;
+                CoreState.Language = "en";
+                CoreState.BaseDirectory = tmp;
+
+                // Write the config resource LoadList consumes. The filename must
+                // match U.ConfigDataFilename("tsaanime2_", rom): tsaanime2_<Title>.en.txt
+                string dataDir = System.IO.Path.Combine(tmp, "config", "data");
+                System.IO.Directory.CreateDirectory(dataDir);
+                string resPath = U.ConfigDataFilename("tsaanime2_", rom);
+                System.IO.File.WriteAllText(resPath,
+                    U.ToHexString(catPointerGba) + "\tSynthCategory\n");
+
+                var vm = new ImageTSAAnime2ViewModel();
+                var list = vm.LoadList();
+
+                // Every one of the K entries is enumerated (the bug emitted 1).
+                Assert.Equal(K, list.Count);
+
+                // Stride-12 geometry from entry0 = headerBase + 20.
+                uint entry0 = headerBaseOff + HEADER;
+                for (int i = 0; i < K; i++)
+                    Assert.Equal(entry0 + (uint)i * SIZE, list[i].addr);
+
+                // HeaderBase resolves the SHARED header for EVERY entry — including
+                // entry[i>0] where the addr-20 formula would be wrong.
+                foreach (var r in list)
+                {
+                    vm.LoadEntry(r.addr);
+                    Assert.Equal(headerBaseOff, vm.HeaderBase);
+                    Assert.Equal(headerBaseOff + 16u, vm.ImagePointerAddr);
+                    Assert.Equal(headerBaseOff + 4u, vm.PalettePointerAddr);
+                    Assert.Equal(r.addr + 8u, vm.TSAPointerAddr);
+                }
+
+                // Proof the addr-20 formula would have been wrong for entry[1..]:
+                uint entry1 = entry0 + SIZE;
+                Assert.NotEqual(headerBaseOff, entry1 - HEADER);
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                CoreState.BaseDirectory = prevBase;
+                CoreState.Language = prevLang;
+                try { System.IO.Directory.Delete(tmp, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void HeaderBase_FallsBackToFormula_ForRawNavigationAddress()
+        {
+            // No map seeded (raw NavigateTo) -> entry0-style formula.
+            uint dataAddr = 0x00500000u;
+            var vm = new ImageTSAAnime2ViewModel { CurrentAddr = dataAddr + HEADER };
+            Assert.Equal(dataAddr, vm.HeaderBase);
+        }
+
+        // ---- FE8U ground-truth (issue #1456 cites 14 entries, ptrs 81C1900..) ----
+
+        [Fact]
+        public void FE8U_LoadList_ExposesAllEntries_NotJustOnePerCategory()
+        {
+            if (TestRomLocator.FindRom("FE8U") == null)
+            {
+                _output.WriteLine("SKIP: FE8U.gba not found in roms/ or ROMS_DIR");
+                return;
+            }
+
+            RomTestHelper.WithRom("FE8U", () =>
+            {
+                var vm = new ImageTSAAnime2ViewModel();
+                var list = vm.LoadList();
+                Assert.NotEmpty(list);
+
+                // Count distinct category pointers (AddrResult.tag) and total rows.
+                var categories = new HashSet<uint>();
+                foreach (var r in list) categories.Add(r.tag);
+                _output.WriteLine($"FE8U: {list.Count} entries across {categories.Count} categories");
+
+                // The bug surfaced exactly one row per category. With the fix the
+                // total must exceed the category count (the active FE8U category
+                // alone has 14 entries per the issue).
+                Assert.True(list.Count > categories.Count,
+                    $"Expected more entries than categories (got {list.Count} entries, {categories.Count} categories)");
+
+                // Geometry: every row in a category is stride-12 from entry0, and
+                // HeaderBase resolves the SHARED category header for every entry.
+                // Group by category tag.
+                var byCat = new Dictionary<uint, List<AddrResult>>();
+                foreach (var r in list)
+                {
+                    if (!byCat.TryGetValue(r.tag, out var l)) { l = new List<AddrResult>(); byCat[r.tag] = l; }
+                    l.Add(r);
+                }
+
+                bool sawMultiEntryCategory = false;
+                foreach (var kv in byCat)
+                {
+                    var entries = kv.Value;
+                    if (entries.Count > 1) sawMultiEntryCategory = true;
+
+                    // entries must be contiguous 12-byte strides
+                    for (int i = 1; i < entries.Count; i++)
+                        Assert.Equal(entries[0].addr + (uint)i * SIZE, entries[i].addr);
+
+                    // category header base = entry0.addr - 20
+                    uint headerBase = entries[0].addr - HEADER;
+
+                    // LoadEntry every entry; HeaderBase must stay the shared base
+                    foreach (var e in entries)
+                    {
+                        vm.LoadEntry(e.addr);
+                        Assert.Equal(headerBase, vm.HeaderBase);
+                        // image/palette resolve off the SHARED header for every entry
+                        Assert.Equal(headerBase + 16u, vm.ImagePointerAddr);
+                        Assert.Equal(headerBase + 4u, vm.PalettePointerAddr);
+                        // TSA pointer varies per entry (entryAddr + 8)
+                        Assert.Equal(e.addr + 8u, vm.TSAPointerAddr);
+                    }
+                }
+
+                Assert.True(sawMultiEntryCategory,
+                    "Expected at least one FE8U category with >1 entry (the bug collapsed these)");
+            });
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
+++ b/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
@@ -4179,20 +4179,38 @@ namespace FEBuilderGBA.Avalonia.Services
             return result;
         }
 
-        /// <summary>Build ImageTSAAnime2 list — from config TSV resource tsaanime2_.</summary>
+        /// <summary>
+        /// Build ImageTSAAnime2 list — from config TSV resource tsaanime2_.
+        /// #1456: enumerate every per-category 12-byte entry (WinForms two-level
+        /// editor), not one row per category, so --data-verify-full covers all
+        /// reachable entries. Uses the same stop condition as the VM
+        /// (<see cref="FEBuilderGBA.Avalonia.ViewModels.ImageTSAAnime2ViewModel.CountCategoryEntries"/>).
+        /// </summary>
         static List<AddrResult> BuildImageTSAAnime2List(ROM rom)
         {
             var tsaAnime = U.LoadTSVResource1(U.ConfigDataFilename("tsaanime2_"), false);
             if (tsaAnime == null || tsaAnime.Count == 0) return new List<AddrResult>();
 
+            const uint SIZE = 12;
             var result = new List<AddrResult>();
             foreach (var pair in tsaAnime)
             {
                 uint pointer = pair.Key;
-                string label = U.ToHexString(pointer) + " " + pair.Value;
+                string catName = pair.Value;
                 uint offset = U.toOffset(pointer);
                 if (!U.isSafetyOffset(offset, rom)) continue;
-                result.Add(new AddrResult(offset, label, pointer));
+                uint dataAddr = rom.p32(offset);
+                if (!U.isSafetyOffset(dataAddr, rom)) continue;
+
+                uint entry0Addr = dataAddr + 20;
+                uint count = FEBuilderGBA.Avalonia.ViewModels.ImageTSAAnime2ViewModel
+                    .CountCategoryEntries(rom, entry0Addr);
+                for (uint i = 0; i < count; i++)
+                {
+                    uint entryAddr = entry0Addr + i * SIZE;
+                    string label = U.ToHexString(pointer) + " " + catName + " " + U.To0xHexString(i);
+                    result.Add(new AddrResult(entryAddr, label, pointer));
+                }
             }
             return result;
         }

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageTSAAnime2ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageTSAAnime2ViewModel.cs
@@ -27,10 +27,14 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
         public bool CanWrite { get => _canWrite; set => SetField(ref _canWrite, value); }
 
-        // The list only exposes the FIRST v2 entry record, which lives 20 bytes
-        // after the shared header (see LoadList: tsaDataAddr = dataAddr + 20).
-        // So the header base = CurrentAddr - HEADER_SIZE, and the coupled
-        // image/palette pointers live at fixed header offsets:
+        // #1456: the list exposes EVERY 12-byte entry in a category, each living
+        // at headerBase + 20 + i*12 (see LoadList). All entries in a category
+        // share ONE header, so the IMAGE/PALETTE pointers are common while the
+        // TSA pointer varies per entry. The header base therefore comes from the
+        // per-entry map (HeaderBase, keyed on CurrentAddr), NOT an unconditional
+        // CurrentAddr - HEADER_SIZE (that formula is only valid for entry[0] and
+        // remains the fallback for raw-navigation addresses). The coupled
+        // pointers, relative to the resolved header base:
         //   palette pointer  @ headerBase + 4   (raw 0x20)
         //   image   pointer  @ headerBase + 16  (LZ77)
         //   per-entry TSA ptr @ CurrentAddr + 8 (raw header-wrapped TSA)

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageTSAAnime2ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageTSAAnime2ViewModel.cs
@@ -14,6 +14,15 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         uint _unknown0, _unknown2, _unknown4, _unknown6;
         uint _tsaHeaderPointer;
 
+        // #1456: each per-category 12-byte entry maps to its category's SHARED
+        // header base (dataAddr). IMAGE/PALETTE live at headerBase+16/+4 (shared
+        // by every entry in the category); only the TSA pointer (entryAddr+8)
+        // varies per entry. Keyed on the entry address so HeaderBase resolves
+        // correctly for entry[i>0] without relying on stale "last loaded" state.
+        // Rebuilt on every LoadList; lookup falls back to the entry[0] formula
+        // for raw-navigation addresses not produced by LoadList.
+        readonly Dictionary<uint, uint> _entryHeaderBase = new Dictionary<uint, uint>();
+
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
         public bool CanWrite { get => _canWrite; set => SetField(ref _canWrite, value); }
@@ -28,8 +37,29 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         // This mirrors WinForms ImageTSAAnime2Form.MakeAllDataLength.
         public const uint HEADER_SIZE = 20;
 
-        /// <summary>Shared-header base address for the selected v2 entry.</summary>
-        public uint HeaderBase => (CurrentAddr >= HEADER_SIZE) ? CurrentAddr - HEADER_SIZE : 0;
+        /// <summary>
+        /// Shared-header base address for the selected v2 entry.
+        /// <para>
+        /// #1456: a category exposes N 12-byte entries (entry[i] at
+        /// <c>headerBase + 20 + i*12</c>), all sharing one header. The IMAGE/
+        /// PALETTE pointers live in that header, so the base must come from the
+        /// per-entry map (keyed on <see cref="CurrentAddr"/>) — NOT the
+        /// <c>CurrentAddr - HEADER_SIZE</c> formula, which is only valid for
+        /// entry[0]. The formula remains the fallback for raw-navigation
+        /// addresses (e.g. <c>NavigateTo</c>) that LoadList never enumerated;
+        /// keying on <see cref="CurrentAddr"/> means a stale map entry can never
+        /// resolve the header for a different active entry.
+        /// </para>
+        /// </summary>
+        public uint HeaderBase
+        {
+            get
+            {
+                if (_entryHeaderBase.TryGetValue(CurrentAddr, out uint hb))
+                    return hb;
+                return (CurrentAddr >= HEADER_SIZE) ? CurrentAddr - HEADER_SIZE : 0;
+            }
+        }
         /// <summary>ROM offset of the header IMAGE (LZ77) pointer slot.</summary>
         public uint ImagePointerAddr => HeaderBase + 16;
         /// <summary>ROM offset of the header PALETTE (raw 0x20) pointer slot.</summary>
@@ -48,8 +78,38 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         // D8: TSA header pointer
         public uint TSAHeaderPointer { get => _tsaHeaderPointer; set => SetField(ref _tsaHeaderPointer, value); }
 
+        /// <summary>
+        /// Count the 12-byte entries inside a v2 category header. Mirrors the
+        /// WinForms <c>ImageTSAAnime2Form</c> main <c>InputFormRef</c>
+        /// (BlockSize 12, count-callback <c>isPointer(u32(addr+8))</c>) walked by
+        /// <c>ROM.getBlockDataCount</c>: starting at <paramref name="entry0Addr"/>
+        /// (= dataAddr + 20), count entry <c>i</c> while the per-entry TSA pointer
+        /// slot (<c>addr + 8</c>) is pointer-shaped, stopping at the first entry
+        /// that is not (or that would read past EOF). #1456.
+        /// </summary>
+        internal static uint CountCategoryEntries(ROM rom, uint entry0Addr)
+        {
+            if (rom?.Data == null) return 0;
+            uint len = (uint)rom.Data.Length;
+            uint addr = entry0Addr;
+            uint i = 0;
+            // EOF-hard-bound: need the full 12-byte entry (the +8 pointer slot is
+            // the last 4 bytes) before reading it.
+            while (addr + SIZE <= len)
+            {
+                // List-time check is pointer SHAPE only (matches WinForms, which
+                // does NOT require the TSA target to be a safety offset here).
+                if (!U.isPointer(rom.u32(addr + 8))) break;
+                addr += SIZE;
+                i++;
+            }
+            return i;
+        }
+
         public List<AddrResult> LoadList()
         {
+            _entryHeaderBase.Clear();
+
             ROM rom = CoreState.ROM;
             if (rom?.RomInfo == null) return new List<AddrResult>();
 
@@ -62,20 +122,31 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             foreach (var pair in tsaAnime)
             {
                 uint pointer = pair.Key;
-                string name = U.ToHexString(pointer) + " " + pair.Value;
+                string catName = pair.Value;
 
-                // Resolve the pointer to get the actual data address
+                // Resolve the pointer to get the actual data address (category header base)
                 uint offset = U.toOffset(pointer);
                 if (!U.isSafetyOffset(offset, rom)) continue;
 
                 uint dataAddr = rom.p32(offset);
                 if (!U.isSafetyOffset(dataAddr, rom)) continue;
 
-                // The TSA data starts 20 bytes after the header
-                uint tsaDataAddr = dataAddr + 20;
-                if (tsaDataAddr + SIZE > (uint)rom.Data.Length) continue;
-
-                result.Add(new AddrResult(tsaDataAddr, name, pointer));
+                // #1456: enumerate EVERY 12-byte entry in this category, not just
+                // entry[0]. The per-entry list starts 20 bytes after the header
+                // (WinForms ReInit(addr + 20)); stride 12 == the loader record size
+                // read by LoadEntry (addr+0..+8), so list geometry == data geometry.
+                uint entry0Addr = dataAddr + 20;
+                uint count = CountCategoryEntries(rom, entry0Addr);
+                for (uint i = 0; i < count; i++)
+                {
+                    uint entryAddr = entry0Addr + i * SIZE;
+                    // Map every entry to its SHARED category header base so
+                    // HeaderBase (and thus IMAGE/PALETTE) resolves correctly for
+                    // entry[i>0].
+                    _entryHeaderBase[entryAddr] = dataAddr;
+                    string name = U.ToHexString(pointer) + " " + catName + " " + U.To0xHexString(i);
+                    result.Add(new AddrResult(entryAddr, name, pointer));
+                }
             }
             return result;
         }

--- a/FEBuilderGBA.Avalonia/Views/ImageTSAAnime2View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageTSAAnime2View.axaml
@@ -37,7 +37,7 @@
           <Button AutomationProperties.AutomationId="ImageTSAAnime2_ImportPng_Button" Grid.Row="4" Grid.Column="1" Content="Import PNG" Click="ImportPng_Click" Margin="0,8,0,0" />
         </Grid>
 
-        <TextBlock Text="Preview (image + palette + entry-0 TSA)" Margin="0,8,0,0" />
+        <TextBlock Text="Preview (shared image + palette + selected entry TSA)" Margin="0,8,0,0" />
         <controls:GbaImageControl AutomationProperties.AutomationId="ImageTSAAnime2_Image_Image" Name="ImageDisplay" Margin="0,4,0,0" />
       </StackPanel>
     </ScrollViewer>

--- a/FEBuilderGBA.Avalonia/Views/ImageTSAAnime2View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageTSAAnime2View.axaml.cs
@@ -135,10 +135,14 @@ namespace FEBuilderGBA.Avalonia.Views
 
                 uint addr = _vm.CurrentAddr;
                 uint headerBase = _vm.HeaderBase;
-                // Range-check the header + first entry (image/palette slots live in
-                // the header; the TSA slot lives in the first 12-byte entry).
+                // Range-check the SHARED header + the selected entry. The image/
+                // palette slots live in the category header (shared across all
+                // entries); the TSA slot lives in the selected 12-byte entry
+                // (addr+8), which #1456 keeps correct for entry[i>0] because
+                // HeaderBase resolves the category base, not addr - HEADER_SIZE.
                 if (!U.isSafetyOffset(headerBase, rom) ||
-                    headerBase + ImageTSAAnime2ViewModel.HEADER_SIZE + 12 > (uint)rom.Data.Length)
+                    headerBase + ImageTSAAnime2ViewModel.HEADER_SIZE > (uint)rom.Data.Length ||
+                    addr + 12 > (uint)rom.Data.Length)
                 {
                     CoreState.Services.ShowError("Entry address is out of range.");
                     return;
@@ -152,9 +156,9 @@ namespace FEBuilderGBA.Avalonia.Views
                 try
                 {
                     // Coupled trio (mirrors WinForms ImageTSAAnime2Form layout):
-                    //   image  (LZ77)            @ headerBase + 16
-                    //   palette(raw 0x20)        @ headerBase + 4
-                    //   TSA    (raw header-wrap)  @ addr + 8 (entry-0 TSA slot)
+                    //   image  (LZ77)            @ headerBase + 16 (shared)
+                    //   palette(raw 0x20)        @ headerBase + 4  (shared)
+                    //   TSA    (raw header-wrap)  @ addr + 8 (selected entry TSA slot)
                     var importResult = ImageImportCore.Import3PointerHeaderTSA(
                         rom, indexed, loadResult.GBAPalette,
                         IMPORT_WIDTH, IMPORT_HEIGHT,

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -4261,8 +4261,8 @@ TSVファイルからユニットをインポート
 :Preview (Frame 0):
 プレビュー (フレーム0):
 
-:Preview (image + palette + entry-0 TSA)
-プレビュー (画像 + パレット + エントリ0のTSA)
+:Preview (shared image + palette + selected entry TSA)
+プレビュー (共有の画像 + パレット + 選択エントリのTSA)
 
 :Click to open Item Editor
 クリックでアイテムエディタを開く

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -20279,8 +20279,8 @@ JASC-PAL (Aseprite/GIMP)
 :Preview (Frame 0):
 预览 (第0帧):
 
-:Preview (image + palette + entry-0 TSA)
-预览 (图像 + 调色板 + 条目0的TSA)
+:Preview (shared image + palette + selected entry TSA)
+预览 (共享图像 + 调色板 + 所选条目的TSA)
 
 :Click to open Item Editor
 点击打开物品编辑器

--- a/docs/avalonia-forms.md
+++ b/docs/avalonia-forms.md
@@ -280,7 +280,7 @@ Editors for portraits, sprites, battle animations, tilesets, and other graphics.
 | 158 | ImageRomAnimeView | ImageRomAnimeViewModel | ROM-stored animation editor |
 | 159 | ImageTSAEditorView | ImageTSAEditorViewModel | Tile Screen Arrangement editor (palette write + raw-tilesheet import/export + per-cell TSA editing & TSA write-back for NON-header TSA, #1005; header-TSA per-cell editing deferred) |
 | 160 | ImageTSAAnimeView | ImageTSAAnimeViewModel | TSA animation editor |
-| 161 | ImageTSAAnime2View | ImageTSAAnime2ViewModel | TSA animation editor (type 2) |
+| 161 | ImageTSAAnime2View | ImageTSAAnime2ViewModel | TSA animation editor (type 2); two-level: per-category list enumerates EVERY 12-byte entry (walk dataAddr+20 stride 12 until u32(addr+8) is not pointer-shaped), HeaderBase keyed per entry so the shared IMAGE/PALETTE resolve for entry[i>0] (#1456) |
 | 162 | ImagePalletView | ImagePalletViewModel | Palette viewer/editor |
 | 163 | ImageMagicFEditorView | ImageMagicFEditorViewModel | Magic effect frame editor |
 | 164 | ImageMagicCSACreatorView | ImageMagicCSACreatorViewModel | Magic CSA (compressed sprite) creator — live 240×128 frame preview (`MagicEffectExportCore.RenderCsaFramePreview`, READ-ONLY; BG→OBJ-back→OBJ-front composite, honors `IsExpandsBG`) on entry-select / Frame spinner / Zoom; working "Find new resources online" → MoreData wiki link (#1021) |


### PR DESCRIPTION
## Summary
Fixes #1456. The Avalonia **TSA Animation Editor v2** (`ImageTSAAnime2`) collapsed the WinForms two-level structure (category selector + per-category 12-byte entry list) to a single row per category, surfacing only **entry[0]**. On FE8U the active category (`012DC0` → `0x08592628`) has **14** distinct 12-byte entries (TSA ptrs `0x81C1900..0x81C1CDC`); 13 were unreachable for view/edit/PNG-import (class D, MED).

This wires the second-level list, matching WinForms `ImageTSAAnime2Form` (category combo + `InputFormRef.ReInit(addr+20)` walking 12-byte strides while `isPointer(u32(addr+8))`).

## Plan reference
Plan + Copilot CLI plan review on issue #1456 (no blocking concerns). Implemented the two hardening points the reviewer asked for: `HeaderBase` keyed on `CurrentAddr` (no stale state), and the walk is EOF-hard-bound + pointer-shape-only at list time.

## What changed
- **`ImageTSAAnime2ViewModel.LoadList`** — walks every 12-byte entry from `dataAddr+20` (stride 12) with the WinForms stop condition `isPointer(u32(addr+8))`, EOF-hard-bound, emitting one `AddrResult` per entry. Extracted as `CountCategoryEntries` (single source of truth).
- **`HeaderBase`** — now keyed on `CurrentAddr` via a per-entry map (`entryAddr → category dataAddr`) so the **shared** IMAGE (`headerBase+16`) / PALETTE (`headerBase+4`) pointers resolve correctly for entry[i>0]; the `CurrentAddr-20` formula was only valid for entry[0] (#1377-class geometry trap). Falls back to the formula for raw-navigation addresses.
- **`ListParityHelper.BuildImageTSAAnime2List`** — same per-entry walk so `--data-verify-full` covers all entries. **List stride (12) == loader record size** read by `LoadEntry`.
- View AXAML label + import/preview comments updated (shared image/palette + selected entry TSA). Write stays undo-tracked (`UndoService` unchanged).

## Scope
Closes #1456.

## Test plan
- [x] `CountCategoryEntries` stops at first non-pointer entry (synthetic ROM, 14 entries).
- [x] `CountCategoryEntries` returns 0 when entry[0] not pointer-shaped.
- [x] `CountCategoryEntries` EOF-hard-bound near end-of-ROM (no over-read).
- [x] `LoadList` on a synthetic category (crafted config + synthetic ROM) emits **every** entry, stride-12 geometry, and `HeaderBase` stays the shared base for entry[i>0] (proves `addr-20` would have been wrong).
- [x] `HeaderBase` formula fallback for raw-navigation address.
- [x] FE8U ground-truth: `LoadList` exposes more entries than categories; every entry's `HeaderBase`/IMAGE/PALETTE resolve to the shared header; per-entry TSA at `addr+8`.
- [x] Existing #1421 entry[0] pointer-derivation tests remain green (12/12 in the TSAAnime2 set).
- [x] All three test projects run locally (Core.Tests, Avalonia.Tests, FEBuilderGBA.Tests net9.0-windows) — see GUI Test Report.

## Screenshots
Real FEBuilderGBA.Avalonia **TSA Animation Editor v2** against FE8U — the left list now enumerates every per-category 12-byte entry (was one row per category). Selected entry shows `Address 0x0059263C`, `TSA w/ Header 0x081C1900` (the first TSA pointer cited in #1456).

![TSA Animation Editor v2 — full per-category entry list](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr1456-tsaanime2-fe8u.png)

## GUI Test Report
| Test | Result |
| --- | --- |
| Launch FEBuilderGBA.Avalonia with FE8U, open TSA Anime 2 | PASS — window "TSA Animation Editor v2" opens |
| Per-category entry list populated (multiple `012DC0` rows, was 1) | PASS — list shows the full category's entries |
| Select entry → preview renders, TSA `0x081C1900` shown | PASS |
| `dotnet test FEBuilderGBA.Avalonia.Tests --filter ImageTSAAnime2` | PASS (12/12) |

🤖 Generated with Claude Code (Opus 4.8, 1M context)
