### PR TITLE
feat(l10n): translate missing ja/zh strings + scan .cs in L10n gate (Closes #1635)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/CodeLiteralL10nCoverageTest.cs
+++ b/FEBuilderGBA.Avalonia.Tests/CodeLiteralL10nCoverageTest.cs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Issue #1635 — Translate code-sourced R._() strings and extend the L10n gate.
+//
+// L10nCoverageTest guards English AXAML literals. EditorDialogLiteralL10nTests
+// guards the SIX #1610-scoped .axaml.cs files. NEITHER sees the ~334 user-facing
+// status / error / dialog strings wrapped in R._("...") across ALL Avalonia
+// ViewModels and code-behind, so a Japanese / Chinese user saw them in English
+// while CI stayed green.
+//
+// This test is the blocking gate that closes that hole: it enumerates every
+// R._("literal") call across FEBuilderGBA.Avalonia/**/*.cs via
+// L10nScanner.ScanCodeLiterals and asserts:
+//   - 0 PartiallyTranslated  (a literal must have BOTH ja AND zh, or neither),
+//   - every Untranslated literal is in an explicit allowlist.
+// NonEnglish findings (the literal already contains CJK / Hangul — a WinForms
+// Japanese-source string reused verbatim) are out of scope, mirroring the AXAML
+// sweep's NonEnglish bucket.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using FEBuilderGBA.Avalonia.GapSweep;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    public class CodeLiteralL10nCoverageTest
+    {
+        /// <summary>
+        /// Literals deliberately kept English in every locale. These are NOT
+        /// translatable UI content — they are URLs, file-format / extension labels
+        /// that double as their own value, or punctuation placeholders. Keep this
+        /// list small and justified; a new untranslated UI string must be
+        /// translated, not allowlisted.
+        /// </summary>
+        static readonly HashSet<string> Allowlist = new(StringComparer.Ordinal)
+        {
+            // Format / brand names that are identical across locales (the existing
+            // translate files already key these verbatim where present).
+            "Adobe ACT (Photoshop)",
+            "JASC-PAL (Aseprite/GIMP)",
+            "Road.BIN",
+        };
+
+        [Fact]
+        public void AvaloniaCodeLiterals_HaveJaAndZhTranslations()
+        {
+            string repoRoot = FindRepoRoot();
+
+            var findings = L10nScanner.ScanCodeLiterals(repoRoot, new[] { "ja", "zh" });
+
+            // The scan must actually find code literals — guard against a silent
+            // "0 findings ⇒ vacuous pass" regression (e.g. a broken regex).
+            Assert.NotEmpty(findings);
+
+            int partial = findings.Count(f => f.Verdict == L10nVerdict.PartiallyTranslated);
+            Assert.True(
+                partial == 0,
+                $"Expected 0 PartiallyTranslated R._() code literals; found {partial}. " +
+                "Each must have BOTH a ja AND a zh entry in config/translate/{ja,zh}.txt. " +
+                "Sample: " + string.Join("; ",
+                    findings.Where(f => f.Verdict == L10nVerdict.PartiallyTranslated)
+                        .Select(f => $"'{Truncate(f.Literal, 60)}' @ {f.SourcePath}:{f.LineNumber}")
+                        .Distinct()
+                        .Take(8)));
+
+            var untranslated = findings
+                .Where(f => f.Verdict == L10nVerdict.Untranslated)
+                .ToList();
+
+            foreach (var f in untranslated)
+            {
+                Assert.True(
+                    Allowlist.Contains(f.Literal),
+                    $"Untranslated R._() code literal '{Truncate(f.Literal, 80)}' at " +
+                    $"{f.SourcePath}:{f.LineNumber} is not in the allowlist. Add ja+zh " +
+                    $"translations to config/translate/{{ja,zh}}.txt, or add this literal " +
+                    $"to the Allowlist in CodeLiteralL10nCoverageTest.cs with justification.");
+            }
+        }
+
+        /// <summary>
+        /// Proves the gate would have caught the exact examples cited in #1635 had
+        /// they not been translated: a literal absent from ja/zh resolves to
+        /// Untranslated (a fail unless allowlisted), and a fully-translated literal
+        /// resolves to Translated. Uses in-memory maps so it is independent of the
+        /// shipped translate files.
+        /// </summary>
+        [Fact]
+        public void Gate_WouldHaveCaught_Issue1635_Examples()
+        {
+            // No translations at all → the issue's example literal is Untranslated.
+            var emptyMaps = new Dictionary<string, IReadOnlyDictionary<string, string>>(StringComparer.Ordinal)
+            {
+                ["ja"] = new Dictionary<string, string>(StringComparer.Ordinal),
+                ["zh"] = new Dictionary<string, string>(StringComparer.Ordinal),
+            };
+            var emptyRev = new Dictionary<string, string>(StringComparer.Ordinal);
+
+            const string src =
+                "void M(){ CoreState.Services?.ShowError(R._(\"2-ROM Diff: no ROM loaded.\")); }";
+            var missing = L10nScanner.ScanCsString(src, "ToolDiffViewModel.cs", emptyRev, emptyMaps);
+            Assert.Single(missing);
+            Assert.Equal(L10nVerdict.Untranslated, missing[0].Verdict);
+            Assert.Equal("2-ROM Diff: no ROM loaded.", missing[0].Literal);
+
+            // Same literal WITH ja+zh entries → Translated (the gate is satisfied).
+            var fullMaps = new Dictionary<string, IReadOnlyDictionary<string, string>>(StringComparer.Ordinal)
+            {
+                ["ja"] = new Dictionary<string, string>(StringComparer.Ordinal)
+                    { ["2-ROM Diff: no ROM loaded."] = "2-ROM 差分: ROMが読み込まれていません。" },
+                ["zh"] = new Dictionary<string, string>(StringComparer.Ordinal)
+                    { ["2-ROM Diff: no ROM loaded."] = "2-ROM 差异: 未加载ROM。" },
+            };
+            var ok = L10nScanner.ScanCsString(src, "ToolDiffViewModel.cs", emptyRev, fullMaps);
+            Assert.Single(ok);
+            Assert.Equal(L10nVerdict.Translated, ok[0].Verdict);
+        }
+
+        static string FindRepoRoot()
+        {
+            string start = AppDomain.CurrentDomain.BaseDirectory;
+            for (var dir = new DirectoryInfo(start); dir != null; dir = dir.Parent)
+            {
+                if (File.Exists(Path.Combine(dir.FullName, "FEBuilderGBA.sln")))
+                    return dir.FullName;
+            }
+            throw new InvalidOperationException(
+                $"Could not locate FEBuilderGBA.sln starting from {start}");
+        }
+
+        static string Truncate(string s, int max) =>
+            s.Length <= max ? s : s.Substring(0, max) + "…";
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/L10nScannerTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/L10nScannerTests.cs
@@ -562,6 +562,165 @@ public class L10nScannerTests
             Verdict: verdict);
     }
 
+    // =====================================================================
+    // ScanCodeLiterals / ScanCsString — R._("literal") code-literal sweep (#1635)
+    // =====================================================================
+
+    [Fact]
+    public void ScanCsString_FindsRUnderscoreLiteral_AndJoinsTranslation()
+    {
+        var (rev, langs) = BuildMaps(new[]
+        {
+            ("ジャンプ", "Jump", "ジャンプ", "跳转", "점프"),
+        });
+        const string src = "void M(){ var s = R._(\"Jump\"); }";
+        var findings = L10nScanner.ScanCsString(src, "X.cs", rev, langs);
+        Assert.Single(findings);
+        Assert.Equal("Jump", findings[0].Literal);
+        Assert.Equal(L10nVerdict.Translated, findings[0].Verdict);
+    }
+
+    [Fact]
+    public void ScanCsString_DirectForwardMapKey_Resolves()
+    {
+        // ja.txt keys many entries by the English literal directly (e.g.
+        // ":Characters" -> "キャラクター"). The direct forward-map lookup must hit.
+        var langs = new Dictionary<string, IReadOnlyDictionary<string, string>>(StringComparer.Ordinal)
+        {
+            ["ja"] = new Dictionary<string, string>(StringComparer.Ordinal) { ["Save failed: {0}"] = "保存に失敗しました: {0}" },
+            ["zh"] = new Dictionary<string, string>(StringComparer.Ordinal) { ["Save failed: {0}"] = "保存失败: {0}" },
+        };
+        const string src = "ShowError(R._(\"Save failed: {0}\", ex));";
+        var f = L10nScanner.ScanCsString(src, "X.cs", EmptyReverse(), langs);
+        Assert.Single(f);
+        Assert.Equal(L10nVerdict.Translated, f[0].Verdict);
+    }
+
+    [Fact]
+    public void ScanCsString_Untranslated_WhenNoEntry()
+    {
+        const string src = "ShowError(R._(\"2-ROM Diff: no ROM loaded.\"));";
+        var f = L10nScanner.ScanCsString(src, "X.cs", EmptyReverse(), EmptyLangs("ja", "zh"));
+        Assert.Single(f);
+        Assert.Equal(L10nVerdict.Untranslated, f[0].Verdict);
+    }
+
+    [Fact]
+    public void ScanCsString_PartiallyTranslated_WhenOnlyOneLang()
+    {
+        var langs = new Dictionary<string, IReadOnlyDictionary<string, string>>(StringComparer.Ordinal)
+        {
+            ["ja"] = new Dictionary<string, string>(StringComparer.Ordinal) { ["Update failed: {0}"] = "更新に失敗しました: {0}" },
+            ["zh"] = new Dictionary<string, string>(StringComparer.Ordinal), // missing zh
+        };
+        const string src = "R._(\"Update failed: {0}\", e);";
+        var f = L10nScanner.ScanCsString(src, "X.cs", EmptyReverse(), langs);
+        Assert.Single(f);
+        Assert.Equal(L10nVerdict.PartiallyTranslated, f[0].Verdict);
+    }
+
+    [Fact]
+    public void ScanCsString_CjkSourceLiteral_IsNonEnglish()
+    {
+        // A WinForms Japanese-source literal reused verbatim is already localized
+        // in JP mode — classify as NonEnglish (out of scope), not a gap.
+        const string src = "R._(\"コピー(&C)\");";
+        var f = L10nScanner.ScanCsString(src, "X.cs", EmptyReverse(), EmptyLangs("ja", "zh"));
+        Assert.Single(f);
+        Assert.Equal(L10nVerdict.NonEnglish, f[0].Verdict);
+    }
+
+    [Fact]
+    public void ScanCsString_IgnoresLiteralsInLineComments()
+    {
+        const string src = "// example: R._(\"Commented out string\")\nint x = 1;";
+        var f = L10nScanner.ScanCsString(src, "X.cs", EmptyReverse(), EmptyLangs("ja", "zh"));
+        Assert.Empty(f);
+    }
+
+    [Fact]
+    public void ScanCsString_IgnoresLiteralsInBlockComments()
+    {
+        const string src = "/* R._(\"Block comment string\") */\nint x = 1;";
+        var f = L10nScanner.ScanCsString(src, "X.cs", EmptyReverse(), EmptyLangs("ja", "zh"));
+        Assert.Empty(f);
+    }
+
+    [Fact]
+    public void ScanCsString_DocCommentExampleIsIgnored_RealCallIsFound()
+    {
+        // Mirrors THIS scanner file's own situation: a `///` doc comment that
+        // mentions R._("literal") must NOT count, but a real call on the next
+        // line MUST.
+        var langs = new Dictionary<string, IReadOnlyDictionary<string, string>>(StringComparer.Ordinal)
+        {
+            ["ja"] = new Dictionary<string, string>(StringComparer.Ordinal) { ["Home"] = "ホーム" },
+            ["zh"] = new Dictionary<string, string>(StringComparer.Ordinal) { ["Home"] = "主页" },
+        };
+        const string src = "/// Matches R._(\"literal\") calls.\nvar t = R._(\"Home\");";
+        var f = L10nScanner.ScanCsString(src, "X.cs", EmptyReverse(), langs);
+        Assert.Single(f);
+        Assert.Equal("Home", f[0].Literal);
+        Assert.Equal(2, f[0].LineNumber); // comment on line 1, real call on line 2
+    }
+
+    [Fact]
+    public void ReadCsStringLiteral_DecodesEscapes()
+    {
+        const string src = "R._(\"a\\r\\nb\\\"c\")";
+        int q = src.IndexOf('"');
+        Assert.True(L10nScanner.ReadCsStringLiteral(src, q, verbatim: false, out string v));
+        Assert.Equal("a\r\nb\"c", v);
+    }
+
+    [Fact]
+    public void ReadCsStringLiteral_HandlesVerbatim()
+    {
+        const string src = "R._(@\"path\\to\\\"\"file\"\"\")";
+        int q = src.IndexOf('"');
+        Assert.True(L10nScanner.ReadCsStringLiteral(src, q, verbatim: true, out string v));
+        Assert.Equal("path\\to\\\"file\"", v);
+    }
+
+    [Fact]
+    public void StripComments_PreservesStringsAndLayout()
+    {
+        const string src = "var url = \"http://x\"; // comment\nint y;";
+        string stripped = L10nScanner.StripCommentsPreservingLayout(src);
+        // The URL string survives (the // inside it is NOT a comment).
+        Assert.Contains("\"http://x\"", stripped);
+        // The trailing // comment body is blanked.
+        Assert.DoesNotContain("comment", stripped);
+        // Length and newline count are unchanged.
+        Assert.Equal(src.Length, stripped.Length);
+        Assert.Equal(src.Count(c => c == '\n'), stripped.Count(c => c == '\n'));
+    }
+
+    [Fact]
+    public void ScanCodeLiterals_OverRepo_FindsTranslatedToolDiffLiteral()
+    {
+        // End-to-end against the real repo + shipped translate files: the #1635
+        // example literal must now resolve as Translated (no Partial/Untranslated
+        // for it).
+        string repoRoot = FindRepoRootForTest();
+        var findings = L10nScanner.ScanCodeLiterals(repoRoot, new[] { "ja", "zh" });
+        Assert.NotEmpty(findings);
+        var diff = findings.FirstOrDefault(f => f.Literal == "2-ROM Diff: no ROM loaded.");
+        Assert.NotNull(diff);
+        Assert.Equal(L10nVerdict.Translated, diff!.Verdict);
+    }
+
+    static string FindRepoRootForTest()
+    {
+        string start = AppContext.BaseDirectory;
+        for (var dir = new DirectoryInfo(start); dir != null; dir = dir.Parent)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "FEBuilderGBA.sln")))
+                return dir.FullName;
+        }
+        throw new InvalidOperationException("Could not locate FEBuilderGBA.sln");
+    }
+
     static IReadOnlyDictionary<string, string> EmptyReverse()
         => new Dictionary<string, string>(StringComparer.Ordinal);
 

