### PR TITLE
fix(e2e): make AvaloniaAllEditorsSmokeTests count-agnostic (Fixes #1545, #1549, #1552, #1557, #1558)

### DIFF
--- a/FEBuilderGBA.E2ETests/Tests/AvaloniaAllEditorsSmokeTests.cs
+++ b/FEBuilderGBA.E2ETests/Tests/AvaloniaAllEditorsSmokeTests.cs
@@ -1,21 +1,34 @@
+using System.Text.RegularExpressions;
 using FEBuilderGBA.E2ETests.Helpers;
 using Xunit;
 
 namespace FEBuilderGBA.E2ETests.Tests
 {
     /// <summary>
-    /// E2E tests that verify ALL 325 Avalonia GUI editor forms can be opened
-    /// without crashing. Uses --smoke-test-all flag to iterate through every
-    /// editor accessible from MainWindow.
+    /// E2E tests that verify EVERY Avalonia GUI editor form (the full list returned by
+    /// <c>MainWindow.GetAllEditorFactories()</c>) can be opened without crashing. Uses the
+    /// <c>--smoke-test-all</c> flag to iterate through every editor accessible from MainWindow.
+    ///
+    /// These assertions are deliberately count-agnostic: they validate the smoke runner's own
+    /// self-reported numbers for internal consistency instead of pinning a hardcoded editor
+    /// count. Adding or removing an editor must NOT require touching a magic literal here
+    /// (a stale literal previously broke nightly E2E across all five ROM versions).
     /// </summary>
     public class AvaloniaAllEditorsSmokeTests
     {
-        private const int ExpectedEditorCount = 325;
         private static readonly string? ExePath = AvaloniaAppRunner.FindExePath();
 
+        // "SMOKE: Testing {editors.Count} editors..."
+        private static readonly Regex TestingLine =
+            new(@"SMOKE: Testing (\d+) editors", RegexOptions.Compiled);
+
+        // "SMOKE: Results: {passed} passed, {failed} failed out of {editors.Count}"
+        private static readonly Regex ResultsLine =
+            new(@"SMOKE: Results: (\d+) passed, (\d+) failed out of (\d+)", RegexOptions.Compiled);
+
         /// <summary>
-        /// Opens every editor from MainWindow with --smoke-test-all flag.
-        /// Verifies all 325 editors can be instantiated and shown without crashing.
+        /// Opens every editor returned by <c>GetAllEditorFactories()</c> via the
+        /// <c>--smoke-test-all</c> flag and verifies none crash on instantiation/show.
         /// </summary>
         [SkippableTheory]
         [MemberData(nameof(RomLocator.AllRoms), MemberType = typeof(RomLocator))]
@@ -37,7 +50,10 @@ namespace FEBuilderGBA.E2ETests.Tests
         }
 
         /// <summary>
-        /// Validates the smoke test output reports the expected number of editors.
+        /// Validates the smoke test output is internally consistent: it reports a positive
+        /// editor count, opens every editor it enumerated, and records zero failures. No fixed
+        /// editor count is asserted, so this test stays green when editors are intentionally
+        /// added or removed.
         /// </summary>
         [SkippableTheory]
         [MemberData(nameof(RomLocator.AllRoms), MemberType = typeof(RomLocator))]
@@ -49,13 +65,36 @@ namespace FEBuilderGBA.E2ETests.Tests
             var (exitCode, stdout, stderr) = AvaloniaAppRunner.Run(
                 ExePath!, $"--rom \"{romPath}\" --smoke-test-all", timeoutMs: 300_000);
 
-            // Should report testing ExpectedEditorCount editors
-            Assert.Contains($"SMOKE: Testing {ExpectedEditorCount} editors", stdout);
+            string diag = $"{romName}: exitCode={exitCode}\nStdout: {stdout}\nStderr: {stderr}";
 
-            // Should report results line
-            Assert.Contains("passed", stdout);
+            // Process-level success must hold (no crash, no nonzero failure exit).
+            Assert.True(exitCode == 0, $"All-editors smoke test exited nonzero.\n{diag}");
 
-            // Verify 0 failures
+            // Parse the "SMOKE: Testing N editors" line.
+            Match testing = TestingLine.Match(stdout);
+            Assert.True(testing.Success, $"Could not find 'SMOKE: Testing N editors' line.\n{diag}");
+            int testedCount = int.Parse(testing.Groups[1].Value);
+
+            // Parse the "SMOKE: Results: P passed, F failed out of T" line.
+            Match results = ResultsLine.Match(stdout);
+            Assert.True(results.Success, $"Could not find 'SMOKE: Results:' line.\n{diag}");
+            int passed = int.Parse(results.Groups[1].Value);
+            int failed = int.Parse(results.Groups[2].Value);
+            int total = int.Parse(results.Groups[3].Value);
+
+            // Internal consistency — no magic literal:
+            //   * at least one editor was exercised (liveness),
+            //   * the "Testing N" count matches the "out of T" total,
+            //   * every enumerated editor passed,
+            //   * nothing failed.
+            Assert.True(testedCount > 0, $"Expected at least one editor to be tested.\n{diag}");
+            Assert.True(testedCount == total,
+                $"'Testing {testedCount}' != 'out of {total}' — runner count mismatch.\n{diag}");
+            Assert.True(passed == testedCount,
+                $"Only {passed}/{testedCount} editors passed.\n{diag}");
+            Assert.True(failed == 0, $"{failed} editor(s) failed.\n{diag}");
+
+            // No per-editor failure list should be emitted.
             Assert.DoesNotContain("SMOKE: Failures:", stdout);
         }
     }


