### PR TITLE
ci(android): conditional release signing for APK/AAB (Closes #1631)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -120,7 +120,9 @@ jobs:
           set_count=0
           missing=""
           for name in ANDROID_KEYSTORE_BASE64 ANDROID_KEY_ALIAS ANDROID_KEYSTORE_PASSWORD ANDROID_KEY_PASSWORD; do
-            eval "val=\${$name}"
+            # Safe bash indirect expansion (NOT eval — never re-evaluates a secret
+            # value, so shell metacharacters in a secret can't be executed).
+            val="${!name}"
             if [ -n "$val" ]; then
               set_count=$((set_count + 1))
             else
@@ -185,8 +187,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: febuildergba-android-apk
-          # Both paths land a *-Signed.apk at the well-known net9.0-android
-          # output path; the release-signing path additionally emits an .aab.
+          # Cover BOTH output layouts:
+          #   * debug fallback (`dotnet build`) writes the *-Signed.apk to
+          #     bin/Release/net9.0-android/.
+          #   * release signing (`dotnet publish`) writes the signed *-Signed.apk
+          #     AND the .aab to bin/Release/net9.0-android/publish/.
+          # Globbing both directories means the upload captures the right
+          # artifact for whichever path ran (and never an empty set).
           # if-no-files-found: error so a run that produced NO apk (a path /
           # packaging regression) fails VISIBLY rather than passing green with
           # an empty artifact — meaningful precisely because the job is NOT
@@ -196,4 +203,6 @@ jobs:
           path: |
             FEBuilderGBA.Android/bin/Release/net9.0-android/*-Signed.apk
             FEBuilderGBA.Android/bin/Release/net9.0-android/*.aab
+            FEBuilderGBA.Android/bin/Release/net9.0-android/publish/*-Signed.apk
+            FEBuilderGBA.Android/bin/Release/net9.0-android/publish/*.aab
           if-no-files-found: error

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -23,8 +23,22 @@
 # being a separate, non-required workflow, so we let genuine failures surface as
 # a (still non-blocking) RED check rather than a misleading green one.
 #
-# Release signing-key handling is deferred: the artifact is the debug-keystore
-# *-Signed.apk the build already produces (docs/ANDROID.md §7).
+# Release signing is CONDITIONAL on a maintainer-provided keystore secret
+# (ANDROID_KEYSTORE_BASE64). When that secret is present the job decodes the
+# keystore and publishes a release-signed APK + AAB (-p:AndroidKeyStore=true +
+# the AndroidSigning* props). When it is ABSENT — the state on this fork's CI,
+# which has no secret — the job falls back to the original debug-keystore
+# *-Signed.apk build, so the existing (non-required) CI keeps passing unchanged.
+# The four secrets (ANDROID_KEYSTORE_BASE64 / ANDROID_KEY_ALIAS /
+# ANDROID_KEYSTORE_PASSWORD / ANDROID_KEY_PASSWORD) are documented in
+# docs/ANDROID.md §7. Attaching the signed artifact to a GitHub release is the
+# separate tag-triggered release workflow (#1629); this workflow only produces
+# the signed build. Closes #1631 (the #1126 signing-key deferral).
+#
+# NOTE: `secrets.*` cannot be referenced in a step-level `if:` (GitHub Actions
+# forbids it), so presence is computed once into a step output (haskeystore)
+# and the signing / fallback steps gate on that output. Passwords are passed via
+# `env:` (never interpolated into a logged command line).
 #
 # The on-device / emulator SkiaSharp byte-parity run (#1125) — running
 # SkiaRenderByteParityTests on the Android native across the 4 ABIs — is NOT
@@ -87,25 +101,99 @@ jobs:
         # Android SDK + a JDK that the workload build consumes.
         run: dotnet workload install android
 
-      - name: Build Android APK
-        # -p:EnableAndroidTarget=true is REQUIRED as a GLOBAL property (#1121):
-        # a bare build fails restore with NETSDK1005 because NuGet restore's
-        # static graph ignores the per-reference AdditionalProperties that
-        # activates the net9.0-android TFM on the shared FEBuilderGBA.Avalonia
-        # project. See docs/ANDROID.md §7.
+      - name: Detect release keystore secret
+        # `secrets.*` is NOT allowed in a step-level `if:`, so classify presence
+        # once here into a step output the later steps can gate on. Only the
+        # boolean is emitted — secret values are never printed. The detector
+        # reads from `env:` (NOT `${{ secrets.* }}` inline) to stay aligned with
+        # GitHub's limitation. All four secrets must be set together: all empty
+        # => debug fallback (the fork's current CI); all set => release signing;
+        # a PARTIAL set fails fast so a half-configured maintainer doesn't get a
+        # confusing publish failure or a silent accidental debug fallback.
+        id: haskeystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          set_count=0
+          missing=""
+          for name in ANDROID_KEYSTORE_BASE64 ANDROID_KEY_ALIAS ANDROID_KEYSTORE_PASSWORD ANDROID_KEY_PASSWORD; do
+            eval "val=\${$name}"
+            if [ -n "$val" ]; then
+              set_count=$((set_count + 1))
+            else
+              missing="$missing $name"
+            fi
+          done
+          if [ "$set_count" -eq 4 ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+            echo "All Android signing secrets detected — building a release-signed APK + AAB."
+          elif [ "$set_count" -eq 0 ]; then
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "No Android signing secrets — falling back to the debug-keystore APK build."
+          else
+            echo "::error::Partial Android signing secrets configured. Set ALL of ANDROID_KEYSTORE_BASE64, ANDROID_KEY_ALIAS, ANDROID_KEYSTORE_PASSWORD, ANDROID_KEY_PASSWORD (or none). Missing:$missing"
+            exit 1
+          fi
+
+      - name: Decode release keystore
+        # Base64-decode the maintainer-provided keystore to a runner-temp file.
+        # Runs ONLY when the secrets are present. The decoded keystore lives under
+        # $RUNNER_TEMP (cleaned up automatically at job end), is chmod 600, and is
+        # never logged. `printf '%s'` avoids any echo-added trailing newline.
+        if: steps.haskeystore.outputs.present == 'true'
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/release.keystore"
+          chmod 600 "$RUNNER_TEMP/release.keystore"
+
+      - name: Build release-signed APK + AAB
+        # Release-signing path (secret present). Publishes BOTH an APK and an AAB
+        # (AndroidPackageFormats=apk;aab) signed with the release keystore.
+        # Passwords come from `env:` so they never appear in the logged command
+        # line. -p:EnableAndroidTarget=true is REQUIRED as a GLOBAL property
+        # (#1121): a bare build fails restore with NETSDK1005 because NuGet
+        # restore's static graph ignores the per-reference AdditionalProperties
+        # that activates the net9.0-android TFM on FEBuilderGBA.Avalonia.
+        if: steps.haskeystore.outputs.present == 'true'
+        env:
+          ANDROID_SIGNING_STORE_PASS: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_SIGNING_KEY_PASS: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          ANDROID_SIGNING_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+        run: |
+          dotnet publish FEBuilderGBA.Android/FEBuilderGBA.Android.csproj \
+            -c Release \
+            -p:EnableAndroidTarget=true \
+            -p:AndroidPackageFormats='apk;aab' \
+            -p:AndroidKeyStore=true \
+            -p:AndroidSigningKeyStore="$RUNNER_TEMP/release.keystore" \
+            -p:AndroidSigningKeyAlias="$ANDROID_SIGNING_KEY_ALIAS" \
+            -p:AndroidSigningStorePass="$ANDROID_SIGNING_STORE_PASS" \
+            -p:AndroidSigningKeyPass="$ANDROID_SIGNING_KEY_PASS"
+
+      - name: Build debug-keystore APK (fallback)
+        # Fallback path (secret ABSENT) — the original #1126 behaviour. This is
+        # what runs on the fork's CI today, so the existing (non-required) check
+        # is unchanged. Produces the debug-keystore *-Signed.apk.
+        if: steps.haskeystore.outputs.present != 'true'
         run: dotnet build FEBuilderGBA.Android/FEBuilderGBA.Android.csproj -c Release -p:EnableAndroidTarget=true
 
-      - name: Upload APK artifact
+      - name: Upload APK / AAB artifact
         uses: actions/upload-artifact@v4
         with:
           name: febuildergba-android-apk
-          # The debug-keystore-signed APK the build already produces
-          # (docs/ANDROID.md §7), at the well-known net9.0-android output path.
+          # Both paths land a *-Signed.apk at the well-known net9.0-android
+          # output path; the release-signing path additionally emits an .aab.
           # if-no-files-found: error so a run that produced NO apk (a path /
           # packaging regression) fails VISIBLY rather than passing green with
-          # an empty artifact — this is meaningful precisely because the job is
-          # NOT continue-on-error. It still can't block merges: the workflow is
+          # an empty artifact — meaningful precisely because the job is NOT
+          # continue-on-error. It still can't block merges: the workflow is
           # separate + non-required (context android-build, not the required
           # `build`).
-          path: FEBuilderGBA.Android/bin/Release/net9.0-android/*-Signed.apk
+          path: |
+            FEBuilderGBA.Android/bin/Release/net9.0-android/*-Signed.apk
+            FEBuilderGBA.Android/bin/Release/net9.0-android/*.aab
           if-no-files-found: error

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -401,7 +401,7 @@ release keystore to the repository's GitHub Actions secrets. The four secrets ar
 
 | Secret | Meaning |
 | --- | --- |
-| `ANDROID_KEYSTORE_BASE64` | base64 of the release keystore (`.keystore` / `.jks`) — e.g. `base64 -w0 release.keystore` |
+| `ANDROID_KEYSTORE_BASE64` | base64 of the release keystore (`.keystore` / `.jks`) — Linux: `base64 -w0 release.keystore`; macOS/BSD: `base64 -i release.keystore` (the `-w0` flag is GNU-only) |
 | `ANDROID_KEY_ALIAS` | the key alias inside the keystore |
 | `ANDROID_KEYSTORE_PASSWORD` | the keystore (store) password |
 | `ANDROID_KEY_PASSWORD` | the key password |

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -395,6 +395,45 @@ non-blocking) red check instead of a misleading green one; the
 produced no APK (e.g. a path regression) fails visibly rather than passing green
 with an empty artifact.
 
+**Conditional release signing (#1631 — DONE):** the same workflow now produces a
+**release-signed** APK **and** AAB *when, and only when,* the maintainer adds a
+release keystore to the repository's GitHub Actions secrets. The four secrets are:
+
+| Secret | Meaning |
+| --- | --- |
+| `ANDROID_KEYSTORE_BASE64` | base64 of the release keystore (`.keystore` / `.jks`) — e.g. `base64 -w0 release.keystore` |
+| `ANDROID_KEY_ALIAS` | the key alias inside the keystore |
+| `ANDROID_KEYSTORE_PASSWORD` | the keystore (store) password |
+| `ANDROID_KEY_PASSWORD` | the key password |
+
+Behaviour by secret state:
+
+- **All four secrets set →** the job decodes the keystore to a runner-temp file
+  (`chmod 600`, never logged) and runs `dotnet publish …
+  -p:AndroidPackageFormats='apk;aab' -p:AndroidKeyStore=true
+  -p:AndroidSigningKeyStore=… -p:AndroidSigningKeyAlias=…
+  -p:AndroidSigningStorePass=… -p:AndroidSigningKeyPass=…`, passing the passwords
+  via `env:` so they never appear in the logged command line. The upload step
+  attaches the release-signed `*-Signed.apk` **and** the `*.aab` to the
+  `febuildergba-android-apk` artifact. The `.aab` is the format Google Play
+  requires; the signed APK is for direct sideload / non-Play distribution.
+- **No secrets set (the state on this fork's CI) →** the job falls back to the
+  original `dotnet build … -p:EnableAndroidTarget=true` and uploads the
+  **debug-keystore** `*-Signed.apk`, exactly as before — the existing
+  (non-required) CI is unchanged.
+- **A partial set →** the detect step fails fast with a clear
+  `::error::Partial Android signing secrets configured …` so a half-configured
+  maintainer never gets a confusing publish failure or a silent debug fallback.
+
+No production signing key is committed to the repo — only the maintainer adds it,
+as a secret. This mirrors how #1126 left the work: the implementation lands now;
+activation requires the maintainer to add the keystore secret. `secrets.*` cannot
+appear in a step-level `if:` (GitHub forbids it), so secret presence is classified
+once into a step output (`haskeystore.outputs.present`) that the signing / fallback
+steps gate on. **Attaching the signed artifact to a GitHub release is the separate
+tag-triggered release workflow ([#1629](https://github.com/laqieer/FEBuilderGBA/issues/1629));**
+this workflow only produces the signed build.
+
 **On-device byte-parity CI (#1125 — DONE, GREEN):**
 `.github/workflows/android-emulator-parity.yml` runs `SkiaRenderByteParityTests`
 + `SkiaSharpVersionGuardTests` on an API-34 Android emulator for `x86_64`
@@ -461,8 +500,14 @@ linked under #1070 as its checklist:
    not the desktop `.sln` build).~~ **DONE (#1126)** — `.github/workflows/android.yml`
    builds the APK on `ubuntu-latest` and uploads the debug-keystore `*-Signed.apk`
    as a workflow artifact; kept off the required `build` check (separate workflow +
-   `android-build` context, non-required). Signed-release-key packaging and the
-   emulator byte-parity run (#1125) are deferred. *(see §7.)*
+   `android-build` context, non-required). ~~Signed-release-key packaging~~ is now
+   **DONE (#1631)** — the same workflow conditionally produces a release-signed APK
+   **+ AAB** when the maintainer adds the `ANDROID_KEYSTORE_BASE64` /
+   `ANDROID_KEY_ALIAS` / `ANDROID_KEYSTORE_PASSWORD` / `ANDROID_KEY_PASSWORD`
+   secrets, and falls back to the debug-keystore `*-Signed.apk` when they are
+   absent (see §7); attaching the signed artifact to a GitHub release is the
+   tag-triggered release workflow ([#1629](https://github.com/laqieer/FEBuilderGBA/issues/1629)).
+   The emulator byte-parity run (#1125) is **DONE** (see item 5). *(see §7.)*
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -258,12 +258,39 @@ Future improvements for CI/CD:
 - [ ] Update notification system
 - [ ] Beta/nightly channel support
 
+## Android release signing
+
+The Android head (`FEBuilderGBA.Android`) is built by a separate workflow,
+`.github/workflows/android.yml` (advisory / non-required — see
+[docs/ANDROID.md §7](ANDROID.md#7-build-status-in-this-environment)). It produces
+a **release-signed APK + AAB** *only when* the maintainer adds a release keystore
+to the repository's GitHub Actions secrets; otherwise it falls back to the
+debug-keystore `*-Signed.apk` (the fork's current CI), so the existing check is
+unchanged.
+
+Required secrets (set ALL four together, or none):
+
+| Secret | Meaning |
+| --- | --- |
+| `ANDROID_KEYSTORE_BASE64` | base64 of the release keystore — `base64 -w0 release.keystore` |
+| `ANDROID_KEY_ALIAS` | the key alias inside the keystore |
+| `ANDROID_KEYSTORE_PASSWORD` | the keystore (store) password |
+| `ANDROID_KEY_PASSWORD` | the key password |
+
+Add them at **Settings → Secrets and variables → Actions → New repository secret**.
+A partial set fails the workflow fast with a clear error. The `.aab` is the
+artifact Google Play requires; the signed APK is for direct sideload. Attaching
+the signed artifact to a GitHub release is handled by the tag-triggered release
+workflow ([#1629](https://github.com/laqieer/FEBuilderGBA/issues/1629)). No
+production signing key is committed to the repo.
+
 ## References
 
 - Split Package Status: `SPLIT-PACKAGE-FINAL-STATUS.md`
 - PowerShell Script: `scripts/create-split-packages.ps1`
 - CI/CD Workflow: `.github/workflows/msbuild.yml`
 - Update Logic: `FEBuilderGBA/UpdateCheckSplitPackage.cs`
+- Android build + signing: `.github/workflows/android.yml`, [docs/ANDROID.md §7](ANDROID.md#7-build-status-in-this-environment)
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -272,7 +272,7 @@ Required secrets (set ALL four together, or none):
 
 | Secret | Meaning |
 | --- | --- |
-| `ANDROID_KEYSTORE_BASE64` | base64 of the release keystore — `base64 -w0 release.keystore` |
+| `ANDROID_KEYSTORE_BASE64` | base64 of the release keystore — Linux `base64 -w0 release.keystore`, macOS/BSD `base64 -i release.keystore` (`-w0` is GNU-only) |
 | `ANDROID_KEY_ALIAS` | the key alias inside the keystore |
 | `ANDROID_KEYSTORE_PASSWORD` | the keystore (store) password |
 | `ANDROID_KEY_PASSWORD` | the key password |


### PR DESCRIPTION
## Summary

`Closes #1631`. Part of the release-readiness umbrella #1628.

`.github/workflows/android.yml` built `-c Release` but uploaded the **debug-keystore** `*-Signed.apk` (release signing was explicitly deferred at #1126), so the artifact was not distributable. This PR adds **conditional release signing** that activates **only when the maintainer adds a release keystore to GitHub Actions secrets**. With the secret absent — the state of this fork's CI — the workflow falls back to the existing debug-keystore build, so **no existing CI breaks**. This mirrors #1126: the implementation lands now; activation requires the maintainer to add the secret. No production signing key is committed.

Attaching the signed artifact to a GitHub release is the separate tag-triggered release workflow (#1629); this PR only produces the signed build.

## Required GitHub Actions secrets (set ALL four, or none)

| Secret | Meaning |
| --- | --- |
| `ANDROID_KEYSTORE_BASE64` | base64 of the release keystore (`.keystore`/`.jks`) — `base64 -w0 release.keystore` |
| `ANDROID_KEY_ALIAS` | the key alias inside the keystore |
| `ANDROID_KEYSTORE_PASSWORD` | the keystore (store) password |
| `ANDROID_KEY_PASSWORD` | the key password |

Add at **Settings → Secrets and variables → Actions → New repository secret**.

## Behaviour by secret state

- **All four set** → decode keystore to `$RUNNER_TEMP` (`chmod 600`, never logged) → `dotnet publish … -p:AndroidPackageFormats='apk;aab' -p:AndroidKeyStore=true -p:AndroidSigning{KeyStore,KeyAlias,StorePass,KeyPass}=…` (passwords via `env:`, never on the logged command line) → uploads release-signed `*-Signed.apk` **+ `.aab`**.
- **None set** (the fork's CI today) → original `dotnet build … -p:EnableAndroidTarget=true` → uploads debug-keystore `*-Signed.apk`, exactly as before.
- **Partial set** → detect step **fails fast** with `::error::Partial Android signing secrets configured …`.

`secrets.*` cannot appear in a step-level `if:` (GitHub forbids it), so presence is classified once into a step output (`haskeystore.outputs.present`) that the signing/fallback steps gate on.

## Plan & review

Plan posted on #1631 and reviewed by Copilot CLI (GPT-5.5). All four findings adopted:
1. ✅ `AndroidPackageFormats='apk;aab'` single-quoted (semicolon safe); password props quoted.
2. ✅ Detector reads from `env:`, not `${{ secrets.* }}` inline in the shell.
3. ✅ All-four-or-none classification with fail-fast on a partial set.
4. ✅ Per-step (not job-wide) env scoping; `printf '%s' | base64 --decode` + `chmod 600` decode.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/android.yml'))"` → `YAML OK` (workflow parses).
- [x] Verified the debug-fallback step is gated `if: steps.haskeystore.outputs.present != 'true'`, so on the fork (no secret) only the original build + upload run — existing non-required `android-build` check unchanged.
- [x] Verified the signing/decode steps are gated `if: … == 'true'` and passwords flow via `env:` (never inline in the logged `dotnet publish` command).
- [x] Docs updated: `docs/ANDROID.md` §7 (new conditional-signing subsection + secrets table) and §8 item 6; `docs/DEPLOYMENT.md` new "Android release signing" subsection. README badge already present (no prose change needed).
- [x] No C#/Core logic changed → no unit tests required; this is a `ci`/docs PR (screenshots optional per workflow).

## YAML-parse evidence

```
$ python -c "import yaml; yaml.safe_load(open('.github/workflows/android.yml')); print('android.yml YAML OK')"
android.yml YAML OK
```

🤖 Generated with Claude Code (Opus 4.8, 1M context)
