### PR TITLE
chore(git): ignore config.xml + drop stray tag (Closes #1649)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ coverage-report/
 # Temp files
 lint_stdout.txt
 lint_stderr.txt
+/tmp/
 
 # Stale release folder
 r/
@@ -65,6 +66,9 @@ ss-stdout.txt
 docs/screenshots/*_test_output.txt
 cli-logs/
 config/log/
+# config/config.xml is a runtime user-preferences file (machine-specific);
+# keep it out of the index so local prefs can't be accidentally committed.
+config/config.xml
 
 # Prevent screenshots in project root (use pr-screenshots/ instead)
 /*.png


### PR DESCRIPTION
## Summary
Two small repo-hygiene items for release cleanliness (`chore`, no build). Plan: https://github.com/laqieer/FEBuilderGBA/issues/1649#issuecomment-4818172512

Closes #1649. Part of #1628 (release-readiness umbrella).

### (a) `.gitignore` — the PR diff
- Ignore `config/config.xml` — a runtime user-preferences file. It was untracked but **not** git-ignored (unlike the sibling `config/log/`), so machine-specific prefs could be accidentally `git add`-ed. Placed next to `config/log/`.
- Ignore the top-level `/tmp/` scratch dir.
- **Not** ignoring `config/etc/` (per-ROM data, not clearly user-local scratch — staying conservative; it is not currently tracked, so nothing changes for it).

### (b) Stray tag deletion — direct git action (NOT in the diff)
The stray lightweight tag `bugsweep-screenshots` (pointed at docs commit `f7a54fe1`) was the nearest tag to HEAD, so `git describe --tags` resolved to `bugsweep-screenshots-676-g…` instead of a `ver_*` description. Deleted on origin and locally:
```
$ git push origin :refs/tags/bugsweep-screenshots
 - [deleted]             bugsweep-screenshots
```

## Evidence
**Part (a) — `config/config.xml` and `/tmp/` now ignored, `git status` clean of them:**
```
$ git check-ignore -v config/config.xml
.gitignore:71:config/config.xml	config/config.xml
$ git check-ignore -v tmp/scratch.txt
.gitignore:44:/tmp/	tmp/scratch.txt
$ git status --short        # with a dummy config/config.xml + tmp/ present
 M .gitignore               # <- config.xml / tmp/ no longer untracked-and-addable
```

**Part (b) — stray tag gone on origin; `git describe` resolves to a `ver_*` tag:**
```
$ git ls-remote --tags origin | grep -i bugsweep
                            # (empty)
$ git describe --tags HEAD
ver_20260204.22-2827-g4bfad931d   # was: bugsweep-screenshots-676-g4bfad931d
```

## Test plan
- [x] `git check-ignore -v config/config.xml` resolves to the new `.gitignore` rule
- [x] `git check-ignore -v tmp/scratch.txt` resolves to the new `/tmp/` rule
- [x] `git status` does not list `config/config.xml` or `tmp/` as untracked-and-addable (dummy files created then verified hidden, then removed)
- [x] `git ls-remote --tags origin | grep -i bugsweep` returns empty (tag deleted on origin)
- [x] `git describe --tags HEAD` resolves to `ver_20260204.22-…` (latest `ver_*`), not the stray tag
- [x] No tracked or shared files were added to `.gitignore` (`config/config.xml`, `config/etc/`, `tmp/` all verified untracked via `git ls-files`)

No build needed (chore, `.gitignore`-only diff; no code changed). Screenshots optional for `chore` PRs.

🤖 Generated with Claude Code (Opus 4.8, 1M context)