### PR DESCRIPTION
## Summary

The nightly E2E smoke test `FEBuilderGBA.E2ETests/Tests/AvaloniaAllEditorsSmokeTests.cs` pinned a stale literal `ExpectedEditorCount = 325`. Two intentional editor removals merged on 2026-06-25 — PR #1535 removed `SongTrackImportWaveView` and PR #1546 removed `SkillSystemsEffectivenessReworkClassTypeView` — dropped the real `GetAllEditorFactories()` count to **323**. The smoke runner prints `SMOKE: Testing 323 editors...`, so `Avalonia_AllEditors_ReportsCorrectCount` failed its `Assert.Contains("SMOKE: Testing 325 editors")` on **all five** ROM versions (the failure is version-independent). The product change is correct; only the test literal was stale.

This filed five identical nightly-E2E issues: #1545 (FE6), #1549 (FE7J), #1552 (FE7U), #1557 (FE8J), #1558 (FE8U). One test-only fix resolves all five.

## Fix (test-only — anti-recurrence)

- **Removed the `ExpectedEditorCount` magic literal entirely.**
- Parse `N` from `SMOKE: Testing N editors` and `passed`/`failed`/`total` from `SMOKE: Results: P passed, F failed out of T`, then assert internal consistency:
  - `exitCode == 0`
  - `N > 0` (liveness)
  - `N == total` ("Testing N" matches "out of T")
  - `passed == N` (every enumerated editor opened)
  - `failed == 0` and no `SMOKE: Failures:` line
- Updated the stale doc comments (dropped the hardcoded "325") to describe "every editor returned by `GetAllEditorFactories()`".

Adding or removing an editor in the future no longer requires bumping a magic literal in this test, so this brittle-literal regression cannot recur. Incorporates both Copilot CLI plan-review notes (remove the dead documentation constant; keep an explicit `exitCode == 0` assertion).

Plan + plan review: issue #1545 comments.

## Test plan

- [x] `dotnet build FEBuilderGBA.Avalonia` (Release) — 0 errors
- [x] `dotnet build FEBuilderGBA.E2ETests` (Release) — 0 errors
- [x] `dotnet test FEBuilderGBA.E2ETests --configuration Release` filtered to `AvaloniaAllEditorsSmokeTests` against all 5 local ROMs — **10/10 PASS** (`Avalonia_AllEditors_ReportsCorrectCount` + `Avalonia_AllEditors_OpenWithoutCrash` × FE6/FE7J/FE7U/FE8J/FE8U)
- [x] `dotnet test FEBuilderGBA.Core.Tests` (Release) — pass (pre-existing ~10 Skill* env failures ignored)
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests` (Release) — pass (pre-existing ~10 SkiaSharp env failures ignored)
- [x] Verified `GetAllEditorFactories()` returns 323 entries on current `origin/master`

## Proof (test-only fix — passing E2E run is acceptable evidence)

```
  Passed FEBuilderGBA.E2ETests.Tests.AvaloniaAllEditorsSmokeTests.Avalonia_AllEditors_ReportsCorrectCount(romName: "FE6"  ...) [52 s]
  Passed FEBuilderGBA.E2ETests.Tests.AvaloniaAllEditorsSmokeTests.Avalonia_AllEditors_ReportsCorrectCount(romName: "FE7J" ...) [1 m 7 s]
  Passed FEBuilderGBA.E2ETests.Tests.AvaloniaAllEditorsSmokeTests.Avalonia_AllEditors_ReportsCorrectCount(romName: "FE7U" ...) [1 m 6 s]
  Passed FEBuilderGBA.E2ETests.Tests.AvaloniaAllEditorsSmokeTests.Avalonia_AllEditors_ReportsCorrectCount(romName: "FE8J" ...) [1 m 23 s]
  Passed FEBuilderGBA.E2ETests.Tests.AvaloniaAllEditorsSmokeTests.Avalonia_AllEditors_ReportsCorrectCount(romName: "FE8U" ...) [1 m 39 s]
  Passed FEBuilderGBA.E2ETests.Tests.AvaloniaAllEditorsSmokeTests.Avalonia_AllEditors_OpenWithoutCrash(...) x5

Test Run Successful.
Total tests: 10
     Passed: 10
```

Fixes #1545, #1549, #1552, #1557, #1558

🤖 Generated with Claude Code (Opus 4.8, 1M context)