--- a/FEBuilderGBA.Avalonia/GapSweep/L10nScanner.cs
+++ b/FEBuilderGBA.Avalonia/GapSweep/L10nScanner.cs
@@ -43,6 +43,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Linq;
 
@@ -194,6 +195,386 @@ namespace FEBuilderGBA.Avalonia.GapSweep
                 .ThenBy(f => f.LineNumber)
                 .ThenBy(f => f.Literal, StringComparer.Ordinal)
                 .ToList();
+        }
+
+        // =====================================================================
+        // Code-literal sweep (#1635)
+        //
+        // The AXAML sweep above only sees attribute values. A large class of
+        // user-facing strings — status / error / dialog messages — instead live
+        // as `R._("literal")` calls inside Avalonia ViewModels and code-behind
+        // (`*.cs`). The AXAML scanner is blind to them, so CI stayed green while
+        // ~334 such strings rendered in English under Japanese / Chinese UI.
+        //
+        // `ScanCodeLiterals` closes that gap: it enumerates every distinct
+        // `R._("...")` first-string-argument across `FEBuilderGBA.Avalonia/**/*.cs`
+        // and joins each against the same reverse-English → forward-map chain the
+        // runtime uses (see `MyTranslateResourceLow.str`). Findings reuse the
+        // existing verdict buckets so the report / gate logic is identical to the
+        // AXAML side.
+        // =====================================================================
+
+        /// <summary>
+        /// One `R._("literal")` finding from a `.cs` source file. Mirrors
+        /// <see cref="L10nFinding"/> but keyed on a source-file path rather than an
+        /// AXAML element/attribute, since a code literal has no XML host.
+        /// </summary>
+        /// <param name="SourcePath">Repo-relative `.cs` path with forward slashes.</param>
+        /// <param name="LineNumber">1-based source line of the `R._(` call.</param>
+        /// <param name="Literal">Decoded literal value (C# escapes already resolved).</param>
+        /// <param name="TranslationStatus">Language code → did the lookup chain produce a non-empty translation.</param>
+        /// <param name="Verdict">Bucket classification (same enum as the AXAML sweep).</param>
+        public record CodeLiteralFinding(
+            string SourcePath,
+            int LineNumber,
+            string Literal,
+            IReadOnlyDictionary<string, bool> TranslationStatus,
+            L10nVerdict Verdict);
+
+        /// <summary>
+        /// Matches the START of an <c>R._("literal"</c> call. The first string
+        /// argument is then captured by a dedicated C#-string-literal scanner
+        /// (<see cref="ReadCsStringLiteral"/>) so embedded escaped quotes
+        /// (<c>\"</c>) never truncate it. Whitespace between <c>R._(</c> and the
+        /// opening quote is tolerated.
+        /// </summary>
+        static readonly Regex RUnderscoreCallStart = new(
+            @"\bR\._\(\s*@?""", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Scan every `*.cs` under `FEBuilderGBA.Avalonia/` for `R._("literal")`
+        /// calls and join each distinct literal against the translation tables.
+        ///
+        /// Returns one finding per (file, line) occurrence (so the report can show
+        /// where a literal is used), ordered by (SourcePath asc, LineNumber asc,
+        /// Literal asc). Files under `bin/` and `obj/` are skipped.
+        /// </summary>
+        public static IReadOnlyList<CodeLiteralFinding> ScanCodeLiterals(
+            string repoRoot,
+            IReadOnlyList<string>? languages = null)
+        {
+            if (string.IsNullOrEmpty(repoRoot))
+                throw new ArgumentException("repoRoot must be non-empty", nameof(repoRoot));
+            if (!Directory.Exists(repoRoot))
+                throw new DirectoryNotFoundException($"repo root not found: {repoRoot}");
+
+            languages ??= DefaultLanguages;
+
+            string translateDir = Path.Combine(repoRoot, "config", "translate");
+            var reverseEnMap = LoadReverseEnglishMap(Path.Combine(translateDir, "en.txt"));
+            var languageMaps = new Dictionary<string, Dictionary<string, string>>(StringComparer.Ordinal);
+            foreach (string lang in languages)
+                languageMaps[lang] = LoadForwardMap(Path.Combine(translateDir, lang + ".txt"));
+
+            var avaloniaDir = Path.Combine(repoRoot, "FEBuilderGBA.Avalonia");
+            var findings = new List<CodeLiteralFinding>();
+            if (!Directory.Exists(avaloniaDir))
+                return findings;
+
+            foreach (string csPath in Directory.EnumerateFiles(avaloniaDir, "*.cs", SearchOption.AllDirectories)
+                                               .OrderBy(p => p, StringComparer.Ordinal))
+            {
+                if (IsInBinOrObj(repoRoot, csPath))
+                    continue;
+                string relPath = ToRelative(repoRoot, csPath);
+                ScanCsFile(csPath, relPath, reverseEnMap, languageMaps, languages, findings);
+            }
+
+            return findings
+                .OrderBy(f => f.SourcePath, StringComparer.Ordinal)
+                .ThenBy(f => f.LineNumber)
+                .ThenBy(f => f.Literal, StringComparer.Ordinal)
+                .ToList();
+        }
+
+        /// <summary>
+        /// In-memory variant for unit tests: scan an arbitrary C# source string
+        /// for `R._("literal")` calls and classify each against the supplied maps.
+        /// Avoids disk I/O so tests stay hermetic.
+        /// </summary>
+        public static IReadOnlyList<CodeLiteralFinding> ScanCsString(
+            string csContent,
+            string sourceRelPath,
+            IReadOnlyDictionary<string, string> reverseEnglishMap,
+            IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> languageMaps)
+        {
+            var findings = new List<CodeLiteralFinding>();
+            var maps = languageMaps.ToDictionary(
+                kv => kv.Key,
+                kv => kv.Value.ToDictionary(p => p.Key, p => p.Value, StringComparer.Ordinal),
+                StringComparer.Ordinal);
+            ScanCsContent(
+                csContent,
+                sourceRelPath,
+                reverseEnglishMap,
+                maps,
+                languageMaps.Keys.ToList(),
+                findings);
+            return findings;
+        }
+
+        static void ScanCsFile(
+            string csPath,
+            string sourceRelPath,
+            IReadOnlyDictionary<string, string> reverseEnMap,
+            IReadOnlyDictionary<string, Dictionary<string, string>> languageMaps,
+            IReadOnlyList<string> languages,
+            List<CodeLiteralFinding> findings)
+        {
+            string content;
+            try
+            {
+                content = File.ReadAllText(csPath);
+            }
+            catch
+            {
+                return;
+            }
+            ScanCsContent(content, sourceRelPath, reverseEnMap, languageMaps, languages, findings);
+        }
+
+        static void ScanCsContent(
+            string content,
+            string sourceRelPath,
+            IReadOnlyDictionary<string, string> reverseEnMap,
+            IReadOnlyDictionary<string, Dictionary<string, string>> languageMaps,
+            IReadOnlyList<string> languages,
+            List<CodeLiteralFinding> findings)
+        {
+            // Blank out `//`, `///` and `/* */` comments (preserving offsets and
+            // newlines so line numbers stay accurate). Without this, doc-comment
+            // examples like the `R._("literal")` in THIS file's own XML docs would
+            // be reported as untranslated UI strings — a false positive. String
+            // literals are NOT blanked, so the comment-detector never trips on a
+            // `//` that lives inside a string.
+            content = StripCommentsPreservingLayout(content);
+
+            foreach (Match m in RUnderscoreCallStart.Matches(content))
+            {
+                // The match ends just past the opening quote. `@?"` — verbatim
+                // (`@"..."`) string literals double their quotes to escape them;
+                // detect which form we matched so the literal scanner uses the
+                // right escaping rule.
+                bool verbatim = m.Value.IndexOf('@') >= 0;
+                int quoteIndex = m.Index + m.Length - 1; // index of the opening '"'
+                if (!ReadCsStringLiteral(content, quoteIndex, verbatim, out string literal))
+                    continue;
+                if (string.IsNullOrWhiteSpace(literal))
+                    continue;
+
+                var status = new Dictionary<string, bool>(StringComparer.Ordinal);
+                int hit = 0;
+                bool isNonEnglish = ContainsCjkOrHangul(literal);
+                foreach (string lang in languages)
+                {
+                    bool ok = false;
+                    if (languageMaps.TryGetValue(lang, out var map))
+                        ok = HasTranslation(literal, reverseEnMap, map);
+                    status[lang] = ok;
+                    if (ok) hit++;
+                }
+
+                L10nVerdict verdict;
+                if (isNonEnglish)
+                    verdict = L10nVerdict.NonEnglish;
+                else if (languages.Count == 0)
+                    verdict = L10nVerdict.Untranslated;
+                else if (hit == languages.Count)
+                    verdict = L10nVerdict.Translated;
+                else if (hit == 0)
+                    verdict = L10nVerdict.Untranslated;
+                else
+                    verdict = L10nVerdict.PartiallyTranslated;
+
+                int line = content.Take(m.Index).Count(c => c == '\n') + 1;
+                findings.Add(new CodeLiteralFinding(
+                    SourcePath: sourceRelPath,
+                    LineNumber: line,
+                    Literal: literal,
+                    TranslationStatus: status,
+                    Verdict: verdict));
+            }
+        }
+
+        /// <summary>
+        /// Read a C# string literal starting at <paramref name="quoteIndex"/> (the
+        /// index of the opening <c>"</c>) and decode its escape sequences. Handles
+        /// both regular literals (backslash escapes) and verbatim <c>@"..."</c>
+        /// literals (doubled quotes). Returns false if the literal is unterminated.
+        /// </summary>
+        public static bool ReadCsStringLiteral(string src, int quoteIndex, bool verbatim, out string value)
+        {
+            value = string.Empty;
+            if (quoteIndex < 0 || quoteIndex >= src.Length || src[quoteIndex] != '"')
+                return false;
+
+            var sb = new StringBuilder();
+            int i = quoteIndex + 1;
+            while (i < src.Length)
+            {
+                char c = src[i];
+                if (verbatim)
+                {
+                    if (c == '"')
+                    {
+                        if (i + 1 < src.Length && src[i + 1] == '"')
+                        {
+                            sb.Append('"');
+                            i += 2;
+                            continue;
+                        }
+                        value = sb.ToString();
+                        return true;
+                    }
+                    sb.Append(c);
+                    i++;
+                }
+                else
+                {
+                    if (c == '\\' && i + 1 < src.Length)
+                    {
+                        char n = src[i + 1];
+                        switch (n)
+                        {
+                            case 'r': sb.Append('\r'); break;
+                            case 'n': sb.Append('\n'); break;
+                            case 't': sb.Append('\t'); break;
+                            case '0': sb.Append('\0'); break;
+                            case '"': sb.Append('"'); break;
+                            case '\\': sb.Append('\\'); break;
+                            default: sb.Append(n); break; // best-effort for \uXXXX etc.
+                        }
+                        i += 2;
+                        continue;
+                    }
+                    if (c == '"')
+                    {
+                        value = sb.ToString();
+                        return true;
+                    }
+                    sb.Append(c);
+                    i++;
+                }
+            }
+            return false; // unterminated
+        }
+
+        /// <summary>
+        /// True if <paramref name="s"/> contains any CJK / Hangul character — the
+        /// same "already localised in-line" heuristic the AXAML sweep uses, exposed
+        /// here for the code-literal path (and reusable by the gate test).
+        /// </summary>
+        public static bool ContainsCjkOrHangul(string s)
+        {
+            if (string.IsNullOrEmpty(s))
+                return false;
+            foreach (char c in s)
+                if (IsCjkOrHangul(c))
+                    return true;
+            return false;
+        }
+
+        /// <summary>
+        /// Replace the BODY of every C# comment (`//`, `///`, `/* */`) with spaces
+        /// while leaving newlines and overall length untouched, so subsequent
+        /// regex matching keeps accurate offsets / line numbers but never sees a
+        /// `R._("...")` that lives inside a comment. String and char literals are
+        /// preserved verbatim (and skipped over) so a `//` or `/*` inside a string
+        /// doesn't start a phantom comment. Handles verbatim (`@"..."`) and
+        /// interpolated (`$"..."`, `$@"..."`) string prefixes well enough for this
+        /// blanking purpose — the goal is comment removal, not a full C# lexer.
+        /// </summary>
+        public static string StripCommentsPreservingLayout(string src)
+        {
+            if (string.IsNullOrEmpty(src))
+                return src ?? string.Empty;
+
+            var sb = new StringBuilder(src.Length);
+            int i = 0;
+            int n = src.Length;
+            while (i < n)
+            {
+                char c = src[i];
+
+                // Line comment: // ... (and ///). Blank to end of line.
+                if (c == '/' && i + 1 < n && src[i + 1] == '/')
+                {
+                    while (i < n && src[i] != '\n') { sb.Append(' '); i++; }
+                    continue;
+                }
+                // Block comment: /* ... */. Blank everything but keep newlines.
+                if (c == '/' && i + 1 < n && src[i + 1] == '*')
+                {
+                    sb.Append(' '); sb.Append(' '); i += 2;
+                    while (i < n && !(src[i] == '*' && i + 1 < n && src[i + 1] == '/'))
+                    {
+                        sb.Append(src[i] == '\n' ? '\n' : ' ');
+                        i++;
+                    }
+                    if (i < n) { sb.Append(' '); sb.Append(' '); i += 2; } // consume the closing */
+                    continue;
+                }
+                // Char literal: '...'. Copy verbatim so an embedded // or /* is safe.
+                if (c == '\'')
+                {
+                    sb.Append(c); i++;
+                    while (i < n)
+                    {
+                        sb.Append(src[i]);
+                        if (src[i] == '\\' && i + 1 < n) { i++; sb.Append(src[i]); i++; continue; }
+                        if (src[i] == '\'') { i++; break; }
+                        i++;
+                    }
+                    continue;
+                }
+                // String literal — verbatim (@"...") or regular ("...").
+                if (c == '"' || (c == '@' && i + 1 < n && src[i + 1] == '"')
+                             || (c == '$' && i + 1 < n && (src[i + 1] == '"' ||
+                                  (src[i + 1] == '@' && i + 2 < n && src[i + 2] == '"'))))
+                {
+                    bool verbatim = false;
+                    // Copy any $ / @ prefix and locate the opening quote.
+                    while (i < n && src[i] != '"')
+                    {
+                        if (src[i] == '@') verbatim = true;
+                        sb.Append(src[i]); i++;
+                    }
+                    if (i >= n) break;
+                    sb.Append(src[i]); i++; // opening quote
+                    while (i < n)
+                    {
+                        char d = src[i];
+                        if (verbatim)
+                        {
+                            if (d == '"')
+                            {
+                                if (i + 1 < n && src[i + 1] == '"') { sb.Append('"'); sb.Append('"'); i += 2; continue; }
+                                sb.Append('"'); i++; break;
+                            }
+                            sb.Append(d); i++;
+                        }
+                        else
+                        {
+                            if (d == '\\' && i + 1 < n) { sb.Append(d); sb.Append(src[i + 1]); i += 2; continue; }
+                            sb.Append(d); i++;
+                            if (d == '"') break;
+                        }
+                    }
+                    continue;
+                }
+
+                sb.Append(c); i++;
+            }
+            return sb.ToString();
+        }
+
+        static bool IsInBinOrObj(string repoRoot, string fullPath)
+        {
+            string rel = Path.GetRelativePath(repoRoot, fullPath).Replace('\\', '/');
+            return rel.Contains("/bin/", StringComparison.Ordinal)
+                || rel.Contains("/obj/", StringComparison.Ordinal)
+                || rel.StartsWith("bin/", StringComparison.Ordinal)
+                || rel.StartsWith("obj/", StringComparison.Ordinal);
         }
 
         /// <summary>

--- a/FEBuilderGBA.Avalonia/GapSweep/L10nScanner.cs
+++ b/FEBuilderGBA.Avalonia/GapSweep/L10nScanner.cs
@@ -349,8 +349,20 @@ namespace FEBuilderGBA.Avalonia.GapSweep
             // `//` that lives inside a string.
             content = StripCommentsPreservingLayout(content);
 
+            // Track the line number incrementally. Regex.Matches yields matches in
+            // ascending index order, so we only ever count the newlines BETWEEN the
+            // previous match index and the current one — keeping the whole scan O(N)
+            // instead of the O(N*M) a from-the-start re-count per match would cost.
+            int lineNumber = 1;
+            int scannedUpTo = 0;
+
             foreach (Match m in RUnderscoreCallStart.Matches(content))
             {
+                // Advance the running line counter across the gap since the last match.
+                for (int p = scannedUpTo; p < m.Index; p++)
+                    if (content[p] == '\n') lineNumber++;
+                scannedUpTo = m.Index;
+
                 // The match ends just past the opening quote. `@?"` — verbatim
                 // (`@"..."`) string literals double their quotes to escape them;
                 // detect which form we matched so the literal scanner uses the
@@ -386,10 +398,9 @@ namespace FEBuilderGBA.Avalonia.GapSweep
                 else
                     verdict = L10nVerdict.PartiallyTranslated;
 
-                int line = content.Take(m.Index).Count(c => c == '\n') + 1;
                 findings.Add(new CodeLiteralFinding(
                     SourcePath: sourceRelPath,
-                    LineNumber: line,
+                    LineNumber: lineNumber,
                     Literal: literal,
                     TranslationStatus: status,
                     Verdict: verdict));
@@ -475,8 +486,9 @@ namespace FEBuilderGBA.Avalonia.GapSweep
         }
 
         /// <summary>
-        /// Replace the BODY of every C# comment (`//`, `///`, `/* */`) with spaces
-        /// while leaving newlines and overall length untouched, so subsequent
+        /// Blank every C# comment (`//`, `///`, `/* */`) — including its delimiters
+        /// (`//`, `/*`, `*/`) AND body — by replacing each comment character with a
+        /// space, while leaving newlines and overall length untouched, so subsequent
         /// regex matching keeps accurate offsets / line numbers but never sees a
         /// `R._("...")` that lives inside a comment. String and char literals are
         /// preserved verbatim (and skipped over) so a `//` or `/*` inside a string

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -12956,3 +12956,1077 @@ AIポインタテーブルを{0}エントリに拡張しました。
 
 :Enter the new entry count for the AI pointer table (current: {0}, max: {1}).
 AIポインタテーブルの新しいエントリ数を入力してください（現在: {0}、最大: {1}）。
+:(No ROM loaded)
+(ROMが読み込まれていません)
+
+:.s assembled into the song at 0x{0:X08}.
+.sを 0x{0:X08} のソングにアセンブルしました。
+
+:.s import failed.
+.sのインポートに失敗しました。
+
+:.s import failed: {0}
+.sのインポートに失敗しました: {0}
+
+:2-ROM Diff failed: {0}
+2-ROM 差分に失敗しました: {0}
+
+:2-ROM Diff: 'other ROM' file not found.
+2-ROM 差分: 'other ROM' ファイルが見つかりません。
+
+:2-ROM Diff: 'other ROM' path required.
+2-ROM 差分: 'other ROM' のパスを指定してください。
+
+:2-ROM Diff: no ROM loaded.
+2-ROM 差分: ROMが読み込まれていません。
+
+:2-ROM Diff: output path required.
+2-ROM 差分: 出力先のパスを指定してください。
+
+:2-ROM Diff: wrote patch file {0}.
+2-ROM 差分: パッチファイル {0} を書き出しました。
+
+:3-ROM Diff failed: {0}
+3-ROM 差分に失敗しました: {0}
+
+:3-ROM Diff: ROM A file not found.
+3-ROM 差分: ROM A のファイルが見つかりません。
+
+:3-ROM Diff: ROM B file not found.
+3-ROM 差分: ROM B のファイルが見つかりません。
+
+:3-ROM Diff: both A and B paths required.
+3-ROM 差分: A と B 両方のパスを指定してください。
+
+:3-ROM Diff: no ROM loaded.
+3-ROM 差分: ROMが読み込まれていません。
+
+:3-ROM Diff: output path required.
+3-ROM 差分: 出力先のパスを指定してください。
+
+:3-ROM Diff: wrote patch file {0}.
+3-ROM 差分: パッチファイル {0} を書き出しました。
+
+:A virtual ROM cannot be updated.
+仮想ROMは更新できません。
+
+:AI pointer table not found.
+AIポインタテーブルが見つかりません。
+
+:Adobe ACT (Photoshop)
+Adobe ACT (Photoshop)
+
+:Already at the maximum Demon King Summon count ({0}).
+既に魔王の召喚数の最大値 ({0}) に達しています。
+
+:Already at the maximum of {0} entries.
+既に最大の {0} 件に達しています。
+
+:Animated GIF
+アニメーションGIF
+
+:Animation @ 0x{0:X08}
+アニメ @ 0x{0:X08}
+
+:Animation Creator{0}
+アニメーションクリエイター{0}
+
+:Animation Script (.txt)
+アニメーションスクリプト (.txt)
+
+:Animation pointer 0x{0:X} is outside the ROM.
+アニメポインタ 0x{0:X} はROMの範囲外です。
+
+:Applying UPS patch...
+UPSパッチを適用しています...
+
+:Assemble this .s source into the selected song using the chosen 
+選択したソングに、この .s ソースを指定の設定でアセンブルします 
+
+:BLANK
+空白
+
+:Back
+戻る
+
+:Base64 read failed: {0}
+Base64の読み込みに失敗しました: {0}
+
+:Base64 write failed: {0}
+Base64の書き込みに失敗しました: {0}
+
+:Base64: could not decode (invalid base64).
+Base64: デコードできませんでした (不正なBase64)。
+
+:Base64: encoded {0} bytes.
+Base64: {0} バイトをエンコードしました。
+
+:Base64: enter base64 text first.
+Base64: 先にBase64テキストを入力してください。
+
+:Base64: output path required.
+Base64: 出力先のパスを指定してください。
+
+:Base64: source file not found.
+Base64: 入力ファイルが見つかりません。
+
+:Base64: source path required.
+Base64: 入力ファイルのパスを指定してください。
+
+:Base64: wrote {0} bytes to {1}.
+Base64: {0} バイトを {1} に書き出しました。
+
+:Battle-screen bulk import supports a single palette bank (max {0} colors). Reduce the image to {0} colors first.
+戦闘画面の一括インポートは1つのパレットバンク (最大 {0} 色) のみ対応しています。先に画像を {0} 色に減色してください。
+
+:Bulk Import Skill Config
+スキル設定を一括インポート
+
+:Bulk import failed: {0}
+一括インポートに失敗しました: {0}
+
+:Bulk imported from: {0}
+{0} から一括インポートしました。
+
+:CSA animation scan failed — bad frame-data pointer.
+CSAアニメのスキャンに失敗しました — フレームデータのポインタが不正です。
+
+:Cannot expand: change list has 0 records.
+拡張できません: 変更リストのレコードが0件です。
+
+:Cannot expand: change list is empty (first byte is 0xFF).
+拡張できません: 変更リストが空です (先頭バイトが 0xFF)。
+
+:Cannot expand: change list is empty.
+拡張できません: 変更リストが空です。
+
+:Cannot expand: the CHANGE PLIST slot could not be resolved.
+拡張できません: CHANGE PLIST スロットを解決できませんでした。
+
+:Cannot expand: the change list appears unterminated (no 0xFF within 256 rows). 
+拡張できません: 変更リストが終端していないようです (256行以内に 0xFF がありません)。 
+
+:Cannot expand: the game option list is already at the maximum of {0} entries.
+拡張できません: ゲームオプションリストは既に最大の {0} 件に達しています。
+
+:Cannot expand: the game option list is empty.
+拡張できません: ゲームオプションリストが空です。
+
+:Cannot expand: the game option order list is empty.
+拡張できません: ゲームオプションの順番リストが空です。
+
+:Cannot expand: the map setting list is empty.
+拡張できません: マップ設定リストが空です。
+
+:Cannot expand: the sound room list is empty (no row 0 to copy).
+拡張できません: サウンドルームリストが空です (コピー元の行0がありません)。
+
+:Cannot expand: the summon list is empty.
+拡張できません: 召喚リストが空です。
+
+:Cannot open file: {0}
+ファイルを開けません: {0}
+
+:Cannot open folder: {0}
+フォルダを開けません: {0}
+
+:Cannot resolve the song-table entry for the selected song.
+選択したソングのソングテーブルエントリを解決できません。
+
+:Cannot write to SongID 0x0.
+SongID 0x0 には書き込めません。
+
+:Compress failed: {0}
+圧縮に失敗しました: {0}
+
+:Compress: destination path required.
+圧縮: 出力先のパスを指定してください。
+
+:Compress: source file not found.
+圧縮: 入力ファイルが見つかりません。
+
+:Compress: source path required.
+圧縮: 入力ファイルのパスを指定してください。
+
+:Compress: wrote {0} bytes to {1}.
+圧縮: {0} バイトを {1} に書き出しました。
+
+:Confirm Move
+移動の確認
+
+:Confirm Multi-Pointer Move
+複数ポインタ移動の確認
+
+:Confirm Raw Pointer Fallback
+生ポインタフォールバックの確認
+
+:Confirm Recompress
+再圧縮の確認
+
+:Confirm Zero Clear
+ゼロクリアの確認
+
+:Convert failed: {0}
+変換に失敗しました: {0}
+
+:Copied generated hex to clipboard.
+生成したHexをクリップボードにコピーしました。
+
+:Could not install the ChapterNameToText patch.
+ChapterNameToText パッチをインストールできませんでした。
+
+:Could not read the skill palette; aborting import.
+スキルパレットを読み込めませんでした。インポートを中止します。
+
+:Could not resolve a local file path for export.
+エクスポート用のローカルファイルパスを解決できませんでした。
+
+:Could not resolve the update URL ({0}).
+更新URL ({0}) を解決できませんでした。
+
+:Could not resolve the update URL ({0}). {1}
+更新URL ({0}) を解決できませんでした。{1}
+
+:Could not select the destination song for import.
+インポート先のソングを選択できませんでした。
+
+:DPCM compression is available (m4a HQ mixer patch detected).
+DPCM圧縮が利用可能です (m4a HQ ミキサーパッチを検出)。
+
+:DPCM compression requires the m4a HQ mixer patch (not installed); raw 8-bit PCM will be used.
+DPCM圧縮には m4a HQ ミキサーパッチが必要です (未インストール)。生の8bit PCMを使用します。
+
+:Dark field map is not available (FE8 only).
+ダークフィールドマップは利用できません (FE8専用)。
+
+:Decompress failed: {0}
+解凍に失敗しました: {0}
+
+:Decompress: SRC address is not a valid hex value.
+解凍: SRCアドレスが正しいHex値ではありません。
+
+:Decompress: address out of range.
+解凍: アドレスが範囲外です。
+
+:Decompress: destination path required.
+解凍: 出力先のパスを指定してください。
+
+:Decompress: no ROM loaded.
+解凍: ROMが読み込まれていません。
+
+:Decompress: source file not found.
+解凍: 入力ファイルが見つかりません。
+
+:Decompress: wrote {0} bytes to {1}.
+解凍: {0} バイトを {1} に書き出しました。
+
+:Demon King Summon table expansion failed.
+魔王の召喚テーブルの拡張に失敗しました。
+
+:Demon King Summon table expansion failed: {0}
+魔王の召喚テーブルの拡張に失敗しました: {0}
+
+:Demon King Summon table is not available for this ROM.
+このROMでは魔王の召喚テーブルを利用できません。
+
+:Download/extract failed ({0}). {1}
+ダウンロード/展開に失敗しました ({0})。{1}
+
+:Downloading and extracting...
+ダウンロードして展開しています...
+
+:EA Event Files
+EAイベントファイル
+
+:Edit Battle Data (FE7)
+戦闘データの編集 (FE7)
+
+:Edit Event Function Pointer
+イベント関数ポインタの編集
+
+:Edit Move Data (FE7)
+移動データの編集 (FE7)
+
+:Edit Palette
+パレットの編集
+
+:Edit Talk Group (FE7)
+会話グループの編集 (FE7)
+
+:Enemy Escape Point
+敵の離脱ポイント
+
+:Enter the new Demon King Summon count (current: {0}, max: {1}).
+新しい魔王の召喚数を入力してください (現在: {0}, 最大: {1})。
+
+:Enter the new entry count for the event map-change list (current: {0}, max: 255).
+イベントマップ変更リストの新しい件数を入力してください (現在: {0}, 最大: 255)。
+
+:Enter the new entry count for the map action animation list (current: {0}, max: 255).
+マップアクションアニメリストの新しい件数を入力してください (現在: {0}, 最大: 255)。
+
+:Enter the new game option entry count (current: {0}, max: {1}).
+ゲームオプションの新しい件数を入力してください (現在: {0}, 最大: {1})。
+
+:Enter the new game option order slot count (current: {0}, max: 255).
+ゲームオプションの順番の新しいスロット数を入力してください (現在: {0}, 最大: 255)。
+
+:Enter the new map setting entry count (current: {0}, max: 255).
+マップ設定の新しい件数を入力してください (現在: {0}, 最大: 255)。
+
+:Enter the new spell-list entry count for this unit (current: {0}, max: {1}).
+このユニットのスペルリストの新しい件数を入力してください (現在: {0}, 最大: {1})。
+
+:Enter the new summon entry count (current: {0}, max: {1}).
+新しい召喚の件数を入力してください (現在: {0}, 最大: {1})。
+
+:Expanded Demon King Summon list to {0} entries.
+魔王の召喚リストを {0} 件に拡張しました。
+
+:Expanded event map-change list to {0} entries.
+イベントマップ変更リストを {0} 件に拡張しました。
+
+:Expanded game option list to {0} entries.
+ゲームオプションリストを {0} 件に拡張しました。
+
+:Expanded game option order list to {0} slots.
+ゲームオプションの順番リストを {0} スロットに拡張しました。
+
+:Expanded map action animation list to {0} entries.
+マップアクションアニメリストを {0} 件に拡張しました。
+
+:Expanded map setting list to {0} entries.
+マップ設定リストを {0} 件に拡張しました。
+
+:Expanded summon list to {0} entries.
+召喚リストを {0} 件に拡張しました。
+
+:Expanded the spell list to {0} entries.
+スペルリストを {0} 件に拡張しました。
+
+:Export Complete
+エクスポート完了
+
+:Export EA Event
+EAイベントのエクスポート
+
+:Export Texts
+テキストのエクスポート
+
+:Exported map to {0} ({1} chars).
+マップを {0} にエクスポートしました ({1} 文字)。
+
+:Exported to: {0}
+{0} にエクスポートしました。
+
+:Exported {0} OBJ + {1} BG frames to {2}
+{0} 個のOBJと {1} 個のBGフレームを {2} にエクスポートしました。
+
+:FE-Repo-Music import failed: {0}
+FE-Repo-Music のインポートに失敗しました: {0}
+
+:FE8N Ver1 skills are render-only and have no animation to edit in the Animation Creator.
+FE8N Ver1 のスキルは表示専用で、アニメーションクリエイターで編集できるアニメはありません。
+
+:FEditor / SCA_Creator magic-system patch not detected.
+FEditor / SCA_Creator のマジックシステムパッチが検出されませんでした。
+
+:Failed to apply UPS patch ({0}). {1}
+UPSパッチの適用に失敗しました ({0})。{1}
+
+:Failed to convert dark map image to bitmap.
+ダークマップ画像のビットマップ変換に失敗しました。
+
+:Failed to encode the icon tile data.
+アイコンのタイルデータのエンコードに失敗しました。
+
+:Failed to load image from: {0}
+{0} から画像を読み込めませんでした。
+
+:Failed to load the border image.
+枠画像の読み込みに失敗しました。
+
+:Failed to load the border name image.
+枠の名前画像の読み込みに失敗しました。
+
+:Failed to open ROM: {0}
+ROMを開けませんでした: {0}
+
+:Failed to save patched ROM ({0}). {1}
+パッチ適用済みROMの保存に失敗しました ({0})。{1}
+
+:Failed to write the icon to ROM; rolled back.
+アイコンのROMへの書き込みに失敗しました。ロールバックしました。
+
+:File size {0} -> {1} ({2}%)\r\nDPCM quality SNR: {3}dB (higher is better; below 20dB you may not want compression).
+ファイルサイズ {0} -> {1} ({2}%)\r\nDPCM品質 SNR: {3}dB (高いほど良い。20dB未満では圧縮しない方が良い場合があります)。
+
+:File size {0} -> {1} ({2}%) (raw 8-bit PCM)
+ファイルサイズ {0} -> {1} ({2}%) (生の8bit PCM)
+
+:Frame-data pointer 0x{0:X} is outside the ROM.
+フレームデータのポインタ 0x{0:X} はROMの範囲外です。
+
+:Free area: cannot scan (text-reference data not ready)
+空き領域: スキャンできません (テキスト参照データが未準備)
+
+:GBA ROMs
+GBA ROM
+
+:Game option list expansion failed.
+ゲームオプションリストの拡張に失敗しました。
+
+:Game option list expansion failed: {0}
+ゲームオプションリストの拡張に失敗しました: {0}
+
+:Game option order count address is unset for this ROM version.
+このROMバージョンではゲームオプションの順番の件数アドレスが未設定です。
+
+:Game option order count is a single byte; the maximum is 255.
+ゲームオプションの順番の件数は1バイトのため、最大は255です。
+
+:Game option order list expansion failed: {0}
+ゲームオプションの順番リストの拡張に失敗しました: {0}
+
+:Game option order list pointer is unset for this ROM version.
+このROMバージョンではゲームオプションの順番リストのポインタが未設定です。
+
+:Generated {0} byte(s).
+{0} バイトを生成しました。
+
+:Generation failed.
+生成に失敗しました。
+
+:Home
+ホーム
+
+:ID 0 is reserved as null data.
+ID 0 はnullデータとして予約されています。
+
+:Icon address is out of range; aborting import.
+アイコンのアドレスが範囲外です。インポートを中止します。
+
+:Image loader is null.
+画像ローダーがnullです。
+
+:Image must be 16x16 pixels.
+画像は16x16ピクセルである必要があります。
+
+:Image pixel data is missing or too short.
+画像のピクセルデータがないか短すぎます。
+
+:Import Class CSV
+クラスCSVのインポート
+
+:Import Classes CSV
+クラスCSVのインポート
+
+:Import Complete
+インポート完了
+
+:Import magic animation script
+マジックアニメスクリプトのインポート
+
+:Import this WAV as a new one-track song? This appends a sample, a 
+このWAVを新しい1トラックのソングとしてインポートしますか? これによりサンプルが1つ追加されます 
+
+:Import this instrument set and point the selected song at it? This 
+この音色セットをインポートして、選択したソングをそれに向けますか? これにより 
+
+:Imported map from {0} ({1}x{2} tiles).
+{0} からマップをインポートしました ({1}x{2} タイル)。
+
+:Imported: {0}
+インポートしました: {0}
+
+:Instrument Set
+音色セット
+
+:Instrument selection failed: {0}
+音色の選択に失敗しました: {0}
+
+:Instrument set import failed.
+音色セットのインポートに失敗しました。
+
+:Instrument set import failed: {0}
+音色セットのインポートに失敗しました: {0}
+
+:Instrument set imported at 0x{0:X08}.
+音色セットを 0x{0:X08} にインポートしました。
+
+:Internal error: missing ROM or editor context.
+内部エラー: ROMまたはエディタのコンテキストがありません。
+
+:Invalid palette address
+不正なパレットアドレス
+
+:Item source updated. Project needs rebuild.
+アイテムのソースを更新しました。プロジェクトの再ビルドが必要です。
+
+:JASC-PAL (Aseprite/GIMP)
+JASC-PAL (Aseprite/GIMP)
+
+:LDR pointer search returned no hits. Falling back to a raw 4-byte binary pointer scan (may match unrelated bytes). Continue?
+LDRポインタ検索で該当がありませんでした。生の4バイトバイナリポインタスキャンにフォールバックします (無関係なバイトに一致する可能性があります)。続行しますか?
+
+:List expansion failed (out of free space?).
+リストの拡張に失敗しました (空き領域不足?)。
+
+:Load Road Data
+道路データの読み込み
+
+:Loaded (Write to apply).
+読み込みました (適用するには書き込んでください)。
+
+:MIDI Files
+MIDIファイル
+
+:MIDI import failed: {0}
+MIDIのインポートに失敗しました: {0}
+
+:Magic Animation (CSA) #{0:X2}
+マジックアニメ (CSA) #{0:X2}
+
+:Magic Animation (FEditor) #{0:X2}
+マジックアニメ (FEditor) #{0:X2}
+
+:Magic Animation (no comments)
+マジックアニメ (コメントなし)
+
+:Magic Animation (with comments)
+マジックアニメ (コメントあり)
+
+:Magic animation import failed: {0}
+マジックアニメのインポートに失敗しました: {0}
+
+:Magic animation imported successfully.
+マジックアニメのインポートに成功しました。
+
+:Magic animation scan failed — bad frame-data pointer.
+マジックアニメのスキャンに失敗しました — フレームデータのポインタが不正です。
+
+:Magic system not detected.
+マジックシステムが検出されませんでした。
+
+:Map Action Animation Script
+マップアクションアニメスクリプト
+
+:Map action animation table not found in this ROM.
+このROMにはマップアクションアニメテーブルが見つかりません。
+
+:Map data is invalid or too small.
+マップデータが不正か小さすぎます。
+
+:Map setting list expansion failed.
+マップ設定リストの拡張に失敗しました。
+
+:Map setting list expansion failed: {0}
+マップ設定リストの拡張に失敗しました: {0}
+
+:Move 0x{0:X} bytes from 0x{1:X8} to 0x{2:X8}{3}?
+0x{0:X} バイトを 0x{1:X8} から 0x{2:X8} へ移動しますか?{3}
+
+:Move failed: {0}
+移動に失敗しました: {0}
+
+:Move: FROM is not a valid hex value.
+移動: FROM が正しいHex値ではありません。
+
+:Move: LENGTH 0x{0:X} exceeds 2 MB limit.
+移動: LENGTH 0x{0:X} は 2 MB の上限を超えています。
+
+:Move: LENGTH is 0 (cannot auto-detect length).
+移動: LENGTH が 0 です (長さを自動検出できません)。
+
+:Move: LENGTH is not a valid hex value.
+移動: LENGTH が正しいHex値ではありません。
+
+:Move: TO is not a valid hex value.
+移動: TO が正しいHex値ではありません。
+
+:Move: canceled at final prompt.
+移動: 最終確認でキャンセルされました。
+
+:Move: canceled at pointer-count prompt.
+移動: ポインタ数の確認でキャンセルされました。
+
+:Move: canceled at raw-fallback prompt.
+移動: 生フォールバックの確認でキャンセルされました。
+
+:Move: destination range 0x{0:X8}+0x{1:X} exceeds ROM end.
+移動: 移動先の範囲 0x{0:X8}+0x{1:X} がROMの末尾を超えています。
+
+:Move: moved 0x{0:X} bytes from 0x{1:X8} to 0x{2:X8} ({3} pointers rewritten{4}).
+移動: 0x{0:X} バイトを 0x{1:X8} から 0x{2:X8} へ移動しました ({3} 個のポインタを書き換え{4})。
+
+:Move: no ROM loaded.
+移動: ROMが読み込まれていません。
+
+:Move: pending user confirmation — see prompt.
+移動: ユーザーの確認待ちです — 確認ダイアログを参照してください。
+
+:Move: source 0x{0:X8}+0x{1:X} and destination 0x{2:X8}+0x{1:X} overlap (not supported).
+移動: 移動元 0x{0:X8}+0x{1:X} と移動先 0x{2:X8}+0x{1:X} が重なっています (非対応)。
+
+:Move: source address is 0 (bad base address).
+移動: 移動元アドレスが 0 です (不正なベースアドレス)。
+
+:Move: source range 0x{0:X8}+0x{1:X} exceeds ROM end.
+移動: 移動元の範囲 0x{0:X8}+0x{1:X} がROMの末尾を超えています。
+
+:Move: {0}
+移動: {0}
+
+:NPC Escape Point
+NPCの離脱ポイント
+
+:New Block Talk Group (FE7)
+新規ブロック会話グループ (FE7)
+
+:New count ({0}) exceeds the maximum ({1}).
+新しい件数 ({0}) が最大値 ({1}) を超えています。
+
+:New count ({0}) must be >= current count ({1}).
+新しい件数 ({0}) は現在の件数 ({1}) 以上である必要があります。
+
+:No .updateinfo.txt found for this ROM.
+このROMの .updateinfo.txt が見つかりません。
+
+:No animation context loaded.
+アニメーションのコンテキストが読み込まれていません。
+
+:No animation frames to export.
+エクスポートするアニメフレームがありません。
+
+:No animation is set for this skill.
+このスキルにはアニメが設定されていません。
+
+:No change-data for the selected map (plist 0/0xFF or resolution failed).
+選択したマップの変更データがありません (plist 0/0xFF または解決失敗)。
+
+:No change: new count must be greater than the current count.
+変更なし: 新しい件数は現在の件数より大きい必要があります。
+
+:No entry selected.
+エントリが選択されていません。
+
+:No instrument set (voicegroup) is loaded to import into.
+インポート先となる音色セット (voicegroup) が読み込まれていません。
+
+:No magic frames found at 0x{0:X}.
+0x{0:X} にマジックフレームが見つかりません。
+
+:No magic-animation entry selected.
+マジックアニメのエントリが選択されていません。
+
+:No map data loaded — select a map first.
+マップデータが読み込まれていません — 先にマップを選択してください。
+
+:No map selected.
+マップが選択されていません。
+
+:No renderable animation frames found for this skill at 0x{0:X}.
+このスキルの描画可能なアニメフレームが 0x{0:X} に見つかりません。
+
+:No road data to export.
+エクスポートする道路データがありません。
+
+:No song selected to export.
+エクスポートするソングが選択されていません。
+
+:No song selected to import.
+インポートするソングが選択されていません。
+
+:No source loaded.
+ソースが読み込まれていません。
+
+:No spell list is allocated for this unit.\r\nUse Expand List to allocate one.
+このユニットにはスペルリストが確保されていません。\r\n「リスト拡張」で確保してください。
+
+:No template selected.
+テンプレートが選択されていません。
+
+:No texts were imported. Check the file format.
+テキストがインポートされませんでした。ファイル形式を確認してください。
+
+:No unit is selected.\r\nOpen this editor from the Unit Editor's "Edit Skills" button to assign a unit's scroll/mastery skills.
+ユニットが選択されていません。\r\nユニットエディタの「スキル編集」ボタンからこのエディタを開いて、ユニットのスクロール/マスタリースキルを設定してください。
+
+:No valid animation selected to export.
+エクスポートする有効なアニメが選択されていません。
+
+:No vanilla ROM selected.
+無改造ROMが選択されていません。
+
+:No wave file is loaded.
+WAVEファイルが読み込まれていません。
+
+:Nothing to export.
+エクスポートするものがありません。
+
+:Open Map Action Animation Script
+マップアクションアニメスクリプトを開く
+
+:Open file to encode as base64
+base64としてエンコードするファイルを開く
+
+:Open folder failed: {0}
+フォルダを開けませんでした: {0}
+
+:Open source failed: {0}
+ソースを開けませんでした: {0}
+
+:Open translation file
+翻訳ファイルを開く
+
+:Override JP Font: the Japanese font tables were wiped 
+JPフォントの上書き: 日本語フォントテーブルが消去されました 
+
+:PLIST Split\r\nPLIST tables pack several purposes into one shared array, 
+PLISTの分割\r\nPLISTテーブルは複数の用途を1つの共有配列にまとめています 
+
+:Per-cell TSA editing is not available.
+セル単位のTSA編集は利用できません。
+
+:Pick a destination song from the list first.
+先にリストから対象のソングを選択してください。
+
+:Press Preview to see the conversion result.
+変換結果を確認するにはプレビューを押してください。
+
+:ROM changed during import; aborting.
+インポート中にROMが変更されました。中止します。
+
+:ROM has unsaved modifications. Save first before recompressing? (Pressing No will proceed anyway, which is risky.)
+ROMに未保存の変更があります。再圧縮の前に保存しますか? (いいえを押すとそのまま続行しますが危険です。)
+
+:Recompress failed: {0}
+再圧縮に失敗しました: {0}
+
+:Recompress: canceled by user.
+再圧縮: ユーザーによりキャンセルされました。
+
+:Recompress: no ROM loaded.
+再圧縮: ROMが読み込まれていません。
+
+:Recompress: no savings — all entries already optimally compressed.
+再圧縮: 削減できませんでした — すべてのエントリが既に最適に圧縮されています。
+
+:Recompress: pending user confirmation — see prompt.
+再圧縮: ユーザーの確認待ちです — 確認ダイアログを参照してください。
+
+:Recompress: running (this may take several minutes)...
+再圧縮: 実行中です (数分かかる場合があります)...
+
+:Recompress: save ROM and retry.
+再圧縮: ROMを保存してから再試行してください。
+
+:Recompress: {0} entries recompressed, {1} bytes saved. Heuristic scan — may miss entries WinForms catches.
+再圧縮: {0} 件のエントリを再圧縮し、{1} バイト削減しました。ヒューリスティックなスキャンのため、WinForms版が検出するエントリを見逃す場合があります。
+
+:Reference: {0}
+参照: {0}
+
+:Referenced (event/menu/patch/symbol)
+参照あり (イベント/メニュー/パッチ/シンボル)
+
+:Resolving download URL...
+ダウンロードURLを解決しています...
+
+:Road.BIN
+Road.BIN
+
+:Run LZ77 recompress? This walks the entire ROM (slow) and rewrites any entries that compress smaller. Heuristic scan — may miss entries WinForms catches.
+LZ77の再圧縮を実行しますか? ROM全体を走査し (低速)、より小さく圧縮できるエントリを書き換えます。ヒューリスティックなスキャンのため、WinForms版が検出するエントリを見逃す場合があります。
+
+:Save 3-Way Binary Patch File
+3-Way バイナリパッチファイルの保存
+
+:Save Animation Script
+アニメーションスクリプトの保存
+
+:Save Binary Patch File
+バイナリパッチファイルの保存
+
+:Save CSA magic animation script
+CSAマジックアニメスクリプトの保存
+
+:Save Compressed File
+圧縮ファイルの保存
+
+:Save Decoded File
+デコード済みファイルの保存
+
+:Save Decompressed File
+解凍済みファイルの保存
+
+:Save Graphics Patch
+グラフィックパッチの保存
+
+:Save Map Action Animation
+マップアクションアニメの保存
+
+:Save Road Data
+道路データの保存
+
+:Save Skill Animation
+スキルアニメの保存
+
+:Save Text Dump
+テキストダンプの保存
+
+:Save failed: {0}
+保存に失敗しました: {0}
+
+:Save magic animation script
+マジックアニメスクリプトの保存
+
+:Save the patched ROM anyway?
+それでもパッチ適用済みROMを保存しますか?
+
+:Save translation file
+翻訳ファイルの保存
+
+:Script file is empty or contains no recognized commands.
+スクリプトファイルが空か、認識できるコマンドが含まれていません。
+
+:Select Backup File
+バックアップファイルの選択
+
+:Select Directory
+ディレクトリの選択
+
+:Select MIDI File
+MIDIファイルの選択
+
+:Select SAV File
+SAVファイルの選択
+
+:Select Translation Data File
+翻訳データファイルの選択
+
+:Select a ROM to import a song from
+ソングのインポート元となるROMを選択してください
+
+:Select a map with change-data before expanding.
+拡張する前に、変更データを持つマップを選択してください。
+
+:Select a non-empty entry first.
+先に空でないエントリを選択してください。
+
+:Select a unit first.
+先にユニットを選択してください。
+
+:Skill Animation #{0:X2}
+スキルアニメ #{0:X2}
+
+:Song ID 0 is write-protected (silence song).
+Song ID 0 は書き込み禁止です (無音ソング)。
+
+:Song address is invalid.
+ソングのアドレスが不正です。
+
+:Song conversion failed.
+ソングの変換に失敗しました。
+
+:Song import complete.
+ソングのインポートが完了しました。
+
+:Song track data is corrupt or truncated.
+ソングのトラックデータが破損または途中で切れています。
+
+:Song track table runs past ROM end.
+ソングのトラックテーブルがROMの末尾を超えています。
+
+:Sound room expand aborted: no references were repointed (expected at least the canonical pointer slot).
+サウンドルームの拡張を中止しました: リポイントされた参照がありません (少なくとも正規のポインタスロットが必要です)。
+
+:Sound room expand aborted: the canonical pointer slot (0x{0:X}) was not among the repointed references.
+サウンドルームの拡張を中止しました: 正規のポインタスロット (0x{0:X}) がリポイントされた参照に含まれていませんでした。
+
+:Sound room expand aborted: {0} references would be repointed, exceeding the plausible maximum ({1}) — likely a false-positive match.
+サウンドルームの拡張を中止しました: {0} 個の参照がリポイントされ、妥当な最大値 ({1}) を超えています — 誤検出の可能性があります。
+
+:Sound room table expansion failed.
+サウンドルームテーブルの拡張に失敗しました。
+
+:Sound room table expansion failed: {0}
+サウンドルームテーブルの拡張に失敗しました: {0}
+
+:Source file not found.
+入力ファイルが見つかりません。
+
+:Source file not recorded or not found.
+入力ファイルが記録されていないか見つかりません。
+
+:Split the PLIST tables?\r\n
+PLISTテーブルを分割しますか?\r\n
+
+:Summon list expansion failed.
+召喚リストの拡張に失敗しました。
+
+:Summon list expansion failed: {0}
+召喚リストの拡張に失敗しました: {0}
+
+:Summon unit table is only available on FE8.
+召喚ユニットテーブルはFE8でのみ利用できます。
+
+:TSV Files
+TSVファイル
+
+:Text Patch File
+テキストパッチファイル
+
+:The TSA pointer is not set.
+TSAポインタが設定されていません。
+
+:The UPS patch produced CRC warnings:
+UPSパッチでCRC警告が発生しました:
+
+:The companion name image is missing.\r\nExpected: {0}
+対応する名前画像がありません。\r\n想定: {0}
+
+:The current Demon King Summon count byte (0x{0:X}) is corrupt — cannot expand.
+現在の魔王の召喚数バイト (0x{0:X}) が破損しています — 拡張できません。
+
+:The destination song could not be loaded for import.
+インポート先のソングを読み込めませんでした。
+
+:The downloaded programs will be placed under the app folder.\r\n\r\nContinue?
+ダウンロードしたプログラムはアプリのフォルダ内に配置されます。\r\n\r\n続行しますか?
+
+:The map setting list is already at the maximum of 255 entries; it cannot be expanded further.
+マップ設定リストは既に最大の255件に達しており、これ以上拡張できません。
+
+:The other ROM has not been loaded.
+もう一方のROMが読み込まれていません。
+
+:The selected instrument set address is invalid.
+選択した音色セットのアドレスが不正です。
+
+:The song table has no song header.
+ソングテーブルにソングヘッダがありません。
+
+:The world map border palette is invalid.
+ワールドマップの枠パレットが不正です。
+
+:This AP pattern is not present in this ROM. Import the AP data, or enter the AP pointer manually.
+このAPパターンはこのROMに存在しません。APデータをインポートするか、APポインタを手動で入力してください。
+
+:This ROM has no sound room table.
+このROMにはサウンドルームテーブルがありません。
+
+:This entry has no valid animation pointer.
+このエントリには有効なアニメポインタがありません。
+
+:This item is ROM-only in decomp mode. Edit the source manually and rebuild.
+このアイテムは decomp モードではROM専用です。ソースを手動で編集して再ビルドしてください。
+
+:This item table is ROM-only in decomp mode.
+このアイテムテーブルは decomp モードではROM専用です。
+
+:This template requires the event editor context (map/label) and is not available here.
+このテンプレートはイベントエディタのコンテキスト (マップ/ラベル) を必要とするため、ここでは利用できません。
+
+:This template requires the event editor context and is not available here.
+このテンプレートはイベントエディタのコンテキストを必要とするため、ここでは利用できません。
+
+:This will download an executable from:\r\n{0}\r\n\r\nThe downloaded program will be placed under the app folder.\r\n\r\nContinue?
+以下から実行ファイルをダウンロードします:\r\n{0}\r\n\r\nダウンロードしたプログラムはアプリのフォルダ内に配置されます。\r\n\r\n続行しますか?
+
+:This will download the official Git for Windows installer from:\r\n{0}\r\n\r\nIt will RUN the installer, which may request administrator (UAC) elevation.\r\n\r\nContinue?
+以下から公式の Git for Windows インストーラーをダウンロードします:\r\n{0}\r\n\r\nインストーラーを実行します。管理者 (UAC) 昇格を要求する場合があります。\r\n\r\n続行しますか?
+
+:To display chapter titles as text (required before wiping the Japanese 
+章タイトルをテキストとして表示するため (日本語を消去する前に必要) 
+
+:Track is invalid.
+トラックが不正です。
+
+:Transplant this song (#{0}) from the other ROM into the current ROM (#{1})?
+このソング (#{0}) をもう一方のROMから現在のROM (#{1}) に移植しますか?
+
+:Update cancelled (CRC warning declined). No ROM written.
+更新をキャンセルしました (CRC警告を拒否)。ROMは書き込まれていません。
+
+:Update cancelled.
+更新をキャンセルしました。
+
+:Update check failed (missing CHECK_URL/CHECK_REGEX or unreachable).
+更新チェックに失敗しました (CHECK_URL/CHECK_REGEX がないか、接続できません)。
+
+:Update complete.
+更新が完了しました。
+
+:Update complete. Reopening ROM...
+更新が完了しました。ROMを再度開いています...
+
+:Update failed: {0}
+更新に失敗しました: {0}
+
+:Warning: unsaved changes are not stored in the ROM. Update anyway?
+警告: 未保存の変更はROMに保存されていません。それでも更新しますか?
+
+:Wave conversion failed.
+WAVEの変換に失敗しました。
+
+:Wave conversion failed: {0}
+WAVEの変換に失敗しました: {0}
+
+:Wave export failed: {0}
+WAVEのエクスポートに失敗しました: {0}
+
+:Wave exported to {0}
+WAVEを {0} にエクスポートしました。
+
+:Wave imported as a new song at 0x{0:X08}.
+WAVEを新しいソングとして 0x{0:X08} にインポートしました。
+
+:Wave imported. The sample pointer is now 0x{0:X08}.
+WAVEをインポートしました。サンプルポインタは 0x{0:X08} になりました。
+
+:World map table pointer not found in this ROM.
+このROMにはワールドマップテーブルのポインタが見つかりません。
+
+:Wrote {0} frames to ROM at 0x{1:X}.
+{0} フレームをROMの 0x{1:X} に書き込みました。
+
+:Wrote {0} frames to {1}.
+{0} フレームを {1} に書き出しました。
+
+:You are up to date.
+最新の状態です。
+
+:ZeroClear failed: {0}
+ゼロクリアに失敗しました: {0}
+
+:ZeroClear: FROM is not a valid hex value.
+ゼロクリア: FROM が正しいHex値ではありません。
+
+:ZeroClear: TO is not a valid hex value.
+ゼロクリア: TO が正しいHex値ではありません。
+
+:ZeroClear: address out of ROM bounds.
+ゼロクリア: アドレスがROMの範囲外です。
+
+:ZeroClear: canceled by user.
+ゼロクリア: ユーザーによりキャンセルされました。
+
+:ZeroClear: low address requires confirmation — set ZeroClearConfirmed=true to proceed.
+ゼロクリア: 低位アドレスには確認が必要です — 続行するには ZeroClearConfirmed=true を設定してください。
+
+:ZeroClear: no ROM loaded.
+ゼロクリア: ROMが読み込まれていません。
+
+:ZeroClear: wrote 0 to 0x{0:X8}..0x{1:X8} ({2} bytes).
+ゼロクリア: 0x{0:X8}..0x{1:X8} に 0 を書き込みました ({2} バイト)。
+
+:Zeroing 0x{0:X8}..0x{1:X8} hits a dangerous low-address region (ROM header, fixed tables). Continue?
+0x{0:X8}..0x{1:X8} のゼロ化は危険な低位アドレス領域 (ROMヘッダ、固定テーブル) にかかります。続行しますか?
+
+:{0} pointer reference(s) will be rewritten. Continue?
+{0} 個のポインタ参照が書き換えられます。続行しますか?
+
+:{1} Version:{0}\r\nCopyright: 2017-\r\nLicense: GPLv3\r\n\r\nThis software is open-source free software.\r\nPlease use it freely under GPLv3.
+{1} バージョン:{0}\r\nCopyright: 2017-\r\nLicense: GPLv3\r\n\r\nこのソフトウェアはオープンソースのフリーソフトウェアです。\r\nGPLv3 のもとで自由にお使いください。
+

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -26787,3 +26787,1074 @@ TSA 写入失败：{0}
 
 :Enter the new entry count for the AI pointer table (current: {0}, max: {1}).
 请输入 AI 指针表的新条目数（当前：{0}，最大：{1}）。
+:(No ROM loaded)
+(未加载ROM)
+
+:.s assembled into the song at 0x{0:X08}.
+已将 .s 汇编到位于 0x{0:X08} 的乐曲中。
+
+:.s import failed.
+.s 导入失败。
+
+:.s import failed: {0}
+.s 导入失败: {0}
+
+:2-ROM Diff failed: {0}
+2-ROM 差异比较失败: {0}
+
+:2-ROM Diff: 'other ROM' file not found.
+2-ROM 差异: 找不到“另一个ROM”文件。
+
+:2-ROM Diff: 'other ROM' path required.
+2-ROM 差异: 需要指定“另一个ROM”的路径。
+
+:2-ROM Diff: no ROM loaded.
+2-ROM 差异: 未加载ROM。
+
+:2-ROM Diff: output path required.
+2-ROM 差异: 需要指定输出路径。
+
+:2-ROM Diff: wrote patch file {0}.
+2-ROM 差异: 已写入补丁文件 {0}。
+
+:3-ROM Diff failed: {0}
+3-ROM 差异比较失败: {0}
+
+:3-ROM Diff: ROM A file not found.
+3-ROM 差异: 找不到 ROM A 文件。
+
+:3-ROM Diff: ROM B file not found.
+3-ROM 差异: 找不到 ROM B 文件。
+
+:3-ROM Diff: both A and B paths required.
+3-ROM 差异: 需要同时指定 A 和 B 的路径。
+
+:3-ROM Diff: no ROM loaded.
+3-ROM 差异: 未加载ROM。
+
+:3-ROM Diff: output path required.
+3-ROM 差异: 需要指定输出路径。
+
+:3-ROM Diff: wrote patch file {0}.
+3-ROM 差异: 已写入补丁文件 {0}。
+
+:A virtual ROM cannot be updated.
+无法更新虚拟ROM。
+
+:AI pointer table not found.
+找不到AI指针表。
+
+:Already at the maximum Demon King Summon count ({0}).
+已达到魔王召唤数量的最大值 ({0})。
+
+:Already at the maximum of {0} entries.
+已达到最大条目数 {0}。
+
+:Animated GIF
+动态GIF
+
+:Animation @ 0x{0:X08}
+动画 @ 0x{0:X08}
+
+:Animation Creator{0}
+动画制作器{0}
+
+:Animation Script (.txt)
+动画脚本 (.txt)
+
+:Animation pointer 0x{0:X} is outside the ROM.
+动画指针 0x{0:X} 超出ROM范围。
+
+:Applying UPS patch...
+正在应用UPS补丁...
+
+:Assemble this .s source into the selected song using the chosen 
+使用所选设置将此 .s 源汇编到选定的乐曲中 
+
+:BLANK
+空白
+
+:Back
+返回
+
+:Base64 read failed: {0}
+Base64 读取失败: {0}
+
+:Base64 write failed: {0}
+Base64 写入失败: {0}
+
+:Base64: could not decode (invalid base64).
+Base64: 无法解码（无效的Base64）。
+
+:Base64: encoded {0} bytes.
+Base64: 已编码 {0} 字节。
+
+:Base64: enter base64 text first.
+Base64: 请先输入Base64文本。
+
+:Base64: output path required.
+Base64: 需要指定输出路径。
+
+:Base64: source file not found.
+Base64: 找不到源文件。
+
+:Base64: source path required.
+Base64: 需要指定源文件路径。
+
+:Base64: wrote {0} bytes to {1}.
+Base64: 已将 {0} 字节写入 {1}。
+
+:Battle-screen bulk import supports a single palette bank (max {0} colors). Reduce the image to {0} colors first.
+战斗画面批量导入仅支持单个调色板组（最多 {0} 色）。请先将图像减色到 {0} 色。
+
+:Bulk Import Skill Config
+批量导入技能配置
+
+:Bulk import failed: {0}
+批量导入失败: {0}
+
+:Bulk imported from: {0}
+已从 {0} 批量导入。
+
+:CSA animation scan failed — bad frame-data pointer.
+CSA动画扫描失败 — 帧数据指针无效。
+
+:Cannot expand: change list has 0 records.
+无法扩展: 变更列表有 0 条记录。
+
+:Cannot expand: change list is empty (first byte is 0xFF).
+无法扩展: 变更列表为空（首字节为 0xFF）。
+
+:Cannot expand: change list is empty.
+无法扩展: 变更列表为空。
+
+:Cannot expand: the CHANGE PLIST slot could not be resolved.
+无法扩展: 无法解析 CHANGE PLIST 槽位。
+
+:Cannot expand: the change list appears unterminated (no 0xFF within 256 rows). 
+无法扩展: 变更列表似乎未终止（256 行内没有 0xFF）。 
+
+:Cannot expand: the game option list is already at the maximum of {0} entries.
+无法扩展: 游戏选项列表已达到最大条目数 {0}。
+
+:Cannot expand: the game option list is empty.
+无法扩展: 游戏选项列表为空。
+
+:Cannot expand: the game option order list is empty.
+无法扩展: 游戏选项顺序列表为空。
+
+:Cannot expand: the map setting list is empty.
+无法扩展: 地图设置列表为空。
+
+:Cannot expand: the sound room list is empty (no row 0 to copy).
+无法扩展: 音乐室列表为空（没有可复制的第 0 行）。
+
+:Cannot expand: the summon list is empty.
+无法扩展: 召唤列表为空。
+
+:Cannot open file: {0}
+无法打开文件: {0}
+
+:Cannot open folder: {0}
+无法打开文件夹: {0}
+
+:Cannot resolve the song-table entry for the selected song.
+无法解析所选乐曲的乐曲表条目。
+
+:Cannot write to SongID 0x0.
+无法写入 SongID 0x0。
+
+:Compress failed: {0}
+压缩失败: {0}
+
+:Compress: destination path required.
+压缩: 需要指定目标路径。
+
+:Compress: source file not found.
+压缩: 找不到源文件。
+
+:Compress: source path required.
+压缩: 需要指定源文件路径。
+
+:Compress: wrote {0} bytes to {1}.
+压缩: 已将 {0} 字节写入 {1}。
+
+:Confirm Move
+确认移动
+
+:Confirm Multi-Pointer Move
+确认多指针移动
+
+:Confirm Raw Pointer Fallback
+确认原始指针回退
+
+:Confirm Recompress
+确认重新压缩
+
+:Confirm Zero Clear
+确认清零
+
+:Convert failed: {0}
+转换失败: {0}
+
+:Copied generated hex to clipboard.
+已将生成的十六进制复制到剪贴板。
+
+:Could not install the ChapterNameToText patch.
+无法安装 ChapterNameToText 补丁。
+
+:Could not read the skill palette; aborting import.
+无法读取技能调色板，导入中止。
+
+:Could not resolve a local file path for export.
+无法解析用于导出的本地文件路径。
+
+:Could not resolve the update URL ({0}).
+无法解析更新URL ({0})。
+
+:Could not resolve the update URL ({0}). {1}
+无法解析更新URL ({0})。{1}
+
+:Could not select the destination song for import.
+无法选择导入目标乐曲。
+
+:DPCM compression is available (m4a HQ mixer patch detected).
+可使用DPCM压缩（已检测到 m4a HQ 混音器补丁）。
+
+:DPCM compression requires the m4a HQ mixer patch (not installed); raw 8-bit PCM will be used.
+DPCM压缩需要 m4a HQ 混音器补丁（未安装），将使用原始 8 位 PCM。
+
+:Dark field map is not available (FE8 only).
+暗场地图不可用（仅限FE8）。
+
+:Decompress failed: {0}
+解压失败: {0}
+
+:Decompress: SRC address is not a valid hex value.
+解压: SRC 地址不是有效的十六进制值。
+
+:Decompress: address out of range.
+解压: 地址超出范围。
+
+:Decompress: destination path required.
+解压: 需要指定目标路径。
+
+:Decompress: no ROM loaded.
+解压: 未加载ROM。
+
+:Decompress: source file not found.
+解压: 找不到源文件。
+
+:Decompress: wrote {0} bytes to {1}.
+解压: 已将 {0} 字节写入 {1}。
+
+:Demon King Summon table expansion failed.
+魔王召唤表扩展失败。
+
+:Demon King Summon table expansion failed: {0}
+魔王召唤表扩展失败: {0}
+
+:Demon King Summon table is not available for this ROM.
+此ROM不支持魔王召唤表。
+
+:Download/extract failed ({0}). {1}
+下载/解压失败 ({0})。{1}
+
+:Downloading and extracting...
+正在下载并解压...
+
+:EA Event Files
+EA事件文件
+
+:Edit Battle Data (FE7)
+编辑战斗数据 (FE7)
+
+:Edit Event Function Pointer
+编辑事件函数指针
+
+:Edit Move Data (FE7)
+编辑移动数据 (FE7)
+
+:Edit Palette
+编辑调色板
+
+:Edit Talk Group (FE7)
+编辑对话组 (FE7)
+
+:Enemy Escape Point
+敌方撤离点
+
+:Enter the new Demon King Summon count (current: {0}, max: {1}).
+请输入新的魔王召唤数量（当前: {0}，最大: {1}）。
+
+:Enter the new entry count for the event map-change list (current: {0}, max: 255).
+请输入事件地图变更列表的新条目数（当前: {0}，最大: 255）。
+
+:Enter the new entry count for the map action animation list (current: {0}, max: 255).
+请输入地图动作动画列表的新条目数（当前: {0}，最大: 255）。
+
+:Enter the new game option entry count (current: {0}, max: {1}).
+请输入新的游戏选项条目数（当前: {0}，最大: {1}）。
+
+:Enter the new game option order slot count (current: {0}, max: 255).
+请输入游戏选项顺序的新槽位数（当前: {0}，最大: 255）。
+
+:Enter the new map setting entry count (current: {0}, max: 255).
+请输入新的地图设置条目数（当前: {0}，最大: 255）。
+
+:Enter the new spell-list entry count for this unit (current: {0}, max: {1}).
+请输入该单位法术列表的新条目数（当前: {0}，最大: {1}）。
+
+:Enter the new summon entry count (current: {0}, max: {1}).
+请输入新的召唤条目数（当前: {0}，最大: {1}）。
+
+:Expanded Demon King Summon list to {0} entries.
+已将魔王召唤列表扩展到 {0} 条。
+
+:Expanded event map-change list to {0} entries.
+已将事件地图变更列表扩展到 {0} 条。
+
+:Expanded game option list to {0} entries.
+已将游戏选项列表扩展到 {0} 条。
+
+:Expanded game option order list to {0} slots.
+已将游戏选项顺序列表扩展到 {0} 个槽位。
+
+:Expanded map action animation list to {0} entries.
+已将地图动作动画列表扩展到 {0} 条。
+
+:Expanded map setting list to {0} entries.
+已将地图设置列表扩展到 {0} 条。
+
+:Expanded summon list to {0} entries.
+已将召唤列表扩展到 {0} 条。
+
+:Expanded the spell list to {0} entries.
+已将法术列表扩展到 {0} 条。
+
+:Export Complete
+导出完成
+
+:Export EA Event
+导出EA事件
+
+:Export Texts
+导出文本
+
+:Exported map to {0} ({1} chars).
+已将地图导出到 {0}（{1} 个字符）。
+
+:Exported to: {0}
+已导出到: {0}
+
+:Exported {0} OBJ + {1} BG frames to {2}
+已将 {0} 个OBJ和 {1} 个BG帧导出到 {2}
+
+:FE-Repo-Music import failed: {0}
+FE-Repo-Music 导入失败: {0}
+
+:FE8N Ver1 skills are render-only and have no animation to edit in the Animation Creator.
+FE8N Ver1 技能仅供显示，在动画制作器中没有可编辑的动画。
+
+:FEditor / SCA_Creator magic-system patch not detected.
+未检测到 FEditor / SCA_Creator 魔法系统补丁。
+
+:Failed to apply UPS patch ({0}). {1}
+应用UPS补丁失败 ({0})。{1}
+
+:Failed to convert dark map image to bitmap.
+无法将暗场地图图像转换为位图。
+
+:Failed to encode the icon tile data.
+图标图块数据编码失败。
+
+:Failed to load image from: {0}
+无法从 {0} 加载图像。
+
+:Failed to load the border image.
+加载边框图像失败。
+
+:Failed to load the border name image.
+加载边框名称图像失败。
+
+:Failed to open ROM: {0}
+无法打开ROM: {0}
+
+:Failed to save patched ROM ({0}). {1}
+保存已打补丁的ROM失败 ({0})。{1}
+
+:Failed to write the icon to ROM; rolled back.
+将图标写入ROM失败，已回滚。
+
+:File size {0} -> {1} ({2}%)\r\nDPCM quality SNR: {3}dB (higher is better; below 20dB you may not want compression).
+文件大小 {0} -> {1} ({2}%)\r\nDPCM 质量 SNR: {3}dB（越高越好；低于 20dB 时可能不宜压缩）。
+
+:File size {0} -> {1} ({2}%) (raw 8-bit PCM)
+文件大小 {0} -> {1} ({2}%)（原始 8 位 PCM）
+
+:Frame-data pointer 0x{0:X} is outside the ROM.
+帧数据指针 0x{0:X} 超出ROM范围。
+
+:Free area: cannot scan (text-reference data not ready)
+空闲区域: 无法扫描（文本引用数据尚未就绪）
+
+:GBA ROMs
+GBA ROM
+
+:Game option list expansion failed.
+游戏选项列表扩展失败。
+
+:Game option list expansion failed: {0}
+游戏选项列表扩展失败: {0}
+
+:Game option order count address is unset for this ROM version.
+此ROM版本未设置游戏选项顺序数量地址。
+
+:Game option order count is a single byte; the maximum is 255.
+游戏选项顺序数量为单字节，最大为 255。
+
+:Game option order list expansion failed: {0}
+游戏选项顺序列表扩展失败: {0}
+
+:Game option order list pointer is unset for this ROM version.
+此ROM版本未设置游戏选项顺序列表指针。
+
+:Generated {0} byte(s).
+已生成 {0} 字节。
+
+:Generation failed.
+生成失败。
+
+:Home
+主页
+
+:ID 0 is reserved as null data.
+ID 0 保留为空数据。
+
+:Icon address is out of range; aborting import.
+图标地址超出范围，导入中止。
+
+:Image loader is null.
+图像加载器为空。
+
+:Image must be 16x16 pixels.
+图像必须为 16x16 像素。
+
+:Image pixel data is missing or too short.
+图像像素数据缺失或过短。
+
+:Import Class CSV
+导入职业CSV
+
+:Import Classes CSV
+导入职业CSV
+
+:Import Complete
+导入完成
+
+:Import magic animation script
+导入魔法动画脚本
+
+:Import this WAV as a new one-track song? This appends a sample, a 
+将此 WAV 作为新的单轨乐曲导入吗？这会追加一个采样、一个 
+
+:Import this instrument set and point the selected song at it? This 
+导入此乐器组并将选定的乐曲指向它吗？这会 
+
+:Imported map from {0} ({1}x{2} tiles).
+已从 {0} 导入地图（{1}x{2} 图块）。
+
+:Imported: {0}
+已导入: {0}
+
+:Instrument Set
+乐器组
+
+:Instrument selection failed: {0}
+乐器选择失败: {0}
+
+:Instrument set import failed.
+乐器组导入失败。
+
+:Instrument set import failed: {0}
+乐器组导入失败: {0}
+
+:Instrument set imported at 0x{0:X08}.
+已将乐器组导入到 0x{0:X08}。
+
+:Internal error: missing ROM or editor context.
+内部错误: 缺少ROM或编辑器上下文。
+
+:Invalid palette address
+无效的调色板地址
+
+:Item source updated. Project needs rebuild.
+已更新道具源代码。项目需要重新构建。
+
+:LDR pointer search returned no hits. Falling back to a raw 4-byte binary pointer scan (may match unrelated bytes). Continue?
+LDR 指针搜索没有命中。将回退到原始 4 字节二进制指针扫描（可能匹配到无关字节）。是否继续？
+
+:List expansion failed (out of free space?).
+列表扩展失败（空闲空间不足？）。
+
+:Load Road Data
+加载道路数据
+
+:Loaded (Write to apply).
+已加载（写入以应用）。
+
+:MIDI Files
+MIDI文件
+
+:MIDI import failed: {0}
+MIDI 导入失败: {0}
+
+:Magic Animation (CSA) #{0:X2}
+魔法动画 (CSA) #{0:X2}
+
+:Magic Animation (FEditor) #{0:X2}
+魔法动画 (FEditor) #{0:X2}
+
+:Magic Animation (no comments)
+魔法动画（无注释）
+
+:Magic Animation (with comments)
+魔法动画（带注释）
+
+:Magic animation import failed: {0}
+魔法动画导入失败: {0}
+
+:Magic animation imported successfully.
+魔法动画导入成功。
+
+:Magic animation scan failed — bad frame-data pointer.
+魔法动画扫描失败 — 帧数据指针无效。
+
+:Magic system not detected.
+未检测到魔法系统。
+
+:Map Action Animation Script
+地图动作动画脚本
+
+:Map action animation table not found in this ROM.
+在此ROM中找不到地图动作动画表。
+
+:Map data is invalid or too small.
+地图数据无效或过小。
+
+:Map setting list expansion failed.
+地图设置列表扩展失败。
+
+:Map setting list expansion failed: {0}
+地图设置列表扩展失败: {0}
+
+:Move 0x{0:X} bytes from 0x{1:X8} to 0x{2:X8}{3}?
+将 0x{0:X} 字节从 0x{1:X8} 移动到 0x{2:X8}{3}？
+
+:Move failed: {0}
+移动失败: {0}
+
+:Move: FROM is not a valid hex value.
+移动: FROM 不是有效的十六进制值。
+
+:Move: LENGTH 0x{0:X} exceeds 2 MB limit.
+移动: LENGTH 0x{0:X} 超过 2 MB 上限。
+
+:Move: LENGTH is 0 (cannot auto-detect length).
+移动: LENGTH 为 0（无法自动检测长度）。
+
+:Move: LENGTH is not a valid hex value.
+移动: LENGTH 不是有效的十六进制值。
+
+:Move: TO is not a valid hex value.
+移动: TO 不是有效的十六进制值。
+
+:Move: canceled at final prompt.
+移动: 在最终确认时已取消。
+
+:Move: canceled at pointer-count prompt.
+移动: 在指针数量确认时已取消。
+
+:Move: canceled at raw-fallback prompt.
+移动: 在原始回退确认时已取消。
+
+:Move: destination range 0x{0:X8}+0x{1:X} exceeds ROM end.
+移动: 目标范围 0x{0:X8}+0x{1:X} 超出ROM末尾。
+
+:Move: moved 0x{0:X} bytes from 0x{1:X8} to 0x{2:X8} ({3} pointers rewritten{4}).
+移动: 已将 0x{0:X} 字节从 0x{1:X8} 移动到 0x{2:X8}（重写了 {3} 个指针{4}）。
+
+:Move: no ROM loaded.
+移动: 未加载ROM。
+
+:Move: pending user confirmation — see prompt.
+移动: 等待用户确认 — 请查看提示。
+
+:Move: source 0x{0:X8}+0x{1:X} and destination 0x{2:X8}+0x{1:X} overlap (not supported).
+移动: 源 0x{0:X8}+0x{1:X} 与目标 0x{2:X8}+0x{1:X} 重叠（不支持）。
+
+:Move: source address is 0 (bad base address).
+移动: 源地址为 0（基址无效）。
+
+:Move: source range 0x{0:X8}+0x{1:X} exceeds ROM end.
+移动: 源范围 0x{0:X8}+0x{1:X} 超出ROM末尾。
+
+:Move: {0}
+移动: {0}
+
+:NPC Escape Point
+NPC撤离点
+
+:New Block Talk Group (FE7)
+新建区块对话组 (FE7)
+
+:New count ({0}) exceeds the maximum ({1}).
+新数量 ({0}) 超过最大值 ({1})。
+
+:New count ({0}) must be >= current count ({1}).
+新数量 ({0}) 必须大于等于当前数量 ({1})。
+
+:No .updateinfo.txt found for this ROM.
+找不到此ROM的 .updateinfo.txt。
+
+:No animation context loaded.
+未加载动画上下文。
+
+:No animation frames to export.
+没有可导出的动画帧。
+
+:No animation is set for this skill.
+此技能未设置动画。
+
+:No change-data for the selected map (plist 0/0xFF or resolution failed).
+所选地图没有变更数据（plist 0/0xFF 或解析失败）。
+
+:No change: new count must be greater than the current count.
+无变化: 新数量必须大于当前数量。
+
+:No entry selected.
+未选择条目。
+
+:No instrument set (voicegroup) is loaded to import into.
+没有加载用于导入的乐器组（voicegroup）。
+
+:No magic frames found at 0x{0:X}.
+在 0x{0:X} 处找不到魔法帧。
+
+:No magic-animation entry selected.
+未选择魔法动画条目。
+
+:No map data loaded — select a map first.
+未加载地图数据 — 请先选择一个地图。
+
+:No map selected.
+未选择地图。
+
+:No renderable animation frames found for this skill at 0x{0:X}.
+在 0x{0:X} 处找不到此技能可渲染的动画帧。
+
+:No road data to export.
+没有可导出的道路数据。
+
+:No song selected to export.
+未选择要导出的乐曲。
+
+:No song selected to import.
+未选择要导入的乐曲。
+
+:No source loaded.
+未加载源。
+
+:No spell list is allocated for this unit.\r\nUse Expand List to allocate one.
+此单位未分配法术列表。\r\n请使用“扩展列表”来分配。
+
+:No template selected.
+未选择模板。
+
+:No texts were imported. Check the file format.
+未导入任何文本。请检查文件格式。
+
+:No unit is selected.\r\nOpen this editor from the Unit Editor's "Edit Skills" button to assign a unit's scroll/mastery skills.
+未选择单位。\r\n请从单位编辑器的“编辑技能”按钮打开此编辑器，以设置单位的卷轴/精通技能。
+
+:No valid animation selected to export.
+未选择要导出的有效动画。
+
+:No vanilla ROM selected.
+未选择原版ROM。
+
+:No wave file is loaded.
+未加载wave文件。
+
+:Nothing to export.
+没有可导出的内容。
+
+:Open Map Action Animation Script
+打开地图动作动画脚本
+
+:Open file to encode as base64
+打开要编码为 base64 的文件
+
+:Open folder failed: {0}
+打开文件夹失败: {0}
+
+:Open source failed: {0}
+打开源失败: {0}
+
+:Open translation file
+打开翻译文件
+
+:Override JP Font: the Japanese font tables were wiped 
+覆盖日文字体: 日文字体表已被清除 
+
+:PLIST Split\r\nPLIST tables pack several purposes into one shared array, 
+PLIST 拆分\r\nPLIST 表将多个用途打包到一个共享数组中，
+
+:Palette No {0}
+调色板编号 {0}
+
+:Per-cell TSA editing is not available.
+不支持逐格TSA编辑。
+
+:Pick a destination song from the list first.
+请先从列表中选择目标乐曲。
+
+:Press Preview to see the conversion result.
+按预览以查看转换结果。
+
+:ROM changed during import; aborting.
+导入过程中ROM被更改，已中止。
+
+:ROM has unsaved modifications. Save first before recompressing? (Pressing No will proceed anyway, which is risky.)
+ROM 有未保存的修改。重新压缩前先保存吗？（按“否”仍会继续，这很危险。）
+
+:Recompress failed: {0}
+重新压缩失败: {0}
+
+:Recompress: canceled by user.
+重新压缩: 用户已取消。
+
+:Recompress: no ROM loaded.
+重新压缩: 未加载ROM。
+
+:Recompress: no savings — all entries already optimally compressed.
+重新压缩: 没有节省 — 所有条目均已最优压缩。
+
+:Recompress: pending user confirmation — see prompt.
+重新压缩: 等待用户确认 — 请查看提示。
+
+:Recompress: running (this may take several minutes)...
+重新压缩: 正在运行（可能需要几分钟）...
+
+:Recompress: save ROM and retry.
+重新压缩: 请保存ROM后重试。
+
+:Recompress: {0} entries recompressed, {1} bytes saved. Heuristic scan — may miss entries WinForms catches.
+重新压缩: 重新压缩了 {0} 条条目，节省了 {1} 字节。启发式扫描 — 可能会遗漏 WinForms 版能捕获的条目。
+
+:Reference: {0}
+引用: {0}
+
+:Referenced (event/menu/patch/symbol)
+已引用（事件/菜单/补丁/符号）
+
+:Resolving download URL...
+正在解析下载URL...
+
+:Road.BIN
+Road.BIN
+
+:Run LZ77 recompress? This walks the entire ROM (slow) and rewrites any entries that compress smaller. Heuristic scan — may miss entries WinForms catches.
+运行 LZ77 重新压缩吗？这会遍历整个ROM（较慢）并重写任何能压缩得更小的条目。启发式扫描 — 可能会遗漏 WinForms 版能捕获的条目。
+
+:Save 3-Way Binary Patch File
+保存三方二进制补丁文件
+
+:Save Animation Script
+保存动画脚本
+
+:Save Binary Patch File
+保存二进制补丁文件
+
+:Save CSA magic animation script
+保存CSA魔法动画脚本
+
+:Save Compressed File
+保存压缩文件
+
+:Save Decoded File
+保存解码后的文件
+
+:Save Decompressed File
+保存解压后的文件
+
+:Save Graphics Patch
+保存图形补丁
+
+:Save Map Action Animation
+保存地图动作动画
+
+:Save Road Data
+保存道路数据
+
+:Save Skill Animation
+保存技能动画
+
+:Save Text Dump
+保存文本转储
+
+:Save failed: {0}
+保存失败: {0}
+
+:Save magic animation script
+保存魔法动画脚本
+
+:Save the patched ROM anyway?
+仍要保存已打补丁的ROM吗？
+
+:Save translation file
+保存翻译文件
+
+:Script file is empty or contains no recognized commands.
+脚本文件为空或不包含可识别的命令。
+
+:Select Backup File
+选择备份文件
+
+:Select Directory
+选择目录
+
+:Select MIDI File
+选择MIDI文件
+
+:Select SAV File
+选择SAV文件
+
+:Select Translation Data File
+选择翻译数据文件
+
+:Select a ROM to import a song from
+选择要从中导入乐曲的ROM
+
+:Select a map with change-data before expanding.
+扩展前请先选择带有变更数据的地图。
+
+:Select a non-empty entry first.
+请先选择一个非空条目。
+
+:Select a unit first.
+请先选择一个单位。
+
+:Skill Animation #{0:X2}
+技能动画 #{0:X2}
+
+:Song ID 0 is write-protected (silence song).
+Song ID 0 受写保护（静音乐曲）。
+
+:Song address is invalid.
+乐曲地址无效。
+
+:Song conversion failed.
+乐曲转换失败。
+
+:Song import complete.
+乐曲导入完成。
+
+:Song track data is corrupt or truncated.
+乐曲音轨数据损坏或被截断。
+
+:Song track table runs past ROM end.
+乐曲音轨表超出ROM末尾。
+
+:Sound room expand aborted: no references were repointed (expected at least the canonical pointer slot).
+音乐室扩展已中止: 没有重定向任何引用（至少应有规范的指针槽位）。
+
+:Sound room expand aborted: the canonical pointer slot (0x{0:X}) was not among the repointed references.
+音乐室扩展已中止: 规范的指针槽位 (0x{0:X}) 不在被重定向的引用中。
+
+:Sound room expand aborted: {0} references would be repointed, exceeding the plausible maximum ({1}) — likely a false-positive match.
+音乐室扩展已中止: 将重定向 {0} 个引用，超过合理最大值 ({1}) — 很可能是误匹配。
+
+:Sound room table expansion failed.
+音乐室表扩展失败。
+
+:Sound room table expansion failed: {0}
+音乐室表扩展失败: {0}
+
+:Source file not found.
+找不到源文件。
+
+:Source file not recorded or not found.
+源文件未记录或找不到。
+
+:Split the PLIST tables?\r\n
+拆分 PLIST 表吗？\r\n
+
+:Summon list expansion failed.
+召唤列表扩展失败。
+
+:Summon list expansion failed: {0}
+召唤列表扩展失败: {0}
+
+:Summon unit table is only available on FE8.
+召唤单位表仅在FE8上可用。
+
+:TSV Files
+TSV文件
+
+:Text Patch File
+文本补丁文件
+
+:The TSA pointer is not set.
+未设置TSA指针。
+
+:The UPS patch produced CRC warnings:
+UPS补丁产生了CRC警告:
+
+:The companion name image is missing.\r\nExpected: {0}
+缺少配套的名称图像。\r\n应为: {0}
+
+:The current Demon King Summon count byte (0x{0:X}) is corrupt — cannot expand.
+当前的魔王召唤数量字节 (0x{0:X}) 已损坏 — 无法扩展。
+
+:The destination song could not be loaded for import.
+无法加载用于导入的目标乐曲。
+
+:The downloaded programs will be placed under the app folder.\r\n\r\nContinue?
+下载的程序将被放置在应用文件夹下。\r\n\r\n是否继续？
+
+:The map setting list is already at the maximum of 255 entries; it cannot be expanded further.
+地图设置列表已达到最大 255 条，无法继续扩展。
+
+:The other ROM has not been loaded.
+尚未加载另一个ROM。
+
+:The selected instrument set address is invalid.
+所选乐器组地址无效。
+
+:The song table has no song header.
+乐曲表没有乐曲头。
+
+:The world map border palette is invalid.
+世界地图边框调色板无效。
+
+:This AP pattern is not present in this ROM. Import the AP data, or enter the AP pointer manually.
+此ROM中不存在该AP模式。请导入AP数据，或手动输入AP指针。
+
+:This ROM has no sound room table.
+此ROM没有音乐室表。
+
+:This entry has no valid animation pointer.
+此条目没有有效的动画指针。
+
+:This item is ROM-only in decomp mode. Edit the source manually and rebuild.
+在反编译模式下此项目仅限ROM。请手动编辑源代码并重新构建。
+
+:This item table is ROM-only in decomp mode.
+在反编译模式下此项目表仅限ROM。
+
+:This template requires the event editor context (map/label) and is not available here.
+此模板需要事件编辑器上下文（地图/标签），在此处不可用。
+
+:This template requires the event editor context and is not available here.
+此模板需要事件编辑器上下文，在此处不可用。
+
+:This will download an executable from:\r\n{0}\r\n\r\nThe downloaded program will be placed under the app folder.\r\n\r\nContinue?
+这将从以下位置下载一个可执行文件:\r\n{0}\r\n\r\n下载的程序将被放置在应用文件夹下。\r\n\r\n是否继续？
+
+:This will download the official Git for Windows installer from:\r\n{0}\r\n\r\nIt will RUN the installer, which may request administrator (UAC) elevation.\r\n\r\nContinue?
+这将从以下位置下载官方 Git for Windows 安装程序:\r\n{0}\r\n\r\n它将运行该安装程序，可能会请求管理员 (UAC) 提权。\r\n\r\n是否继续？
+
+:To display chapter titles as text (required before wiping the Japanese 
+要将章节标题显示为文本（在清除日文之前需要）
+
+:Track is invalid.
+音轨无效。
+
+:Transplant this song (#{0}) from the other ROM into the current ROM (#{1})?
+将这首乐曲 (#{0}) 从另一个ROM移植到当前ROM (#{1}) 吗？
+
+:Update cancelled (CRC warning declined). No ROM written.
+已取消更新（已拒绝CRC警告）。未写入ROM。
+
+:Update cancelled.
+已取消更新。
+
+:Update check failed (missing CHECK_URL/CHECK_REGEX or unreachable).
+更新检查失败（缺少 CHECK_URL/CHECK_REGEX 或无法访问）。
+
+:Update complete.
+更新完成。
+
+:Update complete. Reopening ROM...
+更新完成。正在重新打开ROM...
+
+:Update failed: {0}
+更新失败: {0}
+
+:Warning: unsaved changes are not stored in the ROM. Update anyway?
+警告: 未保存的更改不会存入ROM。仍要更新吗？
+
+:Wave conversion failed.
+wave转换失败。
+
+:Wave conversion failed: {0}
+wave转换失败: {0}
+
+:Wave export failed: {0}
+wave导出失败: {0}
+
+:Wave exported to {0}
+已将wave导出到 {0}
+
+:Wave imported as a new song at 0x{0:X08}.
+已将wave作为新乐曲导入到 0x{0:X08}。
+
+:Wave imported. The sample pointer is now 0x{0:X08}.
+wave已导入。采样指针现在是 0x{0:X08}。
+
+:World map table pointer not found in this ROM.
+在此ROM中找不到世界地图表指针。
+
+:Wrote {0} frames to ROM at 0x{1:X}.
+已将 {0} 帧写入ROM的 0x{1:X}。
+
+:Wrote {0} frames to {1}.
+已将 {0} 帧写入 {1}。
+
+:You are up to date.
+已是最新版本。
+
+:ZeroClear failed: {0}
+清零失败: {0}
+
+:ZeroClear: FROM is not a valid hex value.
+清零: FROM 不是有效的十六进制值。
+
+:ZeroClear: TO is not a valid hex value.
+清零: TO 不是有效的十六进制值。
+
+:ZeroClear: address out of ROM bounds.
+清零: 地址超出ROM范围。
+
+:ZeroClear: canceled by user.
+清零: 用户已取消。
+
+:ZeroClear: low address requires confirmation — set ZeroClearConfirmed=true to proceed.
+清零: 低地址需要确认 — 请设置 ZeroClearConfirmed=true 以继续。
+
+:ZeroClear: no ROM loaded.
+清零: 未加载ROM。
+
+:ZeroClear: wrote 0 to 0x{0:X8}..0x{1:X8} ({2} bytes).
+清零: 已向 0x{0:X8}..0x{1:X8} 写入 0（{2} 字节）。
+
+:Zeroing 0x{0:X8}..0x{1:X8} hits a dangerous low-address region (ROM header, fixed tables). Continue?
+对 0x{0:X8}..0x{1:X8} 清零会涉及危险的低地址区域（ROM头、固定表）。是否继续？
+
+:{0} pointer reference(s) will be rewritten. Continue?
+将重写 {0} 个指针引用。是否继续？
+
+:{1} Version:{0}\r\nCopyright: 2017-\r\nLicense: GPLv3\r\n\r\nThis software is open-source free software.\r\nPlease use it freely under GPLv3.
+{1} 版本:{0}\r\nCopyright: 2017-\r\nLicense: GPLv3\r\n\r\n本软件是开源的自由软件。\r\n请在 GPLv3 下自由使用。
+

--- a/docs/avalonia-gaps/README.md
+++ b/docs/avalonia-gaps/README.md
@@ -353,6 +353,36 @@ the report. Top files by untranslated count: `ClassEditorView.axaml`,
 `ItemEditorView.axaml`, `UnitEditorView.axaml` — the same three editors
 where the original issue #356 screenshot showed the symptom.
 
+### Code-literal gate (`R._("...")` in `.cs`) — #1635
+
+The AXAML sweep above only sees attribute values. A large class of user-facing
+status / error / dialog strings instead live as `R._("literal")` calls inside
+Avalonia ViewModels and `.axaml.cs` code-behind (Tool Diff, LZ77 / Base64,
+list-expansion, magic / skill anime import, MIDI / instrument import,
+move-to-free-space prompts, etc.). The AXAML scanner is blind to them, so before
+#1635 ~334 such strings rendered in English under the Japanese / Chinese UI while
+CI stayed green.
+
+`L10nScanner.ScanCodeLiterals(repoRoot, languages)` closes that gap. It:
+
+- Enumerates every `R._("...")` first-string-argument across
+  `FEBuilderGBA.Avalonia/**/*.cs` (skipping `bin/` / `obj/`), decoding C# string
+  escapes (`\r\n`, `\"`, verbatim `@"…"`).
+- Blanks `//`, `///` and `/* */` comments first (`StripCommentsPreservingLayout`)
+  so doc-comment examples and commented-out code never count.
+- Joins each distinct literal against `config/translate/{ja,zh}.txt` via the SAME
+  reverse-English chain the runtime uses, bucketing it
+  Translated / PartiallyTranslated / Untranslated / NonEnglish (a literal that
+  already contains CJK / Hangul — a WinForms Japanese-source string reused
+  verbatim — is NonEnglish, i.e. out of scope).
+
+The blocking gate is `CodeLiteralL10nCoverageTest` in `FEBuilderGBA.Avalonia.Tests`
+(mirrors the AXAML `L10nCoverageTest`): it asserts **0 PartiallyTranslated** and
+that every **Untranslated** literal is in a small, justified allowlist
+(URL / format-brand placeholders only). This runs under the project's `dotnet test`
+in `check.yml` + `crossplatform.yml`, so a new untranslated `R._()` string now
+fails CI instead of silently shipping in English.
+
 ## Implementation entry points
 
 | File | Role |
@@ -365,7 +395,8 @@ where the original issue #356 screenshot showed the symptom.
 | `FEBuilderGBA.Avalonia/GapSweep/JumpParityScanner.cs` | Phase 4 scanner |
 | `FEBuilderGBA.Avalonia/Services/INavigationTargetSource.cs` | Phase 4 manifest seam |
 | `FEBuilderGBA.Avalonia/GapSweep/UndoCoverageScanner.cs` | Phase 5 scanner |
-| `FEBuilderGBA.Avalonia/GapSweep/L10nScanner.cs` | Phase 6 scanner |
+| `FEBuilderGBA.Avalonia/GapSweep/L10nScanner.cs` | Phase 6 scanner (AXAML literals + `ScanCodeLiterals` `R._()` `.cs` sweep, #1635) |
+| `FEBuilderGBA.Avalonia.Tests/CodeLiteralL10nCoverageTest.cs` | Blocking gate for `R._()` `.cs` literals (#1635) |
 | `FEBuilderGBA.Avalonia/App.axaml.cs` | CLI flag plumbing (see `RunGapSweep`) |
 | `scripts/make-screenshots.ps1` | Phase 3 wrapper — drives both `--screenshot-all` runners then `--gap-sweep-gallery` |
 | `FEBuilderGBA.Avalonia.Tests/GapSweep/` | xunit coverage |


### PR DESCRIPTION
## Summary

Closes #1635.

~334 user-facing `R._("...")` status / error / dialog strings inside Avalonia ViewModels and `.axaml.cs` code-behind (Tool Diff, LZ77 / Base64, list-expansion, magic / skill anime import, MIDI / instrument import, move-to-free-space prompts, etc.) had no entry in `ja.txt` / `zh.txt` and rendered in English under the Japanese / Chinese UI. The L10n CI gate was blind to them because `L10nScanner` globbed only `Views/**/*.axaml`.

This PR translates the missing strings AND extends the gate to scan `.cs` files.

## Changes

- **`config/translate/{ja,zh}.txt`** — add **358 ja** + **357 zh** entries (keyed by the exact English literal; format placeholders `{0}` / `{0:X08}` and `\r\n` escapes preserved byte-identically; pure additions, 0 deletions). The 24 CJK-source literals reused verbatim from WinForms are out of scope (`NonEnglish` — already correct in JP mode and already have zh).
- **`L10nScanner.ScanCodeLiterals(repoRoot, languages)`** — new sibling scanner enumerating every `R._("literal")` across `FEBuilderGBA.Avalonia/**/*.cs` (skips `bin/`/`obj/`), decoding C# escapes + verbatim `@"..."`, blanking `//` / `///` / `/* */` comments via `StripCommentsPreservingLayout` (so doc-comment examples never false-flag), then joining each literal through the **same reverse-en chain** the AXAML sweep + runtime use. Buckets Translated / PartiallyTranslated / Untranslated / NonEnglish.
- **`CodeLiteralL10nCoverageTest`** (blocking gate, mirrors `L10nCoverageTest`) — asserts **0 PartiallyTranslated** and that every **Untranslated** literal is in a small justified allowlist. A self-guard test proves the gate would have caught the issue's examples (`2-ROM Diff: no ROM loaded.`, etc.). Runs under the project's `dotnet test` in `check.yml` + `crossplatform.yml`.
- **`L10nScannerTests`** — 12 unit tests for `ScanCodeLiterals` / `ReadCsStringLiteral` / `StripCommentsPreservingLayout` (CJK detection, escape decoding, line/block/doc-comment exclusion, partial/untranslated buckets, end-to-end over the repo).
- **`docs/avalonia-gaps/README.md`** — document the code-literal gate.

## Key-parity evidence (counts before / after)

Reproduced the issue's set-diff over distinct `R._()` literals (1420 distinct) resolved against `ja.txt`/`zh.txt` via the runtime chain:

| Metric | Before | After |
|---|---:|---:|
| Missing ja | 382 | 26* |
| Missing zh | 355 | 2* |
| Missing **both** | 354 | 2* |
| Substantive English-source literals translated | 0 / 359 | **359 / 359** |

\* The residual after-counts are the **24 CJK-source** Japanese literals (`NonEnglish`, out of scope) + **0** real English gaps. The 2 "missing both" are doc-comment `R._("literal")` / `R._("...")` examples inside the scanner's own file, which the comment-stripping in `ScanCodeLiterals` correctly excludes — so the gate (which strips comments) reports **0** real gaps. Verified: the `CodeLiteralL10nCoverageTest` gate passes against the real shipped translate files.

Translate-file well-formedness: appended regions parse to 358 ja + 357 zh entries with **0 malformed**; all pre-existing malformed/dup lines are below the old EOF boundary (untouched).

## Test plan

- [x] `L10nScannerTests` (incl. 12 new `ScanCodeLiterals` tests) — PASS
- [x] `CodeLiteralL10nCoverageTest` (new blocking gate, scans real repo + translate files) — PASS
- [x] `CodeLiteralL10nCoverageTest.Gate_WouldHaveCaught_Issue1635_Examples` (self-guard) — PASS
- [x] `L10nCoverageTest` (existing AXAML gate, unaffected) — PASS
- [x] `EditorDialogLiteralL10nTests` (existing 6-view gate, unaffected) — PASS
- [x] Full L10n suite: **56 / 56 passed**, 0 failed
- [x] `FEBuilderGBA.Avalonia` + `FEBuilderGBA.Avalonia.Tests` build clean (0 errors)
- [x] Key parity verified (counts table above)

## Proof

```
Passed!  - Failed: 0, Passed: 56, Skipped: 0, Total: 56 - FEBuilderGBA.Avalonia.Tests.dll (net9.0)
  Passed CodeLiteralL10nCoverageTest.AvaloniaCodeLiterals_HaveJaAndZhTranslations
  Passed CodeLiteralL10nCoverageTest.Gate_WouldHaveCaught_Issue1635_Examples
```

This is a non-GUI change (Core scanner + translation data + tests); CLI/test output is the proof.

Part of #1628 (release-readiness umbrella).

🤖 Generated with Claude Code (Opus 4.8, 1M context)
