### PR TITLE
fix(log): real string.Format for {N} placeholders + guard (Closes #1637)

### DIFF
--- a/FEBuilderGBA.Avalonia/Services/AutoSaveService.cs
+++ b/FEBuilderGBA.Avalonia/Services/AutoSaveService.cs
@@ -136,7 +136,7 @@ namespace FEBuilderGBA.Avalonia.Services
                 }
                 catch (Exception ex)
                 {
-                    Log.Error("Auto-save failed: {0}", ex.Message);
+                    Log.ErrorF("Auto-save failed: {0}", ex.Message);
                 }
                 finally
                 {

--- a/FEBuilderGBA.Avalonia/Services/ImageExportService.cs
+++ b/FEBuilderGBA.Avalonia/Services/ImageExportService.cs
@@ -70,7 +70,7 @@ namespace FEBuilderGBA.Avalonia.Services
             }
             catch (Exception ex)
             {
-                Log.Error("ImageExportService.SavePngToFile failed: {0}", ex.Message);
+                Log.ErrorF("ImageExportService.SavePngToFile failed: {0}", ex.Message);
                 return false;
             }
         }

--- a/FEBuilderGBA.Avalonia/Services/ImageImportValidator.cs
+++ b/FEBuilderGBA.Avalonia/Services/ImageImportValidator.cs
@@ -206,7 +206,7 @@ namespace FEBuilderGBA.Avalonia.Services
                     Array.Copy(romBackup, rom.Data, romBackup.Length);
 
                     // Clean up temp files
-                    try { File.Delete(tempFile1); } catch (Exception ex) { Log.Error("ImageImportValidator temp file cleanup: {0}", ex.Message); }
+                    try { File.Delete(tempFile1); } catch (Exception ex) { Log.ErrorF("ImageImportValidator temp file cleanup: {0}", ex.Message); }
                 }
             }
             catch (Exception ex)

--- a/FEBuilderGBA.Avalonia/Services/SkillConfigAnimeImportHelper.cs
+++ b/FEBuilderGBA.Avalonia/Services/SkillConfigAnimeImportHelper.cs
@@ -116,7 +116,7 @@ namespace FEBuilderGBA.Avalonia.Services
             }
             catch (Exception ex)
             {
-                Log.Error("SkillConfigAnimeImportHelper.LoadFrameImage: {0}", ex.Message);
+                Log.ErrorF("SkillConfigAnimeImportHelper.LoadFrameImage: {0}", ex.Message);
                 return null;
             }
         }

--- a/FEBuilderGBA.Avalonia/Services/SkillConfigIconIoHelper.cs
+++ b/FEBuilderGBA.Avalonia/Services/SkillConfigIconIoHelper.cs
@@ -148,7 +148,7 @@ namespace FEBuilderGBA.Avalonia.Services
             catch (Exception ex)
             {
                 undo.Rollback();
-                Log.Error("SkillConfigIconIoHelper.ImportIconAsync write failed: {0}", ex.Message);
+                Log.ErrorF("SkillConfigIconIoHelper.ImportIconAsync write failed: {0}", ex.Message);
                 return R._("Failed to write the icon to ROM; rolled back.");
             }
 
@@ -204,7 +204,7 @@ namespace FEBuilderGBA.Avalonia.Services
             }
             catch (Exception ex)
             {
-                Log.Error("SkillConfigIconIoHelper.ExportIconAsync save failed: {0}", ex.Message);
+                Log.ErrorF("SkillConfigIconIoHelper.ExportIconAsync save failed: {0}", ex.Message);
             }
         }
     }

--- a/FEBuilderGBA.Avalonia/ViewModels/BattleTerrainViewerViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/BattleTerrainViewerViewModel.cs
@@ -66,7 +66,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                         tname += (char)b;
                     }
                 }
-                catch (Exception ex) { Log.Error("BattleTerrainViewerViewModel.LoadList terrain name read: {0}", ex.Message); }
+                catch (Exception ex) { Log.ErrorF("BattleTerrainViewerViewModel.LoadList terrain name read: {0}", ex.Message); }
 
                 string name = U.ToHexString(i) + " " + tname;
                 result.Add(new AddrResult(addr, name, i));
@@ -91,7 +91,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                     tname += (char)b;
                 }
             }
-            catch (Exception ex) { Log.Error("BattleTerrainViewerViewModel.LoadBattleTerrain terrain name read: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("BattleTerrainViewerViewModel.LoadBattleTerrain terrain name read: {0}", ex.Message); }
             TerrainName = tname;
 
             NameChar0 = rom.u8(addr + 0);

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageGenericEnemyPortraitViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageGenericEnemyPortraitViewModel.cs
@@ -109,7 +109,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             }
             catch (Exception ex)
             {
-                Log.Error("ImageGenericEnemyPortraitViewModel.RenderPreview failed: {0}", ex.Message);
+                Log.ErrorF("ImageGenericEnemyPortraitViewModel.RenderPreview failed: {0}", ex.Message);
                 return null;
             }
         }

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageMapActionAnimationViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageMapActionAnimationViewModel.cs
@@ -116,7 +116,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 }
                 catch (Exception ex)
                 {
-                    Log.Error("ImageMapActionAnimationViewModel.LoadDefaultNamesFromConfig U-path failed: {0}", ex.Message);
+                    Log.ErrorF("ImageMapActionAnimationViewModel.LoadDefaultNamesFromConfig U-path failed: {0}", ex.Message);
                 }
             }
 
@@ -145,7 +145,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             }
             catch (Exception ex)
             {
-                Log.Error("ImageMapActionAnimationViewModel.LoadDefaultNamesFromConfig fallback failed: {0}", ex.Message);
+                Log.ErrorF("ImageMapActionAnimationViewModel.LoadDefaultNamesFromConfig fallback failed: {0}", ex.Message);
             }
             return dic;
         }

--- a/FEBuilderGBA.Avalonia/ViewModels/ImagePortraitImporterViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImagePortraitImporterViewModel.cs
@@ -72,7 +72,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 }
                 catch (System.Exception ex)
                 {
-                    Log.Error("ImagePortraitImporterViewModel.LoadList portrait name resolve: {0}", ex.Message);
+                    Log.ErrorF("ImagePortraitImporterViewModel.LoadList portrait name resolve: {0}", ex.Message);
                 }
                 result.Add(new AddrResult(addr, name, (uint)i));
             }

--- a/FEBuilderGBA.Avalonia/ViewModels/ImagePortraitViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImagePortraitViewModel.cs
@@ -194,7 +194,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             }
             catch (Exception ex)
             {
-                Log.Error("RefreshFaceImage failed: {0}", ex.Message);
+                Log.ErrorF("RefreshFaceImage failed: {0}", ex.Message);
                 FaceImage = null;
             }
         }
@@ -207,7 +207,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             }
             catch (Exception ex)
             {
-                Log.Error("RefreshMiniPortrait failed: {0}", ex.Message);
+                Log.ErrorF("RefreshMiniPortrait failed: {0}", ex.Message);
                 MiniPortraitImage = null;
             }
         }
@@ -220,7 +220,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             }
             catch (Exception ex)
             {
-                Log.Error("RefreshMouthStrip failed: {0}", ex.Message);
+                Log.ErrorF("RefreshMouthStrip failed: {0}", ex.Message);
                 MouthStripImage = null;
             }
         }
@@ -233,7 +233,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             }
             catch (Exception ex)
             {
-                Log.Error("RefreshEyeStrip failed: {0}", ex.Message);
+                Log.ErrorF("RefreshEyeStrip failed: {0}", ex.Message);
                 EyeStripImage = null;
             }
         }
@@ -246,7 +246,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             }
             catch (Exception ex)
             {
-                Log.Error("RefreshClassCard failed: {0}", ex.Message);
+                Log.ErrorF("RefreshClassCard failed: {0}", ex.Message);
                 ClassCardImage = null;
             }
         }
@@ -295,7 +295,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                     string pname = NameResolver.GetPortraitName((uint)i);
                     if (!string.IsNullOrEmpty(pname)) name += $" {pname}";
                 }
-                catch (Exception ex) { Log.Error("ImagePortraitViewModel.LoadList portrait name resolve: {0}", ex.Message); }
+                catch (Exception ex) { Log.ErrorF("ImagePortraitViewModel.LoadList portrait name resolve: {0}", ex.Message); }
                 result.Add(new AddrResult(addr, name, (uint)i));
             }
             ReadCount = (uint)result.Count;

--- a/FEBuilderGBA.Avalonia/ViewModels/OPClassAlphaNameFE6ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/OPClassAlphaNameFE6ViewModel.cs
@@ -78,7 +78,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                                 name = U.ToHexString(i + 1) + " " + resolved;
                         }
                     }
-                    catch (Exception ex) { Log.Error("OPClassAlphaNameFE6ViewModel.LoadList name resolve: {0}", ex.Message); }
+                    catch (Exception ex) { Log.ErrorF("OPClassAlphaNameFE6ViewModel.LoadList name resolve: {0}", ex.Message); }
                 }
                 result.Add(new AddrResult(addr, name, i));
             }
@@ -104,7 +104,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                     if (U.isSafetyOffset(strAddr))
                         AlphaName = rom.getString(strAddr, 64);
                 }
-                catch (Exception ex) { Log.Error("OPClassAlphaNameFE6ViewModel.LoadEntry alpha name read: {0}", ex.Message); }
+                catch (Exception ex) { Log.ErrorF("OPClassAlphaNameFE6ViewModel.LoadEntry alpha name read: {0}", ex.Message); }
             }
             CanWrite = true;
         }

--- a/FEBuilderGBA.Avalonia/ViewModels/OptionsViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/OptionsViewModel.cs
@@ -287,7 +287,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             // Use custom URL if set, otherwise restore default
             string effectiveUrl = string.IsNullOrWhiteSpace(customUrl) ? defaultUrl : customUrl;
             if (!GitUtil.SetSubmoduleRemote(submodulePath, effectiveUrl))
-                Log.Error("Failed to set remote for {0}", submodulePath);
+                Log.ErrorF("Failed to set remote for {0}", submodulePath);
         }
 
         internal static void ReloadTranslations()

--- a/FEBuilderGBA.Avalonia/ViewModels/SoundRoomFE6ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SoundRoomFE6ViewModel.cs
@@ -76,7 +76,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 if (textId > 0 && textId < 0xFFFF)
                     return NameResolver.GetTextById(textId);
             }
-            catch (Exception ex) { Log.Error("SoundRoomFE6ViewModel.GetSongName text resolve: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SoundRoomFE6ViewModel.GetSongName text resolve: {0}", ex.Message); }
             return $"Song {rom.u32(addr):X}";
         }
 

--- a/FEBuilderGBA.Avalonia/ViewModels/StatusParamViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/StatusParamViewModel.cs
@@ -89,7 +89,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                     if (!string.IsNullOrEmpty(resolved))
                         name = U.ToHexString(i) + " " + resolved;
                 }
-                catch (Exception ex) { Log.Error("StatusParamViewModel.LoadList string resolve: {0}", ex.Message); }
+                catch (Exception ex) { Log.ErrorF("StatusParamViewModel.LoadList string resolve: {0}", ex.Message); }
 
                 result.Add(new AddrResult(addr, name, i));
             }
@@ -173,7 +173,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             {
                 StringText = ResolveParamName(rom, addr);
             }
-            catch (Exception ex) { Log.Error("StatusParamViewModel.LoadStatusParam string resolve: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("StatusParamViewModel.LoadStatusParam string resolve: {0}", ex.Message); }
 
             CanWrite = true;
         }

--- a/FEBuilderGBA.Avalonia/ViewModels/TextViewerViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/TextViewerViewModel.cs
@@ -357,7 +357,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                     }
                     catch (Exception ex2)
                     {
-                        Log.Error("TextViewerViewModel.FindCrossReferences union: {0}", ex2.Message);
+                        Log.ErrorF("TextViewerViewModel.FindCrossReferences union: {0}", ex2.Message);
                     }
                 }
 
@@ -373,7 +373,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             }
             catch (Exception ex)
             {
-                Log.Error("TextViewerViewModel.FindCrossReferences: {0}", ex.Message);
+                Log.ErrorF("TextViewerViewModel.FindCrossReferences: {0}", ex.Message);
                 return new List<string>();
             }
         }
@@ -635,7 +635,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                             result.Add(new AddrResult(entryAddr, $"{U.ToHexString(i)} {preview}", i));
                         }
                     }
-                    catch (Exception ex) { Log.Error("TextViewerViewModel.SearchTexts text decode: {0}", ex.Message); }
+                    catch (Exception ex) { Log.ErrorF("TextViewerViewModel.SearchTexts text decode: {0}", ex.Message); }
                 }
                 return result;
             }
@@ -740,7 +740,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             }
             catch (Exception ex)
             {
-                Log.Error("TextViewerViewModel.FindUnreferencedTexts: {0}", ex.Message);
+                Log.ErrorF("TextViewerViewModel.FindUnreferencedTexts: {0}", ex.Message);
                 return new FreeAreaScanResult { IsDefinitive = false };
             }
             return new FreeAreaScanResult { IsDefinitive = true, Results = results };

--- a/FEBuilderGBA.Avalonia/ViewModels/ToolAnimationCreatorViewViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ToolAnimationCreatorViewViewModel.cs
@@ -168,7 +168,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 }
                 catch (System.IO.FileNotFoundException ex)
                 {
-                    Log.Error("ToolAnimationCreator.InitFromFile: file not found: {0}", ex.FileName ?? filename);
+                    Log.ErrorF("ToolAnimationCreator.InitFromFile: file not found: {0}", ex.FileName ?? filename);
                     // Leave VM in a partially-initialised state: AnimationKind /
                     // AnimationId / FileHint are set but Frames is empty.
                     // IsLoaded still flips true so the standalone-open path is

--- a/FEBuilderGBA.Avalonia/ViewModels/ToolLZ77ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ToolLZ77ViewModel.cs
@@ -268,7 +268,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             {
                 if (_undo.HasPendingUndo)
                 {
-                    try { _undo.Rollback(); } catch (Exception rollbackEx) { Log.Error("ZeroClear rollback failed: {0}", rollbackEx.Message); }
+                    try { _undo.Rollback(); } catch (Exception rollbackEx) { Log.ErrorF("ZeroClear rollback failed: {0}", rollbackEx.Message); }
                 }
                 StatusText = R._("ZeroClear failed: {0}", ex.Message);
             }
@@ -472,13 +472,13 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 else
                 {
                     if (_undo.HasPendingUndo)
-                        try { _undo.Rollback(); } catch (Exception rbEx) { Log.Error("Move rollback failed: {0}", rbEx.Message); }
+                        try { _undo.Rollback(); } catch (Exception rbEx) { Log.ErrorF("Move rollback failed: {0}", rbEx.Message); }
                 }
             }
             catch (Exception ex)
             {
                 if (_undo.HasPendingUndo)
-                    try { _undo.Rollback(); } catch (Exception rbEx) { Log.Error("Move rollback failed: {0}", rbEx.Message); }
+                    try { _undo.Rollback(); } catch (Exception rbEx) { Log.ErrorF("Move rollback failed: {0}", rbEx.Message); }
                 StatusText = R._("Move failed: {0}", ex.Message);
                 return new LZ77ToolCore.MoveResult { Ok = false, ErrorMessage = ex.Message };
             }
@@ -574,7 +574,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             catch (Exception ex)
             {
                 if (_undo.HasPendingUndo)
-                    try { _undo.Rollback(); } catch (Exception rbEx) { Log.Error("Recompress rollback failed: {0}", rbEx.Message); }
+                    try { _undo.Rollback(); } catch (Exception rbEx) { Log.ErrorF("Recompress rollback failed: {0}", rbEx.Message); }
                 StatusText = R._("Recompress failed: {0}", ex.Message);
                 return (0, 0);
             }

--- a/FEBuilderGBA.Avalonia/Views/AIASMCALLTALKView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIASMCALLTALKView.axaml.cs
@@ -32,7 +32,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIASMCALLTALKView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("AIASMCALLTALKView.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -51,7 +51,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIASMCALLTALKView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("AIASMCALLTALKView.OnSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -85,7 +85,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("AIASMCALLTALKView.Write failed: {0}", ex.Message);
+                Log.ErrorF("AIASMCALLTALKView.Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/AIASMCoordinateView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIASMCoordinateView.axaml.cs
@@ -32,7 +32,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIASMCoordinateView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("AIASMCoordinateView.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -51,7 +51,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIASMCoordinateView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("AIASMCoordinateView.OnSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -85,7 +85,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("AIASMCoordinateView.Write failed: {0}", ex.Message);
+                Log.ErrorF("AIASMCoordinateView.Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/AIASMRangeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIASMRangeView.axaml.cs
@@ -32,7 +32,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIASMRangeView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("AIASMRangeView.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -51,7 +51,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIASMRangeView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("AIASMRangeView.OnSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -85,7 +85,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("AIASMRangeView.Write failed: {0}", ex.Message);
+                Log.ErrorF("AIASMRangeView.Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/AIMapSettingView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIMapSettingView.axaml.cs
@@ -32,7 +32,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIMapSettingView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("AIMapSettingView.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -51,7 +51,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIMapSettingView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("AIMapSettingView.OnSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -85,7 +85,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("AIMapSettingView.Write failed: {0}", ex.Message);
+                Log.ErrorF("AIMapSettingView.Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/AIPerformItemView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIPerformItemView.axaml.cs
@@ -32,7 +32,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIPerformItemView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("AIPerformItemView.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -51,7 +51,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIPerformItemView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("AIPerformItemView.OnSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -83,7 +83,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("AIPerformItemView.Write failed: {0}", ex.Message);
+                Log.ErrorF("AIPerformItemView.Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/AIPerformStaffView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIPerformStaffView.axaml.cs
@@ -32,7 +32,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIPerformStaffView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("AIPerformStaffView.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -51,7 +51,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIPerformStaffView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("AIPerformStaffView.OnSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -83,7 +83,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("AIPerformStaffView.Write failed: {0}", ex.Message);
+                Log.ErrorF("AIPerformStaffView.Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/AIScriptView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIScriptView.axaml.cs
@@ -100,7 +100,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIScriptView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("AIScriptView.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -123,7 +123,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIScriptView.FilterCombo_SelectionChanged failed: {0}", ex.Message);
+                Log.ErrorF("AIScriptView.FilterCombo_SelectionChanged failed: {0}", ex.Message);
             }
         }
 
@@ -136,7 +136,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIScriptView.Reload_Click failed: {0}", ex.Message);
+                Log.ErrorF("AIScriptView.Reload_Click failed: {0}", ex.Message);
             }
         }
 
@@ -173,7 +173,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIScriptView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("AIScriptView.OnSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -238,7 +238,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("AIScriptView.Write: {0}", ex.Message);
+                Log.ErrorF("AIScriptView.Write: {0}", ex.Message);
             }
         }
 
@@ -266,7 +266,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIScriptView.ReloadList_Click failed: {0}", ex.Message);
+                Log.ErrorF("AIScriptView.ReloadList_Click failed: {0}", ex.Message);
             }
         }
 
@@ -348,13 +348,13 @@ namespace FEBuilderGBA.Avalonia.Views
                 catch (Exception inner)
                 {
                     _undoService.Rollback();
-                    Log.Error("AIScriptView.ListExpand_Click inner failed: {0}", inner.Message);
+                    Log.ErrorF("AIScriptView.ListExpand_Click inner failed: {0}", inner.Message);
                     CoreState.Services?.ShowError(R._("List expansion failed: {0}", inner.Message));
                 }
             }
             catch (Exception ex)
             {
-                Log.Error("AIScriptView.ListExpand_Click failed: {0}", ex.Message);
+                Log.ErrorF("AIScriptView.ListExpand_Click failed: {0}", ex.Message);
             }
         }
 
@@ -375,7 +375,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIScriptView.DisassemblyList_SelectionChanged failed: {0}", ex.Message);
+                Log.ErrorF("AIScriptView.DisassemblyList_SelectionChanged failed: {0}", ex.Message);
             }
         }
 
@@ -557,7 +557,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIScriptView.Update_Click failed: {0}", ex.Message);
+                Log.ErrorF("AIScriptView.Update_Click failed: {0}", ex.Message);
             }
         }
 
@@ -605,7 +605,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIScriptView.New_Click failed: {0}", ex.Message);
+                Log.ErrorF("AIScriptView.New_Click failed: {0}", ex.Message);
             }
         }
 
@@ -633,7 +633,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIScriptView.Remove_Click failed: {0}", ex.Message);
+                Log.ErrorF("AIScriptView.Remove_Click failed: {0}", ex.Message);
             }
         }
 
@@ -691,7 +691,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIScriptView.ScriptChange_Click failed: {0}", ex.Message);
+                Log.ErrorF("AIScriptView.ScriptChange_Click failed: {0}", ex.Message);
             }
         }
 
@@ -709,7 +709,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIScriptView.DetailAddress_Click failed: {0}", ex.Message);
+                Log.ErrorF("AIScriptView.DetailAddress_Click failed: {0}", ex.Message);
             }
         }
 
@@ -748,7 +748,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIScriptView.Export_Click failed: {0}", ex.Message);
+                Log.ErrorF("AIScriptView.Export_Click failed: {0}", ex.Message);
             }
         }
 
@@ -799,7 +799,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIScriptView.Import_Click failed: {0}", ex.Message);
+                Log.ErrorF("AIScriptView.Import_Click failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/AIStealItemView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIStealItemView.axaml.cs
@@ -32,7 +32,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIStealItemView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("AIStealItemView.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -51,7 +51,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIStealItemView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("AIStealItemView.OnSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -81,7 +81,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("AIStealItemView.Write failed: {0}", ex.Message);
+                Log.ErrorF("AIStealItemView.Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/AITargetView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AITargetView.axaml.cs
@@ -32,7 +32,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AITargetView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("AITargetView.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -51,7 +51,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AITargetView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("AITargetView.OnSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -117,7 +117,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("AITargetView.Write failed: {0}", ex.Message);
+                Log.ErrorF("AITargetView.Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/AITilesView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AITilesView.axaml.cs
@@ -32,7 +32,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AITilesView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("AITilesView.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -51,7 +51,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AITilesView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("AITilesView.OnSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -79,7 +79,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("AITilesView.Write failed: {0}", ex.Message);
+                Log.ErrorF("AITilesView.Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/AIUnitsView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIUnitsView.axaml.cs
@@ -32,7 +32,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIUnitsView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("AIUnitsView.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -51,7 +51,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("AIUnitsView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("AIUnitsView.OnSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -81,7 +81,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("AIUnitsView.Write failed: {0}", ex.Message);
+                Log.ErrorF("AIUnitsView.Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ArenaClassViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ArenaClassViewerView.axaml.cs
@@ -53,7 +53,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ArenaClassViewerView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ArenaClassViewerView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -68,7 +68,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ArenaClassViewerView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ArenaClassViewerView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -93,7 +93,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.MarkClean();
                 CoreState.Services?.ShowInfo("Arena Class data written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("ArenaClassViewerView.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("ArenaClassViewerView.Write: {0}", ex.Message); }
         }
 
         // #939: resolve the real class id (u8 at entry+0) for the list icon.
@@ -136,7 +136,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 else
                     WindowManager.Instance.Navigate<ClassEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("ArenaClassViewerView.ClassId_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ArenaClassViewerView.ClassId_Jump failed: {0}", ex.Message); }
         }
 
         async void ClassId_Pick(object? sender, RoutedEventArgs e)
@@ -151,7 +151,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     result = await WindowManager.Instance.PickFromEditor<ClassEditorView>(addr, this);
                 if (result != null) ClassIdBox.Value = (uint)result.Index;
             }
-            catch (Exception ex) { Log.Error("ArenaClassViewerView.ClassId_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ArenaClassViewerView.ClassId_Pick failed: {0}", ex.Message); }
         }
 
         void ClassId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/BattleBGViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/BattleBGViewerView.axaml.cs
@@ -28,7 +28,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             _vm.IsLoading = true;
             try { var items = _vm.LoadBattleBGList(); EntryList.SetItems(items); }
-            catch (Exception ex) { Log.Error("BattleBGViewerView.LoadList: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("BattleBGViewerView.LoadList: {0}", ex.Message); }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
 
@@ -41,7 +41,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 UpdateUI();
                 LoadImage();
             }
-            catch (Exception ex) { Log.Error("BattleBGViewerView.OnSelected: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("BattleBGViewerView.OnSelected: {0}", ex.Message); }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/BattleTerrainViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/BattleTerrainViewerView.axaml.cs
@@ -28,7 +28,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             _vm.IsLoading = true;
             try { var items = _vm.LoadBattleTerrainList(); EntryList.SetItems(items); }
-            catch (Exception ex) { Log.Error("BattleTerrainViewerView.LoadList: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("BattleTerrainViewerView.LoadList: {0}", ex.Message); }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
 
@@ -41,7 +41,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 UpdateUI();
                 LoadImage();
             }
-            catch (Exception ex) { Log.Error("BattleTerrainViewerView.OnSelected: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("BattleTerrainViewerView.OnSelected: {0}", ex.Message); }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/BigCGViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/BigCGViewerView.axaml.cs
@@ -28,7 +28,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             _vm.IsLoading = true;
             try { var items = _vm.LoadBigCGList(); EntryList.SetItems(items); }
-            catch (Exception ex) { Log.Error("BigCGViewerView.LoadList: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("BigCGViewerView.LoadList: {0}", ex.Message); }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
 
@@ -41,7 +41,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 UpdateUI();
                 LoadImage();
             }
-            catch (Exception ex) { Log.Error("BigCGViewerView.OnSelected: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("BigCGViewerView.OnSelected: {0}", ex.Message); }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
 
@@ -66,7 +66,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.MarkClean();
                 CoreState.Services.ShowInfo("Big CG data written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("BigCGViewerView.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("BigCGViewerView.Write: {0}", ex.Message); }
         }
 
         void LoadImage()

--- a/FEBuilderGBA.Avalonia/Views/CCBranchEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/CCBranchEditorView.axaml.cs
@@ -32,7 +32,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("CCBranchEditorView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("CCBranchEditorView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -45,7 +45,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("CCBranchEditorView.OnBranchSelected failed: {0}", ex.Message);
+                Log.ErrorF("CCBranchEditorView.OnBranchSelected failed: {0}", ex.Message);
             }
         }
 
@@ -81,7 +81,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("CCBranchEditorView.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("CCBranchEditorView.Write_Click failed: {0}", ex.Message);
             }
         }
 
@@ -127,7 +127,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("CCBranchEditorView.JumpToClass failed: {0}", ex.Message);
+                Log.ErrorF("CCBranchEditorView.JumpToClass failed: {0}", ex.Message);
             }
         }
 
@@ -148,7 +148,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("CCBranchEditorView.PickClass failed: {0}", ex.Message);
+                Log.ErrorF("CCBranchEditorView.PickClass failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ChapterTitleViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ChapterTitleViewerView.axaml.cs
@@ -28,7 +28,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             _vm.IsLoading = true;
             try { var items = _vm.LoadChapterTitleList(); EntryList.SetItems(items); }
-            catch (Exception ex) { Log.Error("ChapterTitleViewerView.LoadList: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ChapterTitleViewerView.LoadList: {0}", ex.Message); }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
 
@@ -41,7 +41,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 UpdateUI();
                 LoadImage();
             }
-            catch (Exception ex) { Log.Error("ChapterTitleViewerView.OnSelected: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ChapterTitleViewerView.OnSelected: {0}", ex.Message); }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
 
@@ -66,7 +66,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.MarkClean();
                 CoreState.Services.ShowInfo("Chapter Title data written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("ChapterTitleViewerView.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("ChapterTitleViewerView.Write: {0}", ex.Message); }
         }
 
         void LoadImage()

--- a/FEBuilderGBA.Avalonia/Views/ClassEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ClassEditorView.axaml.cs
@@ -97,7 +97,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ClassEditorView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ClassEditorView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -602,7 +602,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("ClassEditorView.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("ClassEditorView.Write_Click failed: {0}", ex.Message);
             }
         }
 
@@ -680,7 +680,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("JumpToMoveCost failed: {0}", ex.Message);
+                Log.ErrorF("JumpToMoveCost failed: {0}", ex.Message);
             }
         }
 
@@ -733,7 +733,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var view = WindowManager.Instance.Open<MoveCostEditorView>();
                 view.NavigateToWithCostType(_vm.CurrentAddr, costType);
             }
-            catch (Exception ex) { Log.Error("JumpToPtr60 failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("JumpToPtr60 failed: {0}", ex.Message); }
         }
 
         void JumpToPtr64_Click(object? sender, RoutedEventArgs e)
@@ -747,7 +747,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var view = WindowManager.Instance.Open<MoveCostEditorView>();
                 view.NavigateToWithCostType(_vm.CurrentAddr, costType);
             }
-            catch (Exception ex) { Log.Error("JumpToPtr64 failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("JumpToPtr64 failed: {0}", ex.Message); }
         }
 
         void JumpToPtr68_Click(object? sender, RoutedEventArgs e)
@@ -761,7 +761,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var view = WindowManager.Instance.Open<MoveCostEditorView>();
                 view.NavigateToWithCostType(_vm.CurrentAddr, costType);
             }
-            catch (Exception ex) { Log.Error("JumpToPtr68 failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("JumpToPtr68 failed: {0}", ex.Message); }
         }
 
         void JumpToPtr72_Click(object? sender, RoutedEventArgs e)
@@ -777,7 +777,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var view = WindowManager.Instance.Open<MoveCostEditorView>();
                 view.NavigateToWithCostType(_vm.CurrentAddr, CostType.TerrainDefense);
             }
-            catch (Exception ex) { Log.Error("JumpToPtr72 failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("JumpToPtr72 failed: {0}", ex.Message); }
         }
 
         void JumpToPtr76_Click(object? sender, RoutedEventArgs e)
@@ -791,7 +791,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var view = WindowManager.Instance.Open<MoveCostEditorView>();
                 view.NavigateToWithCostType(_vm.CurrentAddr, CostType.TerrainResistance);
             }
-            catch (Exception ex) { Log.Error("JumpToPtr76 failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("JumpToPtr76 failed: {0}", ex.Message); }
         }
 
         void JumpToBattleAnime_Click(object? sender, RoutedEventArgs e)
@@ -811,7 +811,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("JumpToBattleAnime failed: {0}", ex.Message);
+                Log.ErrorF("JumpToBattleAnime failed: {0}", ex.Message);
             }
         }
 
@@ -894,7 +894,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EditSkills_Click failed: {0}", ex.Message);
+                Log.ErrorF("EditSkills_Click failed: {0}", ex.Message);
             }
         }
 
@@ -953,7 +953,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("GetAllClassAddresses failed: {0}", ex.Message);
+                Log.ErrorF("GetAllClassAddresses failed: {0}", ex.Message);
                 return Array.Empty<uint>();
             }
         }
@@ -968,7 +968,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (addrs.Length == 0) return;
                 await MakeCsvManager().ExportAllAsync(this, rom, addrs);
             }
-            catch (Exception ex) { Log.Error("ExportAll_Click failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ExportAll_Click failed: {0}", ex.Message); }
         }
 
         async void ExportSelected_Click(object? sender, RoutedEventArgs e)
@@ -986,7 +986,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 uint uid = idx >= 0 ? (uint)idx : 0u;
                 await MakeCsvManager().ExportSelectedAsync(this, rom, _vm.CurrentAddr, uid);
             }
-            catch (Exception ex) { Log.Error("ExportSelected_Click failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ExportSelected_Click failed: {0}", ex.Message); }
         }
 
         async void ImportAll_Click(object? sender, RoutedEventArgs e)
@@ -1015,7 +1015,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     ReloadCurrentClassAfterImport();
                 }
             }
-            catch (Exception ex) { Log.Error("ImportAll_Click failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ImportAll_Click failed: {0}", ex.Message); }
         }
 
         async void ImportSelected_Click(object? sender, RoutedEventArgs e)
@@ -1046,7 +1046,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     ReloadCurrentClassAfterImport();
                 }
             }
-            catch (Exception ex) { Log.Error("ImportSelected_Click failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ImportSelected_Click failed: {0}", ex.Message); }
         }
 
         // ---- #406: Address-bar infrastructure (parity with WF ClassForm) ----
@@ -1077,7 +1077,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     TopBar.SizeText = $"0x{rom.RomInfo.class_datasize:X}";
                 }
             }
-            catch (Exception ex) { Log.Error("ClassEditorView.UpdateAddressBarInfra failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ClassEditorView.UpdateAddressBarInfra failed: {0}", ex.Message); }
         }
 
         // #649: routed event from the unified EditorTopBar Reload button.
@@ -1113,7 +1113,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ClassEditorView.RefreshHardCodingWarning failed: {0}", ex.Message);
+                Log.ErrorF("ClassEditorView.RefreshHardCodingWarning failed: {0}", ex.Message);
                 HardCodingWarningLabel.IsVisible = false;
             }
         }
@@ -1128,7 +1128,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var pv = WindowManager.Instance.Open<PatchManagerView>();
                 pv.JumpTo($"HARDCODING_CLASS={classId:X2}", 0);
             }
-            catch (Exception ex) { Log.Error("ClassEditorView.HardCodingWarning_Click failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ClassEditorView.HardCodingWarning_Click failed: {0}", ex.Message); }
         }
 
         // ---- #406: CC Branch jump (FE8 parity with WF ClassForm.J_5_Click) ----
@@ -1144,7 +1144,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // mirrors WF InputFormRef.JumpForm<CCBranchForm>(SelectedIndex).
                 WindowManager.Instance.Navigate<CCBranchEditorView>((uint)idx);
             }
-            catch (Exception ex) { Log.Error("ClassEditorView.JumpToCCBranch_Click failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ClassEditorView.JumpToCCBranch_Click failed: {0}", ex.Message); }
         }
 
         /// <summary>

--- a/FEBuilderGBA.Avalonia/Views/ClassFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ClassFE6View.axaml.cs
@@ -71,7 +71,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ClassFE6View.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ClassFE6View.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -85,7 +85,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ClassFE6View.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ClassFE6View.OnSelected failed: {0}", ex.Message);
             }
         }
 
@@ -372,7 +372,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ClassFE6View.RefreshHardCodingWarning failed: {0}", ex.Message);
+                Log.ErrorF("ClassFE6View.RefreshHardCodingWarning failed: {0}", ex.Message);
                 HardCodingWarningLabel.IsVisible = false;
             }
         }
@@ -411,7 +411,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ClassFE6View.UpdateAddressBarInfra failed: {0}", ex.Message);
+                Log.ErrorF("ClassFE6View.UpdateAddressBarInfra failed: {0}", ex.Message);
             }
         }
 
@@ -436,7 +436,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("ClassFE6View.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("ClassFE6View.Write_Click failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ClassOPDemoView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ClassOPDemoView.axaml.cs
@@ -159,7 +159,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ClassOPDemoView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ClassOPDemoView.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -181,7 +181,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ClassOPDemoView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ClassOPDemoView.OnSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -306,7 +306,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 else
                     WindowManager.Instance.Navigate<ClassEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("ClassOPDemoView.ClassId_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ClassOPDemoView.ClassId_Jump failed: {0}", ex.Message); }
         }
 
         async void ClassId_Pick(object? sender, RoutedEventArgs e)
@@ -321,7 +321,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     result = await WindowManager.Instance.PickFromEditor<ClassEditorView>(addr, this);
                 if (result != null) DisplayWeaponBox.Value = (uint)result.Index;
             }
-            catch (Exception ex) { Log.Error("ClassOPDemoView.ClassId_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ClassOPDemoView.ClassId_Pick failed: {0}", ex.Message); }
         }
 
         void ClassId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -408,7 +408,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ClassOPDemoView.ApplyN1Rows failed: {0}", ex.Message);
+                Log.ErrorF("ClassOPDemoView.ApplyN1Rows failed: {0}", ex.Message);
             }
         }
 
@@ -428,7 +428,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ClassOPDemoView.OnN1Selected failed: {0}", ex.Message);
+                Log.ErrorF("ClassOPDemoView.OnN1Selected failed: {0}", ex.Message);
             }
             // #1032: refresh the font-glyph image preview from the just-loaded
             // glyph id. Run OUTSIDE the `_vm.IsLoading` gate above so it isn't
@@ -459,7 +459,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ClassOPDemoView.RefreshN1GlyphPreview failed: {0}", ex.Message);
+                Log.ErrorF("ClassOPDemoView.RefreshN1GlyphPreview failed: {0}", ex.Message);
                 N1GlyphPreview?.SetImage(null);
             }
         }
@@ -554,7 +554,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ClassOPDemoView.LoadAnimeShared failed: {0}", ex.Message);
+                Log.ErrorF("ClassOPDemoView.LoadAnimeShared failed: {0}", ex.Message);
             }
         }
 
@@ -612,7 +612,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("ClassOPDemoView.Write failed: {0}", ex.Message);
+                Log.ErrorF("ClassOPDemoView.Write failed: {0}", ex.Message);
                 CoreState.Services?.ShowError(string.Format(R._("Failed to write Class OP Demo entry: {0}"), ex.Message));
             }
         }
@@ -636,7 +636,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("ClassOPDemoView.N1_Write failed: {0}", ex.Message);
+                Log.ErrorF("ClassOPDemoView.N1_Write failed: {0}", ex.Message);
                 CoreState.Services?.ShowError(string.Format(R._("Failed to write JP name font glyph: {0}"), ex.Message));
             }
         }
@@ -665,7 +665,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("ClassOPDemoView.N2_Write failed: {0}", ex.Message);
+                Log.ErrorF("ClassOPDemoView.N2_Write failed: {0}", ex.Message);
                 CoreState.Services?.ShowError(string.Format(R._("Failed to write anime spec tuple: {0}"), ex.Message));
             }
         }
@@ -707,7 +707,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("ClassOPDemoView.N1_WritePtr failed: {0}", ex.Message);
+                Log.ErrorF("ClassOPDemoView.N1_WritePtr failed: {0}", ex.Message);
                 CoreState.Services?.ShowError(string.Format(R._("Failed to write JP name pointer: {0}"), ex.Message));
             }
         }
@@ -745,7 +745,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("ClassOPDemoView.N2_WritePtr failed: {0}", ex.Message);
+                Log.ErrorF("ClassOPDemoView.N2_WritePtr failed: {0}", ex.Message);
                 CoreState.Services?.ShowError(string.Format(R._("Failed to write anime spec pointer: {0}"), ex.Message));
             }
         }
@@ -782,7 +782,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("ClassOPDemoView.N1_ListExpand failed: {0}", ex.Message);
+                Log.ErrorF("ClassOPDemoView.N1_ListExpand failed: {0}", ex.Message);
                 CoreState.Services?.ShowError(string.Format(R._("Failed to expand JP name font block: {0}"), ex.Message));
             }
         }

--- a/FEBuilderGBA.Avalonia/Views/ClassOPFontView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ClassOPFontView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ClassOPFontView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ClassOPFontView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ClassOPFontView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ClassOPFontView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/DecreaseColorTSAToolView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/DecreaseColorTSAToolView.axaml.cs
@@ -103,7 +103,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("DecreaseColorTSAToolView.InputBrowse failed: {0}", ex.Message);
+                Log.ErrorF("DecreaseColorTSAToolView.InputBrowse failed: {0}", ex.Message);
                 _vm.StatusMessage = ex.Message;
             }
         }
@@ -139,7 +139,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("DecreaseColorTSAToolView.OutputBrowse failed: {0}", ex.Message);
+                Log.ErrorF("DecreaseColorTSAToolView.OutputBrowse failed: {0}", ex.Message);
                 _vm.StatusMessage = ex.Message;
             }
         }
@@ -161,7 +161,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 // Keep the low-level/English-only detail in the log; show the
                 // user the standard localized failure status (SetReduceStatus(-1)).
-                Log.Error("DecreaseColorTSAToolView.Reduce failed: {0}", ex.Message);
+                Log.ErrorF("DecreaseColorTSAToolView.Reduce failed: {0}", ex.Message);
                 _vm.SetReduceStatus(-1);
             }
             finally

--- a/FEBuilderGBA.Avalonia/Views/DumpStructSelectDialogView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/DumpStructSelectDialogView.axaml.cs
@@ -62,7 +62,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("DumpStructSelectDialogView.BinaryButton failed: {0}", ex.Message);
+                Log.ErrorF("DumpStructSelectDialogView.BinaryButton failed: {0}", ex.Message);
             }
         }
 
@@ -79,7 +79,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("DumpStructSelectDialogView.CopyPointer failed: {0}", ex.Message);
+                Log.ErrorF("DumpStructSelectDialogView.CopyPointer failed: {0}", ex.Message);
             }
         }
 
@@ -92,7 +92,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("DumpStructSelectDialogView.CopyClipboard failed: {0}", ex.Message);
+                Log.ErrorF("DumpStructSelectDialogView.CopyClipboard failed: {0}", ex.Message);
             }
         }
 
@@ -105,7 +105,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("DumpStructSelectDialogView.CopyLittleEndian failed: {0}", ex.Message);
+                Log.ErrorF("DumpStructSelectDialogView.CopyLittleEndian failed: {0}", ex.Message);
             }
         }
 
@@ -118,7 +118,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("DumpStructSelectDialogView.CopyNoDollGBARadBreakPoint failed: {0}", ex.Message);
+                Log.ErrorF("DumpStructSelectDialogView.CopyNoDollGBARadBreakPoint failed: {0}", ex.Message);
             }
         }
 
@@ -177,7 +177,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("DumpStructSelectDialogView.ExportSelected({0}) failed: {1}", formatName, ex.Message);
+                Log.ErrorF("DumpStructSelectDialogView.ExportSelected({0}) failed: {1}", formatName, ex.Message);
             }
         }
 
@@ -205,7 +205,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("DumpStructSelectDialogView.OpenPreviewDialog({0}) failed: {1}", formatName, ex.Message);
+                Log.ErrorF("DumpStructSelectDialogView.OpenPreviewDialog({0}) failed: {1}", formatName, ex.Message);
             }
         }
 
@@ -235,7 +235,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("DumpStructSelectDialogView.ImportButton failed: {0}", ex.Message);
+                Log.ErrorF("DumpStructSelectDialogView.ImportButton failed: {0}", ex.Message);
             }
         }
 
@@ -259,7 +259,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("DumpStructSelectDialogView.SetClipboardAsync failed: {0}", ex.Message);
+                Log.ErrorF("DumpStructSelectDialogView.SetClipboardAsync failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/DumpStructSelectToTextDialogView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/DumpStructSelectToTextDialogView.axaml.cs
@@ -64,7 +64,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("DumpStructSelectToTextDialogView.Save failed: {0}", ex.Message);
+                Log.ErrorF("DumpStructSelectToTextDialogView.Save failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/EDFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EDFE7View.axaml.cs
@@ -53,13 +53,13 @@ namespace FEBuilderGBA.Avalonia.Views
         void LoadAllLists()
         {
             try { LoadLynList(); }
-            catch (Exception ex) { Log.Error("EDFE7View.LoadLynList failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDFE7View.LoadLynList failed: {0}", ex.Message); }
             try { LoadRetreatList(); }
-            catch (Exception ex) { Log.Error("EDFE7View.LoadRetreatList failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDFE7View.LoadRetreatList failed: {0}", ex.Message); }
             try { LoadEpithetList(); }
-            catch (Exception ex) { Log.Error("EDFE7View.LoadEpithetList failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDFE7View.LoadEpithetList failed: {0}", ex.Message); }
             try { LoadEpilogueList(); }
-            catch (Exception ex) { Log.Error("EDFE7View.LoadEpilogueList failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDFE7View.LoadEpilogueList failed: {0}", ex.Message); }
         }
 
         // ============================================================
@@ -98,7 +98,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EDFE7View.OnLynSelected failed: {0}", ex.Message);
+                Log.ErrorF("EDFE7View.OnLynSelected failed: {0}", ex.Message);
             }
         }
 
@@ -130,7 +130,7 @@ namespace FEBuilderGBA.Avalonia.Views
         void OnLynTopBarReloadRequested(object? sender, RoutedEventArgs e)
         {
             try { LoadLynList(); }
-            catch (Exception ex) { Log.Error("EDFE7View.ReloadLyn failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDFE7View.ReloadLyn failed: {0}", ex.Message); }
         }
 
         void WriteLyn_Click(object? sender, RoutedEventArgs e)
@@ -151,7 +151,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EDFE7View.WriteLyn failed: {0}", ex.Message);
+                Log.ErrorF("EDFE7View.WriteLyn failed: {0}", ex.Message);
             }
         }
 
@@ -163,7 +163,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (addr == 0) return;
                 WindowManager.Instance.Navigate<UnitEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("EDFE7View.LynUnitId_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDFE7View.LynUnitId_Jump failed: {0}", ex.Message); }
         }
 
         async void LynUnitId_Pick(object? sender, RoutedEventArgs e)
@@ -174,7 +174,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var result = await WindowManager.Instance.PickFromEditor<UnitEditorView>(addr, this);
                 if (result != null) Lyn_UnitIdBox.Value = (uint)result.Index + 1;
             }
-            catch (Exception ex) { Log.Error("EDFE7View.LynUnitId_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDFE7View.LynUnitId_Pick failed: {0}", ex.Message); }
         }
 
         void LynUnitId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -216,7 +216,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EDFE7View.OnRetreatSelected failed: {0}", ex.Message);
+                Log.ErrorF("EDFE7View.OnRetreatSelected failed: {0}", ex.Message);
             }
         }
 
@@ -224,7 +224,7 @@ namespace FEBuilderGBA.Avalonia.Views
         void OnRetreatTopBarReloadRequested(object? sender, RoutedEventArgs e)
         {
             try { LoadRetreatList(); }
-            catch (Exception ex) { Log.Error("EDFE7View.ReloadRetreat failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDFE7View.ReloadRetreat failed: {0}", ex.Message); }
         }
 
         void WriteRetreat_Click(object? sender, RoutedEventArgs e)
@@ -246,7 +246,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EDFE7View.WriteRetreat failed: {0}", ex.Message);
+                Log.ErrorF("EDFE7View.WriteRetreat failed: {0}", ex.Message);
             }
         }
 
@@ -269,7 +269,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EDFE7View.ExpandRetreat failed: {0}", ex.Message);
+                Log.ErrorF("EDFE7View.ExpandRetreat failed: {0}", ex.Message);
             }
         }
 
@@ -281,7 +281,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (addr == 0) return;
                 WindowManager.Instance.Navigate<UnitEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("EDFE7View.RetreatUnitId_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDFE7View.RetreatUnitId_Jump failed: {0}", ex.Message); }
         }
 
         async void RetreatUnitId_Pick(object? sender, RoutedEventArgs e)
@@ -292,7 +292,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var result = await WindowManager.Instance.PickFromEditor<UnitEditorView>(addr, this);
                 if (result != null) Retreat_UnitIdBox.Value = (uint)result.Index + 1;
             }
-            catch (Exception ex) { Log.Error("EDFE7View.RetreatUnitId_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDFE7View.RetreatUnitId_Pick failed: {0}", ex.Message); }
         }
 
         void RetreatUnitId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -333,7 +333,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EDFE7View.OnEpithetSelected failed: {0}", ex.Message);
+                Log.ErrorF("EDFE7View.OnEpithetSelected failed: {0}", ex.Message);
             }
         }
 
@@ -353,7 +353,7 @@ namespace FEBuilderGBA.Avalonia.Views
         void OnEpithetTopBarReloadRequested(object? sender, RoutedEventArgs e)
         {
             try { LoadEpithetList(); }
-            catch (Exception ex) { Log.Error("EDFE7View.ReloadEpithet failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDFE7View.ReloadEpithet failed: {0}", ex.Message); }
         }
 
         void WriteEpithet_Click(object? sender, RoutedEventArgs e)
@@ -373,7 +373,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EDFE7View.WriteEpithet failed: {0}", ex.Message);
+                Log.ErrorF("EDFE7View.WriteEpithet failed: {0}", ex.Message);
             }
         }
 
@@ -396,7 +396,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EDFE7View.ExpandEpithet failed: {0}", ex.Message);
+                Log.ErrorF("EDFE7View.ExpandEpithet failed: {0}", ex.Message);
             }
         }
 
@@ -408,7 +408,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (addr == 0) return;
                 WindowManager.Instance.Navigate<UnitEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("EDFE7View.EpithetUnitId_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDFE7View.EpithetUnitId_Jump failed: {0}", ex.Message); }
         }
 
         async void EpithetUnitId_Pick(object? sender, RoutedEventArgs e)
@@ -419,7 +419,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var result = await WindowManager.Instance.PickFromEditor<UnitEditorView>(addr, this);
                 if (result != null) Epithet_UnitIdBox.Value = (uint)result.Index + 1;
             }
-            catch (Exception ex) { Log.Error("EDFE7View.EpithetUnitId_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDFE7View.EpithetUnitId_Pick failed: {0}", ex.Message); }
         }
 
         void EpithetUnitId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -481,7 +481,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EDFE7View.OnEpilogueSelected failed: {0}", ex.Message);
+                Log.ErrorF("EDFE7View.OnEpilogueSelected failed: {0}", ex.Message);
             }
         }
 
@@ -513,14 +513,14 @@ namespace FEBuilderGBA.Avalonia.Views
                 : EDFE7ViewModel.EpilogueRouteKind.Eliwood;
             if (!IsLoaded && CoreState.ROM == null) return;
             try { LoadEpilogueList(); }
-            catch (Exception ex) { Log.Error("EDFE7View.EpilogueFilter_SelectionChanged failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDFE7View.EpilogueFilter_SelectionChanged failed: {0}", ex.Message); }
         }
 
         // #668: routed event from the unified EditorTopBar control.
         void OnEpilogueTopBarReloadRequested(object? sender, RoutedEventArgs e)
         {
             try { LoadEpilogueList(); }
-            catch (Exception ex) { Log.Error("EDFE7View.ReloadEpilogue failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDFE7View.ReloadEpilogue failed: {0}", ex.Message); }
         }
 
         void WriteEpilogue_Click(object? sender, RoutedEventArgs e)
@@ -547,7 +547,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EDFE7View.WriteEpilogue failed: {0}", ex.Message);
+                Log.ErrorF("EDFE7View.WriteEpilogue failed: {0}", ex.Message);
             }
         }
 
@@ -570,7 +570,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EDFE7View.ExpandEpilogue failed: {0}", ex.Message);
+                Log.ErrorF("EDFE7View.ExpandEpilogue failed: {0}", ex.Message);
             }
         }
 
@@ -582,7 +582,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (addr == 0) return;
                 WindowManager.Instance.Navigate<UnitEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("EDFE7View.EpilogueUnitId1_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDFE7View.EpilogueUnitId1_Jump failed: {0}", ex.Message); }
         }
 
         async void EpilogueUnitId1_Pick(object? sender, RoutedEventArgs e)
@@ -593,7 +593,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var result = await WindowManager.Instance.PickFromEditor<UnitEditorView>(addr, this);
                 if (result != null) Epilogue_UnitId1Box.Value = (uint)result.Index + 1;
             }
-            catch (Exception ex) { Log.Error("EDFE7View.EpilogueUnitId1_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDFE7View.EpilogueUnitId1_Pick failed: {0}", ex.Message); }
         }
 
         void EpilogueUnitId1_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -610,7 +610,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (addr == 0) return;
                 WindowManager.Instance.Navigate<UnitEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("EDFE7View.EpilogueUnitId2_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDFE7View.EpilogueUnitId2_Jump failed: {0}", ex.Message); }
         }
 
         async void EpilogueUnitId2_Pick(object? sender, RoutedEventArgs e)
@@ -621,7 +621,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var result = await WindowManager.Instance.PickFromEditor<UnitEditorView>(addr, this);
                 if (result != null) Epilogue_UnitId2Box.Value = (uint)result.Index + 1;
             }
-            catch (Exception ex) { Log.Error("EDFE7View.EpilogueUnitId2_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDFE7View.EpilogueUnitId2_Pick failed: {0}", ex.Message); }
         }
 
         void EpilogueUnitId2_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/EDSensekiCommentView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EDSensekiCommentView.axaml.cs
@@ -35,7 +35,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EDSensekiCommentView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("EDSensekiCommentView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -48,7 +48,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EDSensekiCommentView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("EDSensekiCommentView.OnSelected failed: {0}", ex.Message);
             }
         }
 
@@ -82,7 +82,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EDSensekiCommentView.Write failed: {0}", ex.Message);
+                Log.ErrorF("EDSensekiCommentView.Write failed: {0}", ex.Message);
             }
         }
 
@@ -98,7 +98,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (addr == 0) return;
                 WindowManager.Instance.Navigate<UnitEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("EDSensekiCommentView.UnitId_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDSensekiCommentView.UnitId_Jump failed: {0}", ex.Message); }
         }
 
         async void UnitId_Pick(object? sender, RoutedEventArgs e)
@@ -110,7 +110,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // PickResult.Index is 0-based; UnitId is 1-based (#937).
                 if (result != null) UnitIdBox.Value = SupportUnitNavigation.OneBasedIdFromPickIndex(result.Index);
             }
-            catch (Exception ex) { Log.Error("EDSensekiCommentView.UnitId_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDSensekiCommentView.UnitId_Pick failed: {0}", ex.Message); }
         }
 
         void UnitId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/EDStaffRollView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EDStaffRollView.axaml.cs
@@ -31,7 +31,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EDStaffRollView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("EDStaffRollView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -44,7 +44,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EDStaffRollView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("EDStaffRollView.OnSelected failed: {0}", ex.Message);
             }
         }
 
@@ -72,7 +72,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EDStaffRollView.Write failed: {0}", ex.Message);
+                Log.ErrorF("EDStaffRollView.Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/EDView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EDView.axaml.cs
@@ -50,11 +50,11 @@ namespace FEBuilderGBA.Avalonia.Views
         void LoadAllLists()
         {
             try { LoadRetreatList(); }
-            catch (Exception ex) { Log.Error("EDView.LoadRetreatList failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDView.LoadRetreatList failed: {0}", ex.Message); }
             try { LoadEpithetList(); }
-            catch (Exception ex) { Log.Error("EDView.LoadEpithetList failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDView.LoadEpithetList failed: {0}", ex.Message); }
             try { LoadEpilogueList(); }
-            catch (Exception ex) { Log.Error("EDView.LoadEpilogueList failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDView.LoadEpilogueList failed: {0}", ex.Message); }
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EDView.UpdateEpilogueAvailability failed: {0}", ex.Message);
+                Log.ErrorF("EDView.UpdateEpilogueAvailability failed: {0}", ex.Message);
             }
         }
 
@@ -111,7 +111,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EDView.OnRetreatSelected failed: {0}", ex.Message);
+                Log.ErrorF("EDView.OnRetreatSelected failed: {0}", ex.Message);
             }
         }
 
@@ -119,7 +119,7 @@ namespace FEBuilderGBA.Avalonia.Views
         void OnRetreatTopBarReloadRequested(object? sender, RoutedEventArgs e)
         {
             try { LoadRetreatList(); }
-            catch (Exception ex) { Log.Error("EDView.ReloadRetreat failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDView.ReloadRetreat failed: {0}", ex.Message); }
         }
 
         void WriteRetreat_Click(object? sender, RoutedEventArgs e)
@@ -141,7 +141,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EDView.WriteRetreat failed: {0}", ex.Message);
+                Log.ErrorF("EDView.WriteRetreat failed: {0}", ex.Message);
             }
         }
 
@@ -164,7 +164,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EDView.ExpandRetreat failed: {0}", ex.Message);
+                Log.ErrorF("EDView.ExpandRetreat failed: {0}", ex.Message);
             }
         }
 
@@ -176,7 +176,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (addr == 0) return;
                 WindowManager.Instance.Navigate<UnitEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("EDView.RetreatUnitId_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDView.RetreatUnitId_Jump failed: {0}", ex.Message); }
         }
 
         async void RetreatUnitId_Pick(object? sender, RoutedEventArgs e)
@@ -187,7 +187,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var result = await WindowManager.Instance.PickFromEditor<UnitEditorView>(addr, this);
                 if (result != null) Retreat_UnitIdBox.Value = (uint)result.Index + 1;
             }
-            catch (Exception ex) { Log.Error("EDView.RetreatUnitId_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDView.RetreatUnitId_Pick failed: {0}", ex.Message); }
         }
 
         void RetreatUnitId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -228,7 +228,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EDView.OnEpithetSelected failed: {0}", ex.Message);
+                Log.ErrorF("EDView.OnEpithetSelected failed: {0}", ex.Message);
             }
         }
 
@@ -248,7 +248,7 @@ namespace FEBuilderGBA.Avalonia.Views
         void OnEpithetTopBarReloadRequested(object? sender, RoutedEventArgs e)
         {
             try { LoadEpithetList(); }
-            catch (Exception ex) { Log.Error("EDView.ReloadEpithet failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDView.ReloadEpithet failed: {0}", ex.Message); }
         }
 
         void WriteEpithet_Click(object? sender, RoutedEventArgs e)
@@ -268,7 +268,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EDView.WriteEpithet failed: {0}", ex.Message);
+                Log.ErrorF("EDView.WriteEpithet failed: {0}", ex.Message);
             }
         }
 
@@ -291,7 +291,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EDView.ExpandEpithet failed: {0}", ex.Message);
+                Log.ErrorF("EDView.ExpandEpithet failed: {0}", ex.Message);
             }
         }
 
@@ -303,7 +303,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (addr == 0) return;
                 WindowManager.Instance.Navigate<UnitEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("EDView.EpithetUnitId_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDView.EpithetUnitId_Jump failed: {0}", ex.Message); }
         }
 
         async void EpithetUnitId_Pick(object? sender, RoutedEventArgs e)
@@ -314,7 +314,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var result = await WindowManager.Instance.PickFromEditor<UnitEditorView>(addr, this);
                 if (result != null) Epithet_UnitIdBox.Value = (uint)result.Index + 1;
             }
-            catch (Exception ex) { Log.Error("EDView.EpithetUnitId_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDView.EpithetUnitId_Pick failed: {0}", ex.Message); }
         }
 
         void EpithetUnitId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -380,7 +380,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EDView.OnEpilogueSelected failed: {0}", ex.Message);
+                Log.ErrorF("EDView.OnEpilogueSelected failed: {0}", ex.Message);
             }
         }
 
@@ -417,14 +417,14 @@ namespace FEBuilderGBA.Avalonia.Views
             // Only reload if the entry list has been wired up (post Opened).
             if (!IsLoaded && CoreState.ROM == null) return;
             try { LoadEpilogueList(); }
-            catch (Exception ex) { Log.Error("EDView.EpilogueFilter_SelectionChanged failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDView.EpilogueFilter_SelectionChanged failed: {0}", ex.Message); }
         }
 
         // #668: routed event from the unified EditorTopBar control.
         void OnEpilogueTopBarReloadRequested(object? sender, RoutedEventArgs e)
         {
             try { LoadEpilogueList(); }
-            catch (Exception ex) { Log.Error("EDView.ReloadEpilogue failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDView.ReloadEpilogue failed: {0}", ex.Message); }
         }
 
         void WriteEpilogue_Click(object? sender, RoutedEventArgs e)
@@ -455,7 +455,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EDView.WriteEpilogue failed: {0}", ex.Message);
+                Log.ErrorF("EDView.WriteEpilogue failed: {0}", ex.Message);
             }
         }
 
@@ -478,7 +478,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EDView.ExpandEpilogue failed: {0}", ex.Message);
+                Log.ErrorF("EDView.ExpandEpilogue failed: {0}", ex.Message);
             }
         }
 
@@ -490,7 +490,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (addr == 0) return;
                 WindowManager.Instance.Navigate<UnitEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("EDView.EpilogueUnitId1_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDView.EpilogueUnitId1_Jump failed: {0}", ex.Message); }
         }
 
         async void EpilogueUnitId1_Pick(object? sender, RoutedEventArgs e)
@@ -501,7 +501,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var result = await WindowManager.Instance.PickFromEditor<UnitEditorView>(addr, this);
                 if (result != null) Epilogue_UnitId1Box.Value = (uint)result.Index + 1;
             }
-            catch (Exception ex) { Log.Error("EDView.EpilogueUnitId1_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDView.EpilogueUnitId1_Pick failed: {0}", ex.Message); }
         }
 
         void EpilogueUnitId1_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -518,7 +518,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (addr == 0) return;
                 WindowManager.Instance.Navigate<UnitEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("EDView.EpilogueUnitId2_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDView.EpilogueUnitId2_Jump failed: {0}", ex.Message); }
         }
 
         async void EpilogueUnitId2_Pick(object? sender, RoutedEventArgs e)
@@ -529,7 +529,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var result = await WindowManager.Instance.PickFromEditor<UnitEditorView>(addr, this);
                 if (result != null) Epilogue_UnitId2Box.Value = (uint)result.Index + 1;
             }
-            catch (Exception ex) { Log.Error("EDView.EpilogueUnitId2_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EDView.EpilogueUnitId2_Pick failed: {0}", ex.Message); }
         }
 
         void EpilogueUnitId2_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/EasyModePanel.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EasyModePanel.axaml.cs
@@ -134,7 +134,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EasyExportText failed: {0}", ex.Message);
+                Log.ErrorF("EasyExportText failed: {0}", ex.Message);
                 var topLevel = TopLevel.GetTopLevel(this);
                 if (topLevel is Window w)
                     await MessageBoxWindow.Show(w, $"Export failed: {ex.Message}", "Error", MessageBoxMode.Ok);
@@ -170,7 +170,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EasyImportText failed: {0}", ex.Message);
+                Log.ErrorF("EasyImportText failed: {0}", ex.Message);
                 var topLevel = TopLevel.GetTopLevel(this);
                 if (topLevel is Window w)
                     await MessageBoxWindow.Show(w, $"Import failed: {ex.Message}", "Error", MessageBoxMode.Ok);

--- a/FEBuilderGBA.Avalonia/Views/EventBattleTalkMainView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventBattleTalkMainView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventBattleTalkMainView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("EventBattleTalkMainView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventBattleTalkMainView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("EventBattleTalkMainView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/EventCondMainView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventCondMainView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventCondMainView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("EventCondMainView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventCondMainView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("EventCondMainView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/EventCondView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventCondView.axaml.cs
@@ -107,7 +107,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventCondView.LoadAll failed: {0}", ex.Message);
+                Log.ErrorF("EventCondView.LoadAll failed: {0}", ex.Message);
             }
             finally
             {
@@ -136,7 +136,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventCondView.OnMapSelected failed: {0}", ex.Message);
+                Log.ErrorF("EventCondView.OnMapSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -161,7 +161,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventCondView.OnSlotChanged failed: {0}", ex.Message);
+                Log.ErrorF("EventCondView.OnSlotChanged failed: {0}", ex.Message);
             }
             finally
             {
@@ -223,7 +223,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventCondView.OnRecordSelected failed: {0}", ex.Message);
+                Log.ErrorF("EventCondView.OnRecordSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -718,7 +718,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EventCondView.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("EventCondView.Write_Click failed: {0}", ex.Message);
             }
         }
 
@@ -836,7 +836,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EventCondView.ExpandList_Click failed: {0}", ex.Message);
+                Log.ErrorF("EventCondView.ExpandList_Click failed: {0}", ex.Message);
             }
         }
 
@@ -863,7 +863,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EventCondView.NewAlloc_Click failed: {0}", ex.Message);
+                Log.ErrorF("EventCondView.NewAlloc_Click failed: {0}", ex.Message);
             }
         }
 
@@ -998,7 +998,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EventCondView.PreciseAlloc_Click failed: {0}", ex.Message);
+                Log.ErrorF("EventCondView.PreciseAlloc_Click failed: {0}", ex.Message);
             }
         }
 
@@ -1053,7 +1053,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventCondView.Reload_Click failed: {0}", ex.Message);
+                Log.ErrorF("EventCondView.Reload_Click failed: {0}", ex.Message);
             }
         }
 
@@ -1090,7 +1090,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (addr == 0) return;
                 WindowManager.Instance.Navigate<UnitEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("EventCondView.JumpToUnitEditor failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EventCondView.JumpToUnitEditor failed: {0}", ex.Message); }
         }
 
         async System.Threading.Tasks.Task PickUnitInto(IdFieldControl box)
@@ -1102,7 +1102,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (result != null)
                     box.Value = SupportUnitNavigation.OneBasedIdFromPickIndex(result.Index);
             }
-            catch (Exception ex) { Log.Error("EventCondView.PickUnitInto failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EventCondView.PickUnitInto failed: {0}", ex.Message); }
         }
 
         void Unit1_Jump(object? sender, RoutedEventArgs e) => JumpToUnitEditor(Unit1Box);
@@ -1140,7 +1140,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 else
                     WindowManager.Instance.Navigate<ItemEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("EventCondView.ChestItem_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EventCondView.ChestItem_Jump failed: {0}", ex.Message); }
         }
 
         async void ChestItem_Pick(object? sender, RoutedEventArgs e)
@@ -1155,7 +1155,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     result = await WindowManager.Instance.PickFromEditor<ItemEditorView>(addr, this);
                 if (result != null) ChestItemBox.Value = (uint)result.Index;
             }
-            catch (Exception ex) { Log.Error("EventCondView.ChestItem_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EventCondView.ChestItem_Pick failed: {0}", ex.Message); }
         }
 
         void ChestItem_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -1180,7 +1180,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 uint addr = EditorJumpAddressHelper.TextRowAddrFor(CoreState.ROM, TextIdBox.Value);
                 if (addr != 0) WindowManager.Instance.Navigate<TextViewerView>(addr);
             }
-            catch (Exception ex) { Log.Error("EventCondView.TutorialTextId_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("EventCondView.TutorialTextId_Jump failed: {0}", ex.Message); }
         }
 
         void TutorialTextId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/EventFunctionPointerFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventFunctionPointerFE7View.axaml.cs
@@ -31,7 +31,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventFunctionPointerFE7View.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("EventFunctionPointerFE7View.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -44,7 +44,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventFunctionPointerFE7View.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("EventFunctionPointerFE7View.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/EventFunctionPointerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventFunctionPointerView.axaml.cs
@@ -76,7 +76,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventFunctionPointerView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("EventFunctionPointerView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -89,7 +89,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventFunctionPointerView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("EventFunctionPointerView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/EventMapChangeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventMapChangeView.axaml.cs
@@ -62,7 +62,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventMapChangeView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("EventMapChangeView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -91,7 +91,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventMapChangeView.MapListBox_SelectionChanged failed: {0}", ex.Message);
+                Log.ErrorF("EventMapChangeView.MapListBox_SelectionChanged failed: {0}", ex.Message);
             }
         }
 
@@ -108,7 +108,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventMapChangeView.OnEntrySelected failed: {0}", ex.Message);
+                Log.ErrorF("EventMapChangeView.OnEntrySelected failed: {0}", ex.Message);
             }
         }
 
@@ -216,7 +216,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EventMapChangeView.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("EventMapChangeView.Write_Click failed: {0}", ex.Message);
                 CoreState.Services?.ShowError($"Write failed: {ex.Message}");
             }
         }
@@ -331,13 +331,13 @@ namespace FEBuilderGBA.Avalonia.Views
                 catch (Exception inner)
                 {
                     _undoService.Rollback();
-                    Log.Error("EventMapChangeView.PointerImport inner failed: {0}", inner.Message);
+                    Log.ErrorF("EventMapChangeView.PointerImport inner failed: {0}", inner.Message);
                     CoreState.Services?.ShowError(R._("Pointer import failed: {0}", inner.Message));
                 }
             }
             catch (Exception ex)
             {
-                Log.Error("EventMapChangeView.PointerImport_Click failed: {0}", ex.Message);
+                Log.ErrorF("EventMapChangeView.PointerImport_Click failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/EventScriptInnerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventScriptInnerView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventScriptInnerView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("EventScriptInnerView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventScriptInnerView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("EventScriptInnerView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/EventScriptMainView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventScriptMainView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventScriptMainView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("EventScriptMainView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventScriptMainView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("EventScriptMainView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/EventTalkGroupFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventTalkGroupFE7View.axaml.cs
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventTalkGroupFE7View.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("EventTalkGroupFE7View.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -55,7 +55,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventTalkGroupFE7View.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("EventTalkGroupFE7View.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/EventUnitFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventUnitFE6View.axaml.cs
@@ -52,7 +52,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitFE6View.LoadMapList failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitFE6View.LoadMapList failed: {0}", ex.Message);
             }
         }
 
@@ -78,7 +78,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitFE6View.MapListBox_SelectionChanged failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitFE6View.MapListBox_SelectionChanged failed: {0}", ex.Message);
             }
         }
 
@@ -94,7 +94,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitFE6View.GroupListBox_SelectionChanged failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitFE6View.GroupListBox_SelectionChanged failed: {0}", ex.Message);
             }
         }
 
@@ -123,7 +123,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitFE6View.UnitListBox_SelectionChanged failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitFE6View.UnitListBox_SelectionChanged failed: {0}", ex.Message);
             }
         }
 
@@ -135,14 +135,14 @@ namespace FEBuilderGBA.Avalonia.Views
                 uint addr = U.atoh(text);
                 if (addr == 0 || !U.isSafetyOffset(addr))
                 {
-                    Log.Error("EventUnitFE6View: Invalid address {0}", text);
+                    Log.ErrorF("EventUnitFE6View: Invalid address {0}", text);
                     return;
                 }
                 LoadUnitsFromAddress(addr);
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitFE6View.LoadAddr_Click failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitFE6View.LoadAddr_Click failed: {0}", ex.Message);
             }
         }
 
@@ -226,7 +226,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EventUnitFE6View.Write failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitFE6View.Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/EventUnitFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventUnitFE7View.axaml.cs
@@ -133,7 +133,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitFE7View.LoadMapList failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitFE7View.LoadMapList failed: {0}", ex.Message);
             }
         }
 
@@ -164,7 +164,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitFE7View.MapListBox_SelectionChanged failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitFE7View.MapListBox_SelectionChanged failed: {0}", ex.Message);
             }
         }
 
@@ -181,7 +181,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitFE7View.GroupListBox_SelectionChanged failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitFE7View.GroupListBox_SelectionChanged failed: {0}", ex.Message);
             }
         }
 
@@ -210,7 +210,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitFE7View.UnitListBox_SelectionChanged failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitFE7View.UnitListBox_SelectionChanged failed: {0}", ex.Message);
             }
         }
 
@@ -222,7 +222,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 uint addr = U.atoh(text);
                 if (addr == 0 || !U.isSafetyOffset(addr))
                 {
-                    Log.Error("EventUnitFE7View: Invalid address {0}", text);
+                    Log.ErrorF("EventUnitFE7View: Invalid address {0}", text);
                     return;
                 }
                 TopAddrBox.Text = string.Format("0x{0:X08}", addr);
@@ -230,7 +230,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitFE7View.LoadAddr_Click failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitFE7View.LoadAddr_Click failed: {0}", ex.Message);
             }
         }
 
@@ -334,7 +334,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EventUnitFE7View.Write failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitFE7View.Write failed: {0}", ex.Message);
             }
         }
 
@@ -420,7 +420,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitFE7View.JumpBattleTalk_Click failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitFE7View.JumpBattleTalk_Click failed: {0}", ex.Message);
             }
         }
 
@@ -441,7 +441,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitFE7View.JumpBattleBGM_Click failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitFE7View.JumpBattleBGM_Click failed: {0}", ex.Message);
             }
         }
 
@@ -463,7 +463,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitFE7View.JumpHaiku_Click failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitFE7View.JumpHaiku_Click failed: {0}", ex.Message);
             }
         }
 
@@ -521,7 +521,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitFE7View.NewAlloc_Click failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitFE7View.NewAlloc_Click failed: {0}", ex.Message);
             }
         }
 
@@ -604,7 +604,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitFE7View.ExpandList_Click failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitFE7View.ExpandList_Click failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/EventUnitItemDropView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventUnitItemDropView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitItemDropView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitItemDropView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitItemDropView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitItemDropView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/EventUnitNewAllocView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventUnitNewAllocView.axaml.cs
@@ -47,7 +47,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitNewAllocView.OK_Click failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitNewAllocView.OK_Click failed: {0}", ex.Message);
                 Close((uint?)null);
             }
         }

--- a/FEBuilderGBA.Avalonia/Views/EventUnitSimView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventUnitSimView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitSimView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitSimView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitSimView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitSimView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/EventUnitView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventUnitView.axaml.cs
@@ -103,7 +103,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitView.LoadMapList failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitView.LoadMapList failed: {0}", ex.Message);
             }
         }
 
@@ -134,7 +134,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitView.MapListBox_SelectionChanged failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitView.MapListBox_SelectionChanged failed: {0}", ex.Message);
             }
         }
 
@@ -151,7 +151,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitView.GroupListBox_SelectionChanged failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitView.GroupListBox_SelectionChanged failed: {0}", ex.Message);
             }
         }
 
@@ -185,7 +185,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitView.UnitListBox_SelectionChanged failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitView.UnitListBox_SelectionChanged failed: {0}", ex.Message);
             }
         }
 
@@ -197,7 +197,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 uint addr = U.atoh(text);
                 if (addr == 0 || !U.isSafetyOffset(addr))
                 {
-                    Log.Error("EventUnitView: Invalid address {0}", text);
+                    Log.ErrorF("EventUnitView: Invalid address {0}", text);
                     return;
                 }
                 TopAddrBox.Text = string.Format("0x{0:X08}", addr);
@@ -216,7 +216,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitView.LoadAddr_Click failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitView.LoadAddr_Click failed: {0}", ex.Message);
             }
         }
 
@@ -339,7 +339,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("EventUnitView.Write failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitView.Write failed: {0}", ex.Message);
             }
         }
 
@@ -361,7 +361,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitView.AddCoord_Click failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitView.AddCoord_Click failed: {0}", ex.Message);
             }
         }
 
@@ -377,7 +377,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitView.RemoveCoord_Click failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitView.RemoveCoord_Click failed: {0}", ex.Message);
             }
         }
 
@@ -533,7 +533,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitView.JumpBattleTalk_Click failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitView.JumpBattleTalk_Click failed: {0}", ex.Message);
             }
         }
 
@@ -554,7 +554,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitView.JumpBattleBGM_Click failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitView.JumpBattleBGM_Click failed: {0}", ex.Message);
             }
         }
 
@@ -576,7 +576,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitView.JumpHaiku_Click failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitView.JumpHaiku_Click failed: {0}", ex.Message);
             }
         }
 
@@ -606,7 +606,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitView.JumpMonsterProb_Click failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitView.JumpMonsterProb_Click failed: {0}", ex.Message);
             }
         }
 
@@ -622,7 +622,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitView.ItemDropDialog_Click failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitView.ItemDropDialog_Click failed: {0}", ex.Message);
             }
         }
 
@@ -680,7 +680,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitView.NewAlloc_Click failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitView.NewAlloc_Click failed: {0}", ex.Message);
             }
         }
 
@@ -755,7 +755,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EventUnitView.ExpandList_Click failed: {0}", ex.Message);
+                Log.ErrorF("EventUnitView.ExpandList_Click failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ExtraUnitFE8UView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ExtraUnitFE8UView.axaml.cs
@@ -30,7 +30,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ExtraUnitFE8UView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ExtraUnitFE8UView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -47,7 +47,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _vm.IsLoading = false;
-                Log.Error("ExtraUnitFE8UView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ExtraUnitFE8UView.OnSelected failed: {0}", ex.Message);
             }
         }
 
@@ -78,7 +78,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("ExtraUnitFE8UView.Write failed: {0}", ex.Message);
+                Log.ErrorF("ExtraUnitFE8UView.Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ExtraUnitView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ExtraUnitView.axaml.cs
@@ -30,7 +30,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ExtraUnitView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ExtraUnitView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -47,7 +47,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _vm.IsLoading = false;
-                Log.Error("ExtraUnitView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ExtraUnitView.OnSelected failed: {0}", ex.Message);
             }
         }
 
@@ -80,7 +80,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("ExtraUnitView.Write failed: {0}", ex.Message);
+                Log.ErrorF("ExtraUnitView.Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/GraphicsToolView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/GraphicsToolView.axaml.cs
@@ -113,7 +113,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("GraphicsToolView.TSAEditor_Click failed: {0}", ex.Message);
+                Log.ErrorF("GraphicsToolView.TSAEditor_Click failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/GrowSimulatorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/GrowSimulatorView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("GrowSimulatorView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("GrowSimulatorView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("GrowSimulatorView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("GrowSimulatorView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ImageBGView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBGView.axaml.cs
@@ -248,7 +248,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageBGView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ImageBGView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -264,7 +264,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageBGView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ImageBGView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -355,7 +355,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("ImageBGView.ListExpands_Click: {0}", ex.Message);
+                Log.ErrorF("ImageBGView.ListExpands_Click: {0}", ex.Message);
                 CoreState.Services?.ShowError($"Expand failed: {ex.Message}");
             }
         }
@@ -604,7 +604,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageBGView.OpenSource_Click: {0}", ex.Message);
+                Log.ErrorF("ImageBGView.OpenSource_Click: {0}", ex.Message);
                 CoreState.Services?.ShowError($"Failed to open source file: {ex.Message}");
             }
         }
@@ -637,7 +637,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageBGView.SelectSource_Click: {0}", ex.Message);
+                Log.ErrorF("ImageBGView.SelectSource_Click: {0}", ex.Message);
                 CoreState.Services?.ShowError($"Failed to open source folder: {ex.Message}");
             }
         }

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml.cs
@@ -168,7 +168,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageBattleAnimePalletView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ImageBattleAnimePalletView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -190,7 +190,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageBattleAnimePalletView.OnSelectedEntry failed: {0}", ex.Message);
+                Log.ErrorF("ImageBattleAnimePalletView.OnSelectedEntry failed: {0}", ex.Message);
             }
         }
 
@@ -215,7 +215,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageBattleAnimePalletView.RefreshSamplePreview failed: {0}", ex.Message);
+                Log.ErrorF("ImageBattleAnimePalletView.RefreshSamplePreview failed: {0}", ex.Message);
                 SamplePreview.SetImage(null);
             }
             // #828: gate the Export Image button on a successful render.
@@ -246,7 +246,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageBattleAnimePalletView.Export_Click failed: {0}", ex.Message);
+                Log.ErrorF("ImageBattleAnimePalletView.Export_Click failed: {0}", ex.Message);
             }
         }
 
@@ -280,7 +280,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageBattleAnimePalletView.PaletteIndexCombo_SelectionChanged failed: {0}", ex.Message);
+                Log.ErrorF("ImageBattleAnimePalletView.PaletteIndexCombo_SelectionChanged failed: {0}", ex.Message);
             }
         }
 
@@ -353,7 +353,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageBattleAnimePalletView.Write threw: {0}", ex.Message);
+                Log.ErrorF("ImageBattleAnimePalletView.Write threw: {0}", ex.Message);
                 _undoService.Rollback();
                 return;
             }
@@ -407,7 +407,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageBattleAnimePalletView.RefreshListPreservingSelection failed: {0}", ex.Message);
+                Log.ErrorF("ImageBattleAnimePalletView.RefreshListPreservingSelection failed: {0}", ex.Message);
             }
         }
 
@@ -464,7 +464,7 @@ namespace FEBuilderGBA.Avalonia.Views
             if (loadResult == null || !loadResult.Success)
             {
                 string err = loadResult?.Error ?? "Unknown error";
-                Log.Error("Import_Click: image load/quantize failed: {0}", err);
+                Log.ErrorF("Import_Click: image load/quantize failed: {0}", err);
                 return;
             }
 
@@ -503,7 +503,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("Import_Click: Write threw: {0}", ex.Message);
+                Log.ErrorF("Import_Click: Write threw: {0}", ex.Message);
                 _undoService.Rollback();
                 // FIX 2: restore pre-import VM state so the UI matches the rolled-back ROM.
                 RestorePaletteSnapshot(rSnap, gSnap, bSnap);
@@ -582,7 +582,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("Clipboard_Click failed: {0}", ex.Message);
+                Log.ErrorF("Clipboard_Click failed: {0}", ex.Message);
             }
         }
 
@@ -604,7 +604,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("Undo_Click failed: {0}", ex.Message);
+                Log.ErrorF("Undo_Click failed: {0}", ex.Message);
             }
         }
 
@@ -629,7 +629,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("Redo_Click failed: {0}", ex.Message);
+                Log.ErrorF("Redo_Click failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleAnimeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleAnimeView.axaml.cs
@@ -204,7 +204,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SectionCombo_SelectionChanged: {0}", ex.Message);
+                Log.ErrorF("SectionCombo_SelectionChanged: {0}", ex.Message);
             }
         }
 
@@ -224,7 +224,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("FrameUpDown_ValueChanged: {0}", ex.Message);
+                Log.ErrorF("FrameUpDown_ValueChanged: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleBGView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleBGView.axaml.cs
@@ -115,7 +115,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageBattleBGView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ImageBattleBGView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -130,7 +130,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageBattleBGView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ImageBattleBGView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -347,7 +347,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("ImageBattleBGView.ListExpands_Click: {0}", ex.Message);
+                Log.ErrorF("ImageBattleBGView.ListExpands_Click: {0}", ex.Message);
                 CoreState.Services?.ShowError($"Expand failed: {ex.Message}");
             }
         }
@@ -397,7 +397,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageBattleBGView.OpenSource_Click: {0}", ex.Message);
+                Log.ErrorF("ImageBattleBGView.OpenSource_Click: {0}", ex.Message);
                 CoreState.Services?.ShowError($"Failed to open source file: {ex.Message}");
             }
         }
@@ -433,7 +433,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageBattleBGView.SelectSource_Click: {0}", ex.Message);
+                Log.ErrorF("ImageBattleBGView.SelectSource_Click: {0}", ex.Message);
                 CoreState.Services?.ShowError($"Failed to open source folder: {ex.Message}");
             }
         }

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml.cs
@@ -170,7 +170,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageBattleScreenView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ImageBattleScreenView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -186,7 +186,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageBattleScreenView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ImageBattleScreenView.OnSelected failed: {0}", ex.Message);
             }
         }
 
@@ -209,7 +209,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageBattleScreenView.RefreshBattlePreview failed: {0}", ex.Message);
+                Log.ErrorF("ImageBattleScreenView.RefreshBattlePreview failed: {0}", ex.Message);
                 BattlePreview.SetImage(null);
                 _vm.CanExportBattle = false;
             }
@@ -247,7 +247,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageBattleScreenView.BattleExportPng failed: {0}", ex.Message);
+                Log.ErrorF("ImageBattleScreenView.BattleExportPng failed: {0}", ex.Message);
             }
         }
 
@@ -267,7 +267,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageBattleScreenView.RefreshChipsetPreview failed: {0}", ex.Message);
+                Log.ErrorF("ImageBattleScreenView.RefreshChipsetPreview failed: {0}", ex.Message);
                 ChipsetPreview.SetImage(null);
             }
         }
@@ -321,7 +321,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageBattleScreenView.Zoom_SelectionChanged failed: {0}", ex.Message);
+                Log.ErrorF("ImageBattleScreenView.Zoom_SelectionChanged failed: {0}", ex.Message);
             }
         }
 
@@ -363,7 +363,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageBattleScreenView.Write threw: {0}", ex.Message);
+                Log.ErrorF("ImageBattleScreenView.Write threw: {0}", ex.Message);
                 _undoService.Rollback();
                 return;
             }
@@ -406,7 +406,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageBattleScreenView.WritePalette threw: {0}", ex.Message);
+                Log.ErrorF("ImageBattleScreenView.WritePalette threw: {0}", ex.Message);
                 _undoService.Rollback();
                 return;
             }
@@ -444,7 +444,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageBattleScreenView.PaletteIndex_SelectionChanged failed: {0}", ex.Message);
+                Log.ErrorF("ImageBattleScreenView.PaletteIndex_SelectionChanged failed: {0}", ex.Message);
             }
         }
 
@@ -492,7 +492,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("PaletteClipboard_Click failed: {0}", ex.Message);
+                Log.ErrorF("PaletteClipboard_Click failed: {0}", ex.Message);
             }
         }
 
@@ -510,7 +510,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("PaletteUndo_Click failed: {0}", ex.Message);
+                Log.ErrorF("PaletteUndo_Click failed: {0}", ex.Message);
             }
         }
 
@@ -539,7 +539,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("PaletteRedo_Click failed: {0}", ex.Message);
+                Log.ErrorF("PaletteRedo_Click failed: {0}", ex.Message);
             }
         }
 
@@ -556,7 +556,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("BulkUndo_Click failed: {0}", ex.Message);
+                Log.ErrorF("BulkUndo_Click failed: {0}", ex.Message);
             }
         }
 
@@ -589,7 +589,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageBattleScreenView.BulkExport failed: {0}", ex.Message);
+                Log.ErrorF("ImageBattleScreenView.BulkExport failed: {0}", ex.Message);
             }
         }
 
@@ -627,7 +627,7 @@ namespace FEBuilderGBA.Avalonia.Views
             if (loadResult == null || !loadResult.Success)
             {
                 string err = loadResult?.Error ?? "Unknown error";
-                Log.Error("BulkImport_Click: load/quantize failed: {0}", err);
+                Log.ErrorF("BulkImport_Click: load/quantize failed: {0}", err);
                 return;
             }
 
@@ -654,14 +654,14 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("BulkImport_Click: ImportBattleScreenBulk threw: {0}", ex.Message);
+                Log.ErrorF("BulkImport_Click: ImportBattleScreenBulk threw: {0}", ex.Message);
                 _undoService.Rollback();
                 return;
             }
 
             if (!string.IsNullOrEmpty(error))
             {
-                Log.Error("BulkImport_Click: {0}; rolling back.", error);
+                Log.ErrorF("BulkImport_Click: {0}; rolling back.", error);
                 _undoService.Rollback();
                 return;
             }

--- a/FEBuilderGBA.Avalonia/Views/ImageCGFE7UView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageCGFE7UView.axaml.cs
@@ -33,7 +33,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageCGFE7UView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ImageCGFE7UView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -49,7 +49,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageCGFE7UView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ImageCGFE7UView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }

--- a/FEBuilderGBA.Avalonia/Views/ImageCGView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageCGView.axaml.cs
@@ -94,7 +94,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageCGView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ImageCGView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -108,7 +108,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageCGView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ImageCGView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ImageChapterTitleFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageChapterTitleFE7View.axaml.cs
@@ -27,7 +27,7 @@ namespace FEBuilderGBA.Avalonia.Views
         void LoadList()
         {
             try { var items = _vm.LoadList(); EntryList.SetItems(items); }
-            catch (Exception ex) { Log.Error("ImageChapterTitleFE7View.LoadList: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ImageChapterTitleFE7View.LoadList: {0}", ex.Message); }
         }
 
         void OnSelected(uint addr)
@@ -38,7 +38,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 UpdateUI();
                 LoadImage();
             }
-            catch (Exception ex) { Log.Error("ImageChapterTitleFE7View.OnSelected: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ImageChapterTitleFE7View.OnSelected: {0}", ex.Message); }
         }
 
         void UpdateUI()
@@ -62,7 +62,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("ImageChapterTitleFE7View.Write failed: {0}", ex.Message);
+                Log.ErrorF("ImageChapterTitleFE7View.Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ImageGenericEnemyPortraitView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageGenericEnemyPortraitView.axaml.cs
@@ -48,7 +48,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageGenericEnemyPortraitView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ImageGenericEnemyPortraitView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -64,7 +64,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageGenericEnemyPortraitView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ImageGenericEnemyPortraitView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -90,7 +90,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 PreviewImage.SetImage(null);
-                Log.Error("ImageGenericEnemyPortraitView.RefreshPreview failed: {0}", ex.Message);
+                Log.ErrorF("ImageGenericEnemyPortraitView.RefreshPreview failed: {0}", ex.Message);
             }
         }
 
@@ -110,7 +110,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageGenericEnemyPortraitView.ExportButton failed: {0}", ex.Message);
+                Log.ErrorF("ImageGenericEnemyPortraitView.ExportButton failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ImageMagicCSACreatorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageMagicCSACreatorView.axaml.cs
@@ -81,7 +81,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageMagicCSACreatorView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ImageMagicCSACreatorView.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -127,7 +127,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageMagicCSACreatorView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ImageMagicCSACreatorView.OnSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -186,7 +186,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageMagicCSACreatorView.RenderPreview: {0}", ex.Message);
+                Log.ErrorF("ImageMagicCSACreatorView.RenderPreview: {0}", ex.Message);
                 MagicFramePreview.SetImage(null);
             }
         }
@@ -227,7 +227,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageMagicCSACreatorView.LinkInternet: {0}", ex.Message);
+                Log.ErrorF("ImageMagicCSACreatorView.LinkInternet: {0}", ex.Message);
             }
         }
 
@@ -273,7 +273,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 img.SetPixelData(new byte[width * height * 4]);
                 img.Save(path);
             }
-            catch (Exception ex) { Log.Error("CSA SaveDummyPng: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("CSA SaveDummyPng: {0}", ex.Message); }
         }
 
         void Write_Click(object? sender, RoutedEventArgs e)
@@ -316,7 +316,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("ImageMagicCSACreatorView.Write failed: {0}", ex.Message);
+                Log.ErrorF("ImageMagicCSACreatorView.Write failed: {0}", ex.Message);
                 // Surface the error to the user so it's actionable instead
                 // of silently logged (Copilot bot inline review #2 round 2).
                 CoreState.Services?.ShowError($"Write failed: {ex.Message}");
@@ -380,7 +380,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("ImageMagicCSACreatorView.ListExpand: {0}", ex.Message);
+                Log.ErrorF("ImageMagicCSACreatorView.ListExpand: {0}", ex.Message);
                 CoreState.Services?.ShowError(R._("List expansion failed: {0}", ex.Message));
             }
         }
@@ -526,7 +526,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageMagicCSACreatorView.LoadIndexedImage: {0}", ex.Message);
+                Log.ErrorF("ImageMagicCSACreatorView.LoadIndexedImage: {0}", ex.Message);
                 return null;
             }
         }
@@ -701,7 +701,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("CSAExport: {0}", ex.Message);
+                Log.ErrorF("CSAExport: {0}", ex.Message);
                 CoreState.Services?.ShowError(R._("Export failed: {0}", ex.Message));
                 return ex.Message;
             }
@@ -728,7 +728,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 }
                 catch (Exception ex)
                 {
-                    Log.Error("ImageMagicCSACreatorView.OpenSource: {0}", ex.Message);
+                    Log.ErrorF("ImageMagicCSACreatorView.OpenSource: {0}", ex.Message);
                     CoreState.Services?.ShowError(R._("Cannot open file: {0}", ex.Message));
                 }
             }
@@ -763,7 +763,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 }
                 catch (Exception ex)
                 {
-                    Log.Error("ImageMagicCSACreatorView.SelectSource: {0}", ex.Message);
+                    Log.ErrorF("ImageMagicCSACreatorView.SelectSource: {0}", ex.Message);
                     CoreState.Services?.ShowError(R._("Cannot open folder: {0}", ex.Message));
                 }
             }

--- a/FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageMagicFEditorView.axaml.cs
@@ -68,7 +68,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageMagicFEditorView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ImageMagicFEditorView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -155,7 +155,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageMagicFEditorView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ImageMagicFEditorView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -230,7 +230,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageMagicFEditorView.RenderPreview: {0}", ex.Message);
+                Log.ErrorF("ImageMagicFEditorView.RenderPreview: {0}", ex.Message);
                 MagicFramePreview.SetImage(null);
                 ExportPngButton.IsEnabled = false;
             }
@@ -304,7 +304,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("ImageMagicFEditorView.Write: {0}", ex.Message);
+                Log.ErrorF("ImageMagicFEditorView.Write: {0}", ex.Message);
             }
         }
 
@@ -357,7 +357,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("ImageMagicFEditorView.MagicListExpand: {0}", ex.Message);
+                Log.ErrorF("ImageMagicFEditorView.MagicListExpand: {0}", ex.Message);
                 CoreState.Services?.ShowError(R._("List expansion failed: {0}", ex.Message));
             }
         }
@@ -380,7 +380,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageMagicFEditorView.ExportPng: {0}", ex.Message);
+                Log.ErrorF("ImageMagicFEditorView.ExportPng: {0}", ex.Message);
             }
         }
 
@@ -531,7 +531,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageMagicFEditorView.LoadIndexedImage: {0}", ex.Message);
+                Log.ErrorF("ImageMagicFEditorView.LoadIndexedImage: {0}", ex.Message);
                 return null;
             }
         }
@@ -680,7 +680,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MagicAnimeExport: {0}", ex.Message);
+                Log.ErrorF("MagicAnimeExport: {0}", ex.Message);
                 CoreState.Services?.ShowError(R._("Export failed: {0}", ex.Message));
             }
         }
@@ -696,7 +696,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 img.SetPixelData(new byte[width * height * 4]);
                 img.Save(path);
             }
-            catch (Exception ex) { Log.Error("SaveDummyPng: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SaveDummyPng: {0}", ex.Message); }
         }
 
         // #878 PR1 — Open Source File (mirrors WF OpenSourceButton_Click).
@@ -720,7 +720,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 }
                 catch (Exception ex)
                 {
-                    Log.Error("ImageMagicFEditorView.OpenSource: {0}", ex.Message);
+                    Log.ErrorF("ImageMagicFEditorView.OpenSource: {0}", ex.Message);
                     CoreState.Services?.ShowError(
                         R._("Cannot open file: {0}", ex.Message));
                 }
@@ -758,7 +758,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 }
                 catch (Exception ex)
                 {
-                    Log.Error("ImageMagicFEditorView.SelectSource: {0}", ex.Message);
+                    Log.ErrorF("ImageMagicFEditorView.SelectSource: {0}", ex.Message);
                     CoreState.Services?.ShowError(
                         R._("Cannot open folder: {0}", ex.Message));
                 }
@@ -830,7 +830,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageMagicFEditorView.LinkInternet: {0}", ex.Message);
+                Log.ErrorF("ImageMagicFEditorView.LinkInternet: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ImageMapActionAnimationView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageMapActionAnimationView.axaml.cs
@@ -84,7 +84,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageMapActionAnimationView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ImageMapActionAnimationView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -107,7 +107,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageMapActionAnimationView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ImageMapActionAnimationView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -181,7 +181,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _undoService.Commit();
                 _vm.MarkClean();
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("ImageMapActionAnimationView.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("ImageMapActionAnimationView.Write: {0}", ex.Message); }
         }
 
         /// <summary>
@@ -265,13 +265,13 @@ namespace FEBuilderGBA.Avalonia.Views
                 catch (Exception inner)
                 {
                     _undoService.Rollback();
-                    Log.Error("ImageMapActionAnimationView.ListExpand_Click inner failed: {0}", inner.Message);
+                    Log.ErrorF("ImageMapActionAnimationView.ListExpand_Click inner failed: {0}", inner.Message);
                     CoreState.Services?.ShowError(R._("List expansion failed: {0}", inner.Message));
                 }
             }
             catch (Exception ex)
             {
-                Log.Error("ImageMapActionAnimationView.ListExpand_Click failed: {0}", ex.Message);
+                Log.ErrorF("ImageMapActionAnimationView.ListExpand_Click failed: {0}", ex.Message);
             }
         }
 
@@ -310,7 +310,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageMapActionAnimationView.OpenInCreator_Click failed: {0}", ex.Message);
+                Log.ErrorF("ImageMapActionAnimationView.OpenInCreator_Click failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml.cs
@@ -113,7 +113,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImagePalletView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ImagePalletView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -150,7 +150,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImagePalletView.JumpTo failed: {0}", ex.Message);
+                Log.ErrorF("ImagePalletView.JumpTo failed: {0}", ex.Message);
             }
         }
 
@@ -387,7 +387,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImagePalletView.RenderPreview failed: {0}", ex.Message);
+                Log.ErrorF("ImagePalletView.RenderPreview failed: {0}", ex.Message);
                 try
                 {
                     DisposePreview();
@@ -557,7 +557,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("ImagePalletView.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("ImagePalletView.Write_Click failed: {0}", ex.Message);
                 CoreState.Services?.ShowError(R._("Write failed: {0}", ex.Message));
             }
         }
@@ -616,7 +616,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImagePalletView.Undo_Click failed: {0}", ex.Message);
+                Log.ErrorF("ImagePalletView.Undo_Click failed: {0}", ex.Message);
             }
         }
 
@@ -657,7 +657,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImagePalletView.Redo_Click failed: {0}", ex.Message);
+                Log.ErrorF("ImagePalletView.Redo_Click failed: {0}", ex.Message);
             }
         }
 
@@ -754,7 +754,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImagePalletView.Export_Click failed: {0}", ex.Message);
+                Log.ErrorF("ImagePalletView.Export_Click failed: {0}", ex.Message);
                 CoreState.Services?.ShowError(R._("Export palette failed: {0}", ex.Message));
             }
         }
@@ -816,13 +816,13 @@ namespace FEBuilderGBA.Avalonia.Views
                     _undoService.Rollback();
                     ApplyGbaBytesToNuds(prevBytes); // restore the pre-import grid
                     RefreshSwatches();
-                    Log.Error("ImagePalletView.Import_Click inner failed: {0}", ex.Message);
+                    Log.ErrorF("ImagePalletView.Import_Click inner failed: {0}", ex.Message);
                     CoreState.Services?.ShowError(R._("Import palette failed: {0}", ex.Message));
                 }
             }
             catch (Exception ex)
             {
-                Log.Error("ImagePalletView.Import_Click failed: {0}", ex.Message);
+                Log.ErrorF("ImagePalletView.Import_Click failed: {0}", ex.Message);
                 CoreState.Services?.ShowError(R._("Import palette failed: {0}", ex.Message));
             }
         }
@@ -838,7 +838,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImagePalletView.Clipboard_Click failed: {0}", ex.Message);
+                Log.ErrorF("ImagePalletView.Clipboard_Click failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ImagePortraitFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImagePortraitFE6View.axaml.cs
@@ -44,7 +44,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImagePortraitFE6View.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ImagePortraitFE6View.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -62,7 +62,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImagePortraitFE6View.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ImagePortraitFE6View.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -137,7 +137,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImagePortraitFE6View.TryShowPortraitImage failed: {0}", ex.Message);
+                Log.ErrorF("ImagePortraitFE6View.TryShowPortraitImage failed: {0}", ex.Message);
                 PortraitImage.SetImage(null);
                 MapFaceImage.SetImage(null);
                 ShowExampleImage.SetImage(null);

--- a/FEBuilderGBA.Avalonia/Views/ImagePortraitImporterView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImagePortraitImporterView.axaml.cs
@@ -139,7 +139,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImagePortraitImporterView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ImagePortraitImporterView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -153,7 +153,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImagePortraitImporterView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ImagePortraitImporterView.OnSelected failed: {0}", ex.Message);
             }
         }
 
@@ -271,7 +271,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImagePortraitImporterView.PickFile_Click failed: {0}", ex.Message);
+                Log.ErrorF("ImagePortraitImporterView.PickFile_Click failed: {0}", ex.Message);
                 CoreState.Services.ShowError($"Pick file failed: {ex.Message}");
             }
         }
@@ -295,7 +295,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImagePortraitImporterView.FERepo_Click failed: {0}", ex.Message);
+                Log.ErrorF("ImagePortraitImporterView.FERepo_Click failed: {0}", ex.Message);
                 CoreState.Services.ShowError($"FE-Repo browser failed: {ex.Message}");
             }
         }
@@ -341,7 +341,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImagePortraitImporterView.LoadImageFromPath failed: {0}", ex.Message);
+                Log.ErrorF("ImagePortraitImporterView.LoadImageFromPath failed: {0}", ex.Message);
                 CoreState.Services.ShowError($"Load image failed: {ex.Message}");
             }
         }
@@ -433,7 +433,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 }
                 catch (Exception ex)
                 {
-                    Log.Error("ImagePortraitImporterView.PickFolder_Click batch failed: {0}", ex.Message);
+                    Log.ErrorF("ImagePortraitImporterView.PickFolder_Click batch failed: {0}", ex.Message);
                     CoreState.Services.ShowError($"Batch import error: {ex.Message}");
                 }
                 finally
@@ -447,7 +447,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImagePortraitImporterView.PickFolder_Click failed: {0}", ex.Message);
+                Log.ErrorF("ImagePortraitImporterView.PickFolder_Click failed: {0}", ex.Message);
                 CoreState.Services.ShowError($"Pick folder failed: {ex.Message}");
             }
         }
@@ -526,7 +526,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImagePortraitImporterView.Import_Click failed: {0}", ex.Message);
+                Log.ErrorF("ImagePortraitImporterView.Import_Click failed: {0}", ex.Message);
                 CoreState.Services.ShowError($"Import failed: {ex.Message}");
             }
         }
@@ -609,7 +609,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImagePortraitImporterView.CustomPalettePick_Click failed: {0}", ex.Message);
+                Log.ErrorF("ImagePortraitImporterView.CustomPalettePick_Click failed: {0}", ex.Message);
                 CoreState.Services.ShowError($"Pick palette failed: {ex.Message}");
             }
         }

--- a/FEBuilderGBA.Avalonia/Views/ImagePortraitView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImagePortraitView.axaml.cs
@@ -62,7 +62,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImagePortraitView.UpdatePatchGatedVisibility failed: {0}", ex.Message);
+                Log.ErrorF("ImagePortraitView.UpdatePatchGatedVisibility failed: {0}", ex.Message);
             }
         }
 
@@ -156,7 +156,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImagePortraitView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ImagePortraitView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -177,7 +177,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImagePortraitView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ImagePortraitView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -238,7 +238,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImagePortraitView.UpdateImages show-example failed: {0}", ex.Message);
+                Log.ErrorF("ImagePortraitView.UpdateImages show-example failed: {0}", ex.Message);
                 ShowExampleImage.SetImage(null);
             }
         }
@@ -712,7 +712,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 window.JumpTo(_vm.PalettePtr, maxPaletteCount: 1, defaultSelectPalette: 0, paletteNames: null,
                     renderPreview: block => PortraitRendererCore.DrawPortraitMap(mapFacePtr, block));
             }
-            catch (Exception ex) { Log.Error("JumpToPalette failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("JumpToPalette failed: {0}", ex.Message); }
         }
 
         void JumpToImporter_Click(object? sender, RoutedEventArgs e)
@@ -723,7 +723,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (_vm.CurrentAddr != 0)
                     view.NavigateTo(_vm.CurrentAddr);   // position the importer at the portrait being edited (right target + its B20-B23)
             }
-            catch (Exception ex) { Log.Error("JumpToImporter failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("JumpToImporter failed: {0}", ex.Message); }
         }
 
         void JumpToStatusHeight_Click(object? sender, RoutedEventArgs e)
@@ -736,7 +736,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // leaves the default first row selected — no error (#1019).
                 view.NavigateToId(_vm.GetSelectedPortraitId());
             }
-            catch (Exception ex) { Log.Error("JumpToStatusHeight failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("JumpToStatusHeight failed: {0}", ex.Message); }
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/FEBuilderGBA.Avalonia/Views/ImageSystemAreaView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageSystemAreaView.axaml.cs
@@ -32,7 +32,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageSystemAreaView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ImageSystemAreaView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -47,7 +47,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageSystemAreaView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ImageSystemAreaView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -81,7 +81,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _undoService.Commit();
                 _vm.MarkClean();
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("ImageSystemAreaView.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("ImageSystemAreaView.Write: {0}", ex.Message); }
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/FEBuilderGBA.Avalonia/Views/ImageTSAAnimeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageTSAAnimeView.axaml.cs
@@ -35,7 +35,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageTSAAnimeView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ImageTSAAnimeView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -49,7 +49,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageTSAAnimeView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ImageTSAAnimeView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml.cs
@@ -118,7 +118,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageTSAEditorView.Init failed: {0}", ex.Message);
+                Log.ErrorF("ImageTSAEditorView.Init failed: {0}", ex.Message);
             }
 
             // Populate the 16x3 R/G/B grid from the existing ROM palette so
@@ -292,7 +292,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageTSAEditorView.ReloadPaletteIntoGrid failed: {0}", ex.Message);
+                Log.ErrorF("ImageTSAEditorView.ReloadPaletteIntoGrid failed: {0}", ex.Message);
             }
         }
 
@@ -332,7 +332,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageTSAEditorView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ImageTSAEditorView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -347,7 +347,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageTSAEditorView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ImageTSAEditorView.OnSelected failed: {0}", ex.Message);
             }
         }
 
@@ -383,7 +383,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 BattlePreview.SetImage(null);
                 _vm.CanExportBattle = false;
-                Log.Error("ImageTSAEditorView.RefreshBattleCanvas failed: {0}", ex.Message);
+                Log.ErrorF("ImageTSAEditorView.RefreshBattleCanvas failed: {0}", ex.Message);
             }
         }
 
@@ -407,7 +407,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 ChipListPreview.SetImage(null);
-                Log.Error("ImageTSAEditorView.RefreshChipList failed: {0}", ex.Message);
+                Log.ErrorF("ImageTSAEditorView.RefreshChipList failed: {0}", ex.Message);
             }
         }
 
@@ -645,7 +645,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageTSAEditorView.PaletteClipboard failed: {0}", ex.Message);
+                Log.ErrorF("ImageTSAEditorView.PaletteClipboard failed: {0}", ex.Message);
                 CoreState.Services.ShowError(R._("Palette to clipboard failed: {0}", ex.Message));
             }
         }
@@ -786,7 +786,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageTSAEditorView.MainImageExport failed: {0}", ex.Message);
+                Log.ErrorF("ImageTSAEditorView.MainImageExport failed: {0}", ex.Message);
                 CoreState.Services.ShowError(R._("TSA Image Export failed: {0}", ex.Message));
             }
         }
@@ -804,7 +804,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageTSAEditorView.BattleExportPng failed: {0}", ex.Message);
+                Log.ErrorF("ImageTSAEditorView.BattleExportPng failed: {0}", ex.Message);
             }
         }
     }

--- a/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml.cs
@@ -82,7 +82,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageUnitPaletteView.OnClassChanged failed: {0}", ex.Message);
+                Log.ErrorF("ImageUnitPaletteView.OnClassChanged failed: {0}", ex.Message);
             }
         }
 
@@ -98,7 +98,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageUnitPaletteView.OnPreviewPaletteTypeChanged failed: {0}", ex.Message);
+                Log.ErrorF("ImageUnitPaletteView.OnPreviewPaletteTypeChanged failed: {0}", ex.Message);
             }
         }
 
@@ -148,7 +148,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageUnitPaletteView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ImageUnitPaletteView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -199,7 +199,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageUnitPaletteView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ImageUnitPaletteView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -284,7 +284,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageUnitPaletteView.RefreshSamplePreview (anime id) failed: {0}", ex.Message);
+                Log.ErrorF("ImageUnitPaletteView.RefreshSamplePreview (anime id) failed: {0}", ex.Message);
                 BattleAnimeBox.Text = "";
             }
 
@@ -311,7 +311,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageUnitPaletteView.RefreshSamplePreview failed: {0}", ex.Message);
+                Log.ErrorF("ImageUnitPaletteView.RefreshSamplePreview failed: {0}", ex.Message);
                 SamplePreview.SetImage(null);
             }
         }
@@ -360,7 +360,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _undoService.Commit();
                 _vm.MarkClean();
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("ImageUnitPaletteView.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("ImageUnitPaletteView.Write: {0}", ex.Message); }
         }
 
         /// <summary>Palette Write button handler — delegates to
@@ -428,7 +428,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("ImageUnitPaletteView.PaletteWrite: {0}", ex.Message);
+                Log.ErrorF("ImageUnitPaletteView.PaletteWrite: {0}", ex.Message);
                 return false;
             }
         }
@@ -488,7 +488,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("ImageUnitPaletteView.NewAlloc: {0}", ex.Message);
+                Log.ErrorF("ImageUnitPaletteView.NewAlloc: {0}", ex.Message);
                 CoreState.Services?.ShowError(R._("Failed to allocate a new palette block. Check ROM free space."));
             }
         }
@@ -510,7 +510,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageUnitPaletteView.ExportImage: {0}", ex.Message);
+                Log.ErrorF("ImageUnitPaletteView.ExportImage: {0}", ex.Message);
             }
         }
 
@@ -552,7 +552,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageUnitPaletteView.ImportImage: {0}", ex.Message);
+                Log.ErrorF("ImageUnitPaletteView.ImportImage: {0}", ex.Message);
                 CoreState.Services?.ShowError($"{R._("Import failed:")} {ex.Message}");
             }
         }
@@ -706,7 +706,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 catch (Exception inner)
                 {
                     _undoService.Rollback();
-                    Log.Error("ImageUnitPaletteView.Expand_Click inner failed: {0}", inner.Message);
+                    Log.ErrorF("ImageUnitPaletteView.Expand_Click inner failed: {0}", inner.Message);
                     CoreState.Services?.ShowError(R._("List expansion failed: {0}", inner.Message));
                 }
             }
@@ -717,7 +717,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // count-prep path) and surface the error to the user (Copilot
                 // review on PR #1080 — the outer catch previously only logged).
                 try { _undoService.Rollback(); } catch { /* no active scope — ignore */ }
-                Log.Error("ImageUnitPaletteView.Expand_Click failed: {0}", ex.Message);
+                Log.ErrorF("ImageUnitPaletteView.Expand_Click failed: {0}", ex.Message);
                 CoreState.Services?.ShowError(R._("List expansion failed: {0}", ex.Message));
             }
         }
@@ -756,7 +756,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageUnitPaletteView.Clipboard_Click failed: {0}", ex.Message);
+                Log.ErrorF("ImageUnitPaletteView.Clipboard_Click failed: {0}", ex.Message);
                 CoreState.Services?.ShowError(R._("Failed to copy palette to clipboard."));
             }
         }
@@ -779,7 +779,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageUnitPaletteView.Zoom_SelectionChanged failed: {0}", ex.Message);
+                Log.ErrorF("ImageUnitPaletteView.Zoom_SelectionChanged failed: {0}", ex.Message);
             }
         }
 
@@ -803,7 +803,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (CoreState.Undo.Postion != before)
                     ReloadAfterUndoRedo();
             }
-            catch (Exception ex) { Log.Error("ImageUnitPaletteView.Undo_Click failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ImageUnitPaletteView.Undo_Click failed: {0}", ex.Message); }
         }
 
         /// <summary>
@@ -819,7 +819,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (CoreState.Undo == null || !CoreState.Undo.RunRedo()) return;   // empty -> no-op
                 ReloadAfterUndoRedo();
             }
-            catch (Exception ex) { Log.Error("ImageUnitPaletteView.Redo_Click failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ImageUnitPaletteView.Redo_Click failed: {0}", ex.Message); }
         }
 
         /// <summary>

--- a/FEBuilderGBA.Avalonia/Views/ImageUnitWaitIconView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageUnitWaitIconView.axaml.cs
@@ -43,7 +43,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageUnitWaitIconView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ImageUnitWaitIconView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -59,7 +59,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageUnitWaitIconView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ImageUnitWaitIconView.OnSelected failed: {0}", ex.Message);
             }
         }
 
@@ -266,7 +266,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ImageUnitWaitIconView.JumpMoveIcon_Click: {0}", ex.Message);
+                Log.ErrorF("ImageUnitWaitIconView.JumpMoveIcon_Click: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml.cs
@@ -61,7 +61,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemEditorView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ItemEditorView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -145,7 +145,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _vm.IsLoading = false;
-                Log.Error("ItemEditorView.OnItemSelected failed: {0}", ex.Message);
+                Log.ErrorF("ItemEditorView.OnItemSelected failed: {0}", ex.Message);
             }
         }
 
@@ -164,7 +164,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemEditorView.UpdateHardCodingWarning failed: {0}", ex.Message);
+                Log.ErrorF("ItemEditorView.UpdateHardCodingWarning failed: {0}", ex.Message);
                 HardCodingWarningLink.IsVisible = false;
             }
         }
@@ -184,7 +184,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemEditorView.OnHardCodingLink_Click failed: {0}", ex.Message);
+                Log.ErrorF("ItemEditorView.OnHardCodingLink_Click failed: {0}", ex.Message);
             }
         }
 
@@ -210,7 +210,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemEditorView.JumpToWeaponEffect_Click failed: {0}", ex.Message);
+                Log.ErrorF("ItemEditorView.JumpToWeaponEffect_Click failed: {0}", ex.Message);
             }
         }
 
@@ -269,7 +269,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemEditorView.UpdateWeaponDebuffsLink failed: {0}", ex.Message);
+                Log.ErrorF("ItemEditorView.UpdateWeaponDebuffsLink failed: {0}", ex.Message);
                 WeaponDebuffsLink.IsVisible = false;
             }
         }
@@ -284,7 +284,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemEditorView.OnWeaponDebuffsLink_Click failed: {0}", ex.Message);
+                Log.ErrorF("ItemEditorView.OnWeaponDebuffsLink_Click failed: {0}", ex.Message);
             }
         }
 
@@ -482,7 +482,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("Write failed: {0}", ex.Message);
+                Log.ErrorF("Write failed: {0}", ex.Message);
             }
         }
 
@@ -574,7 +574,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("AllocStatBonuses failed: {0}", ex.Message);
+                Log.ErrorF("AllocStatBonuses failed: {0}", ex.Message);
             }
         }
 
@@ -603,7 +603,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("AllocEffectiveness failed: {0}", ex.Message);
+                Log.ErrorF("AllocEffectiveness failed: {0}", ex.Message);
             }
         }
 
@@ -625,7 +625,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("JumpToStatBonuses failed: {0}", ex.Message);
+                Log.ErrorF("JumpToStatBonuses failed: {0}", ex.Message);
             }
         }
 
@@ -644,7 +644,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("JumpToEffectiveness failed: {0}", ex.Message);
+                Log.ErrorF("JumpToEffectiveness failed: {0}", ex.Message);
             }
         }
 
@@ -694,7 +694,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("EditSkillConfig_Click failed: {0}", ex.Message);
+                Log.ErrorF("EditSkillConfig_Click failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ItemEffectPointerViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemEffectPointerViewerView.axaml.cs
@@ -31,7 +31,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemEffectPointerViewerView.LoadList: {0}", ex.Message);
+                Log.ErrorF("ItemEffectPointerViewerView.LoadList: {0}", ex.Message);
             }
         }
 
@@ -48,7 +48,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _vm.IsLoading = false;
-                Log.Error("ItemEffectPointerViewerView.OnSelected: {0}", ex.Message);
+                Log.ErrorF("ItemEffectPointerViewerView.OnSelected: {0}", ex.Message);
             }
         }
 
@@ -73,7 +73,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("Write failed: {0}", ex.Message);
+                Log.ErrorF("Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ItemEffectivenessMainView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemEffectivenessMainView.axaml.cs
@@ -32,7 +32,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemEffectivenessMainView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ItemEffectivenessMainView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -45,7 +45,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemEffectivenessMainView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ItemEffectivenessMainView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ItemEffectivenessViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemEffectivenessViewerView.axaml.cs
@@ -53,7 +53,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemEffectivenessViewerView.LoadList: {0}", ex.Message);
+                Log.ErrorF("ItemEffectivenessViewerView.LoadList: {0}", ex.Message);
             }
         }
 
@@ -98,7 +98,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _vm.IsLoading = false;
-                Log.Error("ItemEffectivenessViewerView.OnOuterSelected: {0}", ex.Message);
+                Log.ErrorF("ItemEffectivenessViewerView.OnOuterSelected: {0}", ex.Message);
             }
         }
 
@@ -163,7 +163,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemEffectivenessViewerView.Write_Click: {0}", ex.Message);
+                Log.ErrorF("ItemEffectivenessViewerView.Write_Click: {0}", ex.Message);
                 CoreState.Services?.ShowError("Write failed: " + ex.Message);
             }
         }
@@ -184,7 +184,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemEffectivenessViewerView.ListExpands_Click: {0}", ex.Message);
+                Log.ErrorF("ItemEffectivenessViewerView.ListExpands_Click: {0}", ex.Message);
                 CoreState.Services?.ShowError("Expand failed: " + ex.Message);
             }
         }
@@ -199,7 +199,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemEffectivenessViewerView.Independence_Click: {0}", ex.Message);
+                Log.ErrorF("ItemEffectivenessViewerView.Independence_Click: {0}", ex.Message);
                 CoreState.Services?.ShowError("Independence failed: " + ex.Message);
             }
         }
@@ -233,7 +233,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 else
                     WindowManager.Instance.Navigate<ClassEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("ItemEffectivenessViewerView.ClassId_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ItemEffectivenessViewerView.ClassId_Jump failed: {0}", ex.Message); }
         }
 
         async void ClassId_Pick(object? sender, RoutedEventArgs e)
@@ -248,7 +248,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     result = await WindowManager.Instance.PickFromEditor<ClassEditorView>(addr, this);
                 if (result != null) ClassIdBox.Value = (uint)result.Index;
             }
-            catch (Exception ex) { Log.Error("ItemEffectivenessViewerView.ClassId_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ItemEffectivenessViewerView.ClassId_Pick failed: {0}", ex.Message); }
         }
 
         void ClassId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/ItemFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemFE6View.axaml.cs
@@ -61,7 +61,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemFE6View.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ItemFE6View.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -118,7 +118,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemFE6View.OnTopBarFilterTextChanged failed: {0}", ex.Message);
+                Log.ErrorF("ItemFE6View.OnTopBarFilterTextChanged failed: {0}", ex.Message);
             }
         }
 
@@ -141,7 +141,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _vm.IsLoading = false;
-                Log.Error("ItemFE6View.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ItemFE6View.OnSelected failed: {0}", ex.Message);
             }
         }
 
@@ -329,7 +329,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemFE6View.UpdateHardCodingWarning failed: {0}", ex.Message);
+                Log.ErrorF("ItemFE6View.UpdateHardCodingWarning failed: {0}", ex.Message);
                 HardCodingWarningLink.IsVisible = false;
             }
         }
@@ -348,7 +348,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemFE6View.OnHardCodingLink_Click failed: {0}", ex.Message);
+                Log.ErrorF("ItemFE6View.OnHardCodingLink_Click failed: {0}", ex.Message);
             }
         }
 
@@ -371,7 +371,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemFE6View.JumpToWeaponEffect_Click failed: {0}", ex.Message);
+                Log.ErrorF("ItemFE6View.JumpToWeaponEffect_Click failed: {0}", ex.Message);
             }
         }
 
@@ -422,7 +422,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("JumpToStatBonuses failed: {0}", ex.Message);
+                Log.ErrorF("JumpToStatBonuses failed: {0}", ex.Message);
             }
         }
 
@@ -443,7 +443,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("JumpToEffectiveness failed: {0}", ex.Message);
+                Log.ErrorF("JumpToEffectiveness failed: {0}", ex.Message);
             }
         }
 
@@ -503,7 +503,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("Write failed: {0}", ex.Message);
+                Log.ErrorF("Write failed: {0}", ex.Message);
             }
         }
 
@@ -531,7 +531,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("AllocStatBonuses failed: {0}", ex.Message);
+                Log.ErrorF("AllocStatBonuses failed: {0}", ex.Message);
             }
         }
 
@@ -559,7 +559,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("AllocEffectiveness failed: {0}", ex.Message);
+                Log.ErrorF("AllocEffectiveness failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ItemIconViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemIconViewerView.axaml.cs
@@ -27,7 +27,7 @@ namespace FEBuilderGBA.Avalonia.Views
         void LoadList()
         {
             try { var items = _vm.LoadItemIconList(); EntryList.SetItemsWithIcons(items, i => ListIconLoaders.DirectItemIconLoader(items, i)); }
-            catch (Exception ex) { Log.Error("ItemIconViewerView.LoadList: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ItemIconViewerView.LoadList: {0}", ex.Message); }
         }
 
         void OnSelected(uint addr)
@@ -44,7 +44,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _vm.IsLoading = false;
-                Log.Error("ItemIconViewerView.OnSelected: {0}", ex.Message);
+                Log.ErrorF("ItemIconViewerView.OnSelected: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ItemPromotionViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemPromotionViewerView.axaml.cs
@@ -47,7 +47,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemPromotionViewerView.LoadList: {0}", ex.Message);
+                Log.ErrorF("ItemPromotionViewerView.LoadList: {0}", ex.Message);
             }
         }
 
@@ -60,7 +60,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemPromotionViewerView.CheckIERPatch: {0}", ex.Message);
+                Log.ErrorF("ItemPromotionViewerView.CheckIERPatch: {0}", ex.Message);
             }
         }
 
@@ -95,7 +95,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _vm.IsLoading = false;
-                Log.Error("ItemPromotionViewerView.OnOuterSelected: {0}", ex.Message);
+                Log.ErrorF("ItemPromotionViewerView.OnOuterSelected: {0}", ex.Message);
             }
         }
 
@@ -151,7 +151,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemPromotionViewerView.Write_Click: {0}", ex.Message);
+                Log.ErrorF("ItemPromotionViewerView.Write_Click: {0}", ex.Message);
                 CoreState.Services?.ShowError("Write failed: " + ex.Message);
             }
         }
@@ -172,7 +172,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemPromotionViewerView.ListExpands_Click: {0}", ex.Message);
+                Log.ErrorF("ItemPromotionViewerView.ListExpands_Click: {0}", ex.Message);
                 CoreState.Services?.ShowError("Expand failed: " + ex.Message);
             }
         }
@@ -185,7 +185,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemPromotionViewerView.OpenPatchManager_Click: {0}", ex.Message);
+                Log.ErrorF("ItemPromotionViewerView.OpenPatchManager_Click: {0}", ex.Message);
             }
         }
 
@@ -218,7 +218,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 else
                     WindowManager.Instance.Navigate<ClassEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("ItemPromotionViewerView.ClassId_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ItemPromotionViewerView.ClassId_Jump failed: {0}", ex.Message); }
         }
 
         async void ClassId_Pick(object? sender, RoutedEventArgs e)
@@ -233,7 +233,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     result = await WindowManager.Instance.PickFromEditor<ClassEditorView>(addr, this);
                 if (result != null) ClassIdBox.Value = (uint)result.Index;
             }
-            catch (Exception ex) { Log.Error("ItemPromotionViewerView.ClassId_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ItemPromotionViewerView.ClassId_Pick failed: {0}", ex.Message); }
         }
 
         void ClassId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/ItemRandomChestView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemRandomChestView.axaml.cs
@@ -34,7 +34,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemRandomChestView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ItemRandomChestView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -51,7 +51,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _vm.IsLoading = false;
-                Log.Error("ItemRandomChestView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ItemRandomChestView.OnSelected failed: {0}", ex.Message);
             }
         }
 
@@ -81,7 +81,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("Write failed: {0}", ex.Message);
+                Log.ErrorF("Write failed: {0}", ex.Message);
             }
         }
 
@@ -120,7 +120,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 else
                     WindowManager.Instance.Navigate<ItemEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("ItemRandomChestView.ItemId_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ItemRandomChestView.ItemId_Jump failed: {0}", ex.Message); }
         }
 
         async void ItemId_Pick(object? sender, RoutedEventArgs e)
@@ -139,7 +139,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     // NameText refresh happens via ValueChanged.
                 }
             }
-            catch (Exception ex) { Log.Error("ItemRandomChestView.ItemId_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ItemRandomChestView.ItemId_Pick failed: {0}", ex.Message); }
         }
 
         void ItemId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/ItemShopViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemShopViewerView.axaml.cs
@@ -58,7 +58,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemShopViewerView.LoadShopList: {0}", ex.Message);
+                Log.ErrorF("ItemShopViewerView.LoadShopList: {0}", ex.Message);
                 StatusLabel.Text = $"Failed to load shop list: {ex.Message}";
             }
         }
@@ -93,7 +93,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemShopViewerView.ReloadShopListAndSelect: {0}", ex.Message);
+                Log.ErrorF("ItemShopViewerView.ReloadShopListAndSelect: {0}", ex.Message);
                 StatusLabel.Text = $"Reload failed after relocation: {ex.Message}";
             }
         }
@@ -137,7 +137,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _vm.IsLoading = false;
-                Log.Error("ItemShopViewerView.OnShopSelected: {0}", ex.Message);
+                Log.ErrorF("ItemShopViewerView.OnShopSelected: {0}", ex.Message);
             }
         }
 
@@ -164,7 +164,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _vm.IsLoading = false;
-                Log.Error("ItemShopViewerView.OnSlotSelected: {0}", ex.Message);
+                Log.ErrorF("ItemShopViewerView.OnSlotSelected: {0}", ex.Message);
             }
         }
 
@@ -224,7 +224,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("Write failed: {0}", ex.Message);
+                Log.ErrorF("Write failed: {0}", ex.Message);
                 StatusLabel.Text = $"Write failed: {ex.Message}";
             }
         }
@@ -296,7 +296,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("AppendSlot failed: {0}", ex.Message);
+                Log.ErrorF("AppendSlot failed: {0}", ex.Message);
                 StatusLabel.Text = $"Append failed: {ex.Message}";
             }
         }
@@ -346,7 +346,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("RemoveLastSlot failed: {0}", ex.Message);
+                Log.ErrorF("RemoveLastSlot failed: {0}", ex.Message);
                 StatusLabel.Text = $"Remove failed: {ex.Message}";
             }
         }
@@ -449,7 +449,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 else
                     WindowManager.Instance.Navigate<ItemEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("ItemShopViewerView.ItemId_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ItemShopViewerView.ItemId_Jump failed: {0}", ex.Message); }
         }
 
         async void ItemId_Pick(object? sender, RoutedEventArgs e)
@@ -464,7 +464,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     result = await WindowManager.Instance.PickFromEditor<ItemEditorView>(addr, this);
                 if (result != null) ItemIdBox.Value = (uint)result.Index;
             }
-            catch (Exception ex) { Log.Error("ItemShopViewerView.ItemId_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ItemShopViewerView.ItemId_Pick failed: {0}", ex.Message); }
         }
 
         void ItemId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/ItemStatBonusesSkillSystemsView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemStatBonusesSkillSystemsView.axaml.cs
@@ -31,7 +31,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemStatBonusesSkillSystemsView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ItemStatBonusesSkillSystemsView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -48,7 +48,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _vm.IsLoading = false;
-                Log.Error("ItemStatBonusesSkillSystemsView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ItemStatBonusesSkillSystemsView.OnSelected failed: {0}", ex.Message);
             }
         }
 
@@ -119,7 +119,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("Write failed: {0}", ex.Message);
+                Log.ErrorF("Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ItemStatBonusesVennoView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemStatBonusesVennoView.axaml.cs
@@ -31,7 +31,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemStatBonusesVennoView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ItemStatBonusesVennoView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -48,7 +48,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _vm.IsLoading = false;
-                Log.Error("ItemStatBonusesVennoView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ItemStatBonusesVennoView.OnSelected failed: {0}", ex.Message);
             }
         }
 
@@ -106,7 +106,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("Write failed: {0}", ex.Message);
+                Log.ErrorF("Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ItemStatBonusesViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemStatBonusesViewerView.axaml.cs
@@ -31,7 +31,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemStatBonusesViewerView.LoadList: {0}", ex.Message);
+                Log.ErrorF("ItemStatBonusesViewerView.LoadList: {0}", ex.Message);
             }
         }
 
@@ -48,7 +48,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _vm.IsLoading = false;
-                Log.Error("ItemStatBonusesViewerView.OnSelected: {0}", ex.Message);
+                Log.ErrorF("ItemStatBonusesViewerView.OnSelected: {0}", ex.Message);
             }
         }
 
@@ -95,7 +95,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("Write failed: {0}", ex.Message);
+                Log.ErrorF("Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ItemUsagePointerViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemUsagePointerViewerView.axaml.cs
@@ -56,7 +56,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemUsagePointerViewerView.InitialLoad: {0}", ex.Message);
+                Log.ErrorF("ItemUsagePointerViewerView.InitialLoad: {0}", ex.Message);
             }
             finally
             {
@@ -147,7 +147,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemUsagePointerViewerView.LoadListForFilter: {0}", ex.Message);
+                Log.ErrorF("ItemUsagePointerViewerView.LoadListForFilter: {0}", ex.Message);
             }
         }
 
@@ -200,7 +200,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemUsagePointerViewerView.OnSelected: {0}", ex.Message);
+                Log.ErrorF("ItemUsagePointerViewerView.OnSelected: {0}", ex.Message);
             }
             finally
             {
@@ -271,7 +271,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("ItemUsagePointerViewerView.Write_Click: {0}", ex.Message);
+                Log.ErrorF("ItemUsagePointerViewerView.Write_Click: {0}", ex.Message);
             }
         }
 
@@ -320,7 +320,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("ItemUsagePointerViewerView.SwitchListExpands_Click: {0}", ex.Message);
+                Log.ErrorF("ItemUsagePointerViewerView.SwitchListExpands_Click: {0}", ex.Message);
             }
         }
 
@@ -364,7 +364,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemUsagePointerViewerView.PromotionItemLink_Click: {0}", ex.Message);
+                Log.ErrorF("ItemUsagePointerViewerView.PromotionItemLink_Click: {0}", ex.Message);
             }
         }
 
@@ -377,7 +377,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemUsagePointerViewerView.StatBoosterItemLink_Click: {0}", ex.Message);
+                Log.ErrorF("ItemUsagePointerViewerView.StatBoosterItemLink_Click: {0}", ex.Message);
             }
         }
 
@@ -389,7 +389,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemUsagePointerViewerView.IerPatch_Click: {0}", ex.Message);
+                Log.ErrorF("ItemUsagePointerViewerView.IerPatch_Click: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ItemWeaponEffectViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemWeaponEffectViewerView.axaml.cs
@@ -34,7 +34,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemWeaponEffectViewerView.LoadList: {0}", ex.Message);
+                Log.ErrorF("ItemWeaponEffectViewerView.LoadList: {0}", ex.Message);
             }
         }
 
@@ -51,7 +51,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _vm.IsLoading = false;
-                Log.Error("ItemWeaponEffectViewerView.OnSelected: {0}", ex.Message);
+                Log.ErrorF("ItemWeaponEffectViewerView.OnSelected: {0}", ex.Message);
             }
         }
 
@@ -98,7 +98,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("Write failed: {0}", ex.Message);
+                Log.ErrorF("Write failed: {0}", ex.Message);
             }
         }
 
@@ -136,7 +136,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 else
                     WindowManager.Instance.Navigate<ItemEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("ItemWeaponEffectViewerView.ItemId_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ItemWeaponEffectViewerView.ItemId_Jump failed: {0}", ex.Message); }
         }
 
         async void ItemId_Pick(object? sender, RoutedEventArgs e)
@@ -154,7 +154,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     ItemIdBox.Value = (uint)result.Index;
                 }
             }
-            catch (Exception ex) { Log.Error("ItemWeaponEffectViewerView.ItemId_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ItemWeaponEffectViewerView.ItemId_Pick failed: {0}", ex.Message); }
         }
 
         void ItemId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/ItemWeaponTriangleViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemWeaponTriangleViewerView.axaml.cs
@@ -33,7 +33,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ItemWeaponTriangleViewerView.LoadList: {0}", ex.Message);
+                Log.ErrorF("ItemWeaponTriangleViewerView.LoadList: {0}", ex.Message);
             }
         }
 
@@ -50,7 +50,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _vm.IsLoading = false;
-                Log.Error("ItemWeaponTriangleViewerView.OnSelected: {0}", ex.Message);
+                Log.ErrorF("ItemWeaponTriangleViewerView.OnSelected: {0}", ex.Message);
             }
         }
 
@@ -86,7 +86,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("Write failed: {0}", ex.Message);
+                Log.ErrorF("Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/LinkArenaDenyUnitViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/LinkArenaDenyUnitViewerView.axaml.cs
@@ -34,7 +34,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("LinkArenaDenyUnitViewerView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("LinkArenaDenyUnitViewerView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -49,7 +49,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("LinkArenaDenyUnitViewerView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("LinkArenaDenyUnitViewerView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -76,7 +76,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.MarkClean();
                 CoreState.Services?.ShowInfo("Link Arena Deny Unit data written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("LinkArenaDenyUnitViewerView.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("LinkArenaDenyUnitViewerView.Write: {0}", ex.Message); }
         }
 
         // -- IdFieldControl handlers (#360) ----------------------------------
@@ -91,7 +91,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (addr == 0) return;
                 WindowManager.Instance.Navigate<UnitEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("LinkArenaDenyUnitViewerView.UnitId_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("LinkArenaDenyUnitViewerView.UnitId_Jump failed: {0}", ex.Message); }
         }
 
         async void UnitId_Pick(object? sender, RoutedEventArgs e)
@@ -106,7 +106,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     UnitIdBox.Value = SupportUnitNavigation.OneBasedIdFromPickIndex(result.Index);
                 }
             }
-            catch (Exception ex) { Log.Error("LinkArenaDenyUnitViewerView.UnitId_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("LinkArenaDenyUnitViewerView.UnitId_Pick failed: {0}", ex.Message); }
         }
 
         void UnitId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/MainSimpleMenuEventErrorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MainSimpleMenuEventErrorView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MainSimpleMenuEventErrorView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MainSimpleMenuEventErrorView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MainSimpleMenuEventErrorView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MainSimpleMenuEventErrorView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/MainSimpleMenuImageSubView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MainSimpleMenuImageSubView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MainSimpleMenuImageSubView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MainSimpleMenuImageSubView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MainSimpleMenuImageSubView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MainSimpleMenuImageSubView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/MainSimpleMenuView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MainSimpleMenuView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MainSimpleMenuView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MainSimpleMenuView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MainSimpleMenuView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MainSimpleMenuView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
@@ -777,7 +777,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 }
                 catch (Exception ex)
                 {
-                    Log.Error("Failed to init SystemTextEncoder, using headless fallback: {0}", ex.Message);
+                    Log.ErrorF("Failed to init SystemTextEncoder, using headless fallback: {0}", ex.Message);
                     // Use ROM-aware fallback so JP ROMs get Shift_JIS, not ISO-8859-1
                     CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(CoreState.ROM);
                 }
@@ -787,7 +787,7 @@ namespace FEBuilderGBA.Avalonia.Views
             if (CoreState.FETextEncoder == null)
             {
                 try { CoreState.FETextEncoder = new FETextEncode(); }
-                catch (Exception ex) { Log.Error("Failed to init FETextEncode: {0}", ex.Message); }
+                catch (Exception ex) { Log.ErrorF("Failed to init FETextEncode: {0}", ex.Message); }
             }
 
             // Init text escape
@@ -804,7 +804,7 @@ namespace FEBuilderGBA.Avalonia.Views
             if (CoreState.FlagCache == null)
             {
                 try { CoreState.FlagCache = new EtcCacheFLag(); }
-                catch (Exception ex) { Log.Error("Failed to init FlagCache: {0}", ex.Message); }
+                catch (Exception ex) { Log.ErrorF("Failed to init FlagCache: {0}", ex.Message); }
             }
 
             // Init export function + undo
@@ -837,7 +837,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("Failed to init EventScripts: {0}", ex.Message);
+                Log.ErrorF("Failed to init EventScripts: {0}", ex.Message);
             }
 
             // Detect installed patches (SkillSystem, MagicSplit, etc.)
@@ -961,7 +961,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     }
                     catch (Exception ex)
                     {
-                        Log.Error("Smoke test failed: {0}", ex.Message);
+                        Log.ErrorF("Smoke test failed: {0}", ex.Message);
                         Environment.ExitCode = 1;
                     }
                     finally
@@ -973,7 +973,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("Smoke test failed: {0}", ex.Message);
+                Log.ErrorF("Smoke test failed: {0}", ex.Message);
                 Environment.ExitCode = 1;
                 Close();
             }
@@ -1001,7 +1001,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     {
                         var window = factory();
                         await Task.Delay(50);  // Let it initialize
-                        try { window.Close(); } catch (Exception ex) { Log.Error("MainWindow.SmokeTest window close: {0}", ex.Message); }
+                        try { window.Close(); } catch (Exception ex) { Log.ErrorF("MainWindow.SmokeTest window close: {0}", ex.Message); }
                         passed++;
                         Console.WriteLine($"SMOKE: {name} ... OK");
                     }
@@ -1156,7 +1156,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     }
                     finally
                     {
-                        try { window?.Close(); } catch (Exception ex) { Log.Error("MainWindow.ScreenshotAll window close: {0}", ex.Message); }
+                        try { window?.Close(); } catch (Exception ex) { Log.ErrorF("MainWindow.ScreenshotAll window close: {0}", ex.Message); }
                     }
                 }
 
@@ -1701,7 +1701,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     }
                     finally
                     {
-                        try { window?.Close(); } catch (Exception ex) { Log.Error("MainWindow.DataVerify window close: {0}", ex.Message); }
+                        try { window?.Close(); } catch (Exception ex) { Log.ErrorF("MainWindow.DataVerify window close: {0}", ex.Message); }
                     }
                 }
 
@@ -1813,7 +1813,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     }
                     finally
                     {
-                        try { window?.Close(); } catch (Exception ex) { Log.Error("MainWindow.ListParity window close: {0}", ex.Message); }
+                        try { window?.Close(); } catch (Exception ex) { Log.ErrorF("MainWindow.ListParity window close: {0}", ex.Message); }
                     }
                 }
 
@@ -3609,13 +3609,13 @@ namespace FEBuilderGBA.Avalonia.Views
         private void OnlineManual_Click(object? sender, RoutedEventArgs e)
         {
             try { System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("https://github.com/laqieer/FEBuilderGBA/wiki") { UseShellExecute = true }); }
-            catch (Exception ex) { Log.Error("MainWindow.OnlineManual_Click launch browser: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("MainWindow.OnlineManual_Click launch browser: {0}", ex.Message); }
         }
 
         private void Discussions_Click(object? sender, RoutedEventArgs e)
         {
             try { System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("https://github.com/laqieer/FEBuilderGBA/discussions") { UseShellExecute = true }); }
-            catch (Exception ex) { Log.Error("MainWindow.Discussions_Click launch browser: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("MainWindow.Discussions_Click launch browser: {0}", ex.Message); }
         }
 
         private async void RunEmulator_Click(object? sender, RoutedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/MapChangeMainView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapChangeMainView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapChangeMainView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MapChangeMainView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapChangeMainView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MapChangeMainView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/MapChangeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapChangeView.axaml.cs
@@ -38,7 +38,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapChangeView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MapChangeView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -54,7 +54,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapChangeView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MapChangeView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -106,7 +106,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapChangeView.OnRecordSelected failed: {0}", ex.Message);
+                Log.ErrorF("MapChangeView.OnRecordSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -135,7 +135,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 LoadRecords();
                 CoreState.Services?.ShowInfo("Map Change pointer written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("MapChangeView.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("MapChangeView.Write: {0}", ex.Message); }
         }
 
         void WriteRecord_Click(object? sender, RoutedEventArgs e)
@@ -162,7 +162,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
                 CoreState.Services?.ShowInfo("Change record written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("MapChangeView.WriteRecord: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("MapChangeView.WriteRecord: {0}", ex.Message); }
         }
 
         public void NavigateTo(uint address)

--- a/FEBuilderGBA.Avalonia/Views/MapEditorAddMapChangeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapEditorAddMapChangeView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapEditorAddMapChangeView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MapEditorAddMapChangeView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapEditorAddMapChangeView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MapEditorAddMapChangeView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/MapEditorMarSizeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapEditorMarSizeView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapEditorMarSizeView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MapEditorMarSizeView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapEditorMarSizeView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MapEditorMarSizeView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/MapEditorResizeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapEditorResizeView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapEditorResizeView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MapEditorResizeView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapEditorResizeView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MapEditorResizeView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/MapEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapEditorView.axaml.cs
@@ -52,7 +52,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapEditorView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MapEditorView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -80,7 +80,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapEditorView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MapEditorView.OnSelected failed: {0}", ex.Message);
                 MapInfoLabel.Text = "Error: " + ex.Message;
             }
         }
@@ -137,7 +137,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapEditorView.UpdateTilePalette failed: {0}", ex.Message);
+                Log.ErrorF("MapEditorView.UpdateTilePalette failed: {0}", ex.Message);
             }
         }
 
@@ -243,7 +243,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapEditorView.OnMapImageClick failed: {0}", ex.Message);
+                Log.ErrorF("MapEditorView.OnMapImageClick failed: {0}", ex.Message);
             }
         }
 
@@ -264,7 +264,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapEditorView.OnTilePaletteClick failed: {0}", ex.Message);
+                Log.ErrorF("MapEditorView.OnTilePaletteClick failed: {0}", ex.Message);
             }
         }
 
@@ -294,7 +294,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapEditorView.PatchPaintedTileIntoCache failed: {0}", ex.Message);
+                Log.ErrorF("MapEditorView.PatchPaintedTileIntoCache failed: {0}", ex.Message);
             }
         }
 
@@ -340,7 +340,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undo.Rollback();
-                Log.Error("MapEditorView.OnWriteTile failed: {0}", ex.Message);
+                Log.ErrorF("MapEditorView.OnWriteTile failed: {0}", ex.Message);
                 TileInfoLabel.Text = "ERROR: " + ex.Message;
             }
         }
@@ -357,7 +357,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapEditorView.OnRefreshMap failed: {0}", ex.Message);
+                Log.ErrorF("MapEditorView.OnRefreshMap failed: {0}", ex.Message);
             }
         }
 
@@ -412,7 +412,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapEditorView.ExportCsv_Click failed: {0}", ex.Message);
+                Log.ErrorF("MapEditorView.ExportCsv_Click failed: {0}", ex.Message);
                 CoreState.Services?.ShowError(string.Format(R._("Export failed: {0}"), ex.Message));
             }
         }

--- a/FEBuilderGBA.Avalonia/Views/MapExitPointMainView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapExitPointMainView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapExitPointMainView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MapExitPointMainView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapExitPointMainView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MapExitPointMainView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/MapExitPointView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapExitPointView.axaml.cs
@@ -88,7 +88,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapExitPointView.ReloadMapList failed: {0}", ex.Message);
+                Log.ErrorF("MapExitPointView.ReloadMapList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -117,7 +117,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapExitPointView.OnMapSelected failed: {0}", ex.Message);
+                Log.ErrorF("MapExitPointView.OnMapSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -132,7 +132,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapExitPointView.OnExitSelected failed: {0}", ex.Message);
+                Log.ErrorF("MapExitPointView.OnExitSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -269,7 +269,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // Reload sub-list to reflect the new pointer.
                 OnMapSelected(_vm.SelectedMapSlotAddr);
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("MapExitPointView.WritePointer: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("MapExitPointView.WritePointer: {0}", ex.Message); }
         }
 
         void Write_Click(object? sender, RoutedEventArgs e)
@@ -287,7 +287,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.MarkClean();
                 CoreState.Services?.ShowInfo("Map Exit Point data written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("MapExitPointView.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("MapExitPointView.Write: {0}", ex.Message); }
         }
 
         void NewAlloc_Click(object? sender, RoutedEventArgs e)
@@ -309,7 +309,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 OnMapSelected(_vm.SelectedMapSlotAddr);
                 CoreState.Services?.ShowInfo($"Allocated new exit-point block at 0x{newaddr:X08}.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("MapExitPointView.NewAlloc: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("MapExitPointView.NewAlloc: {0}", ex.Message); }
         }
 
         void ExpandList_Click(object? sender, RoutedEventArgs e)
@@ -325,7 +325,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 OnMapSelected(_vm.SelectedMapSlotAddr);
                 CoreState.Services?.ShowInfo($"Expanded exit-point block to {r.NewCount} rows at 0x{r.NewBaseAddress:X08}.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("MapExitPointView.ExpandList: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("MapExitPointView.ExpandList: {0}", ex.Message); }
         }
 
         // -----------------------------------------------------------------

--- a/FEBuilderGBA.Avalonia/Views/MapLoadFunctionView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapLoadFunctionView.axaml.cs
@@ -30,7 +30,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapLoadFunctionView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MapLoadFunctionView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -43,7 +43,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapLoadFunctionView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MapLoadFunctionView.OnSelected failed: {0}", ex.Message);
             }
         }
 
@@ -71,7 +71,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("MapLoadFunctionView.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("MapLoadFunctionView.Write_Click failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/MapPointerMainView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapPointerMainView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapPointerMainView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MapPointerMainView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapPointerMainView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MapPointerMainView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/MapPointerNewPLISTView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapPointerNewPLISTView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapPointerNewPLISTView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MapPointerNewPLISTView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapPointerNewPLISTView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MapPointerNewPLISTView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/MapSettingDifficultyExtraView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapSettingDifficultyExtraView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapSettingDifficultyExtraView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MapSettingDifficultyExtraView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapSettingDifficultyExtraView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MapSettingDifficultyExtraView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/MapSettingDifficultyView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapSettingDifficultyView.axaml.cs
@@ -49,7 +49,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapSettingDifficultyView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MapSettingDifficultyView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -64,7 +64,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapSettingDifficultyView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MapSettingDifficultyView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -125,7 +125,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("MapSettingDifficultyView.Write failed: {0}", ex.Message);
+                Log.ErrorF("MapSettingDifficultyView.Write failed: {0}", ex.Message);
                 CoreState.Services?.ShowError(R._("Difficulty Settings write failed: {0}", ex.Message));
             }
         }

--- a/FEBuilderGBA.Avalonia/Views/MapSettingFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapSettingFE6View.axaml.cs
@@ -100,13 +100,13 @@ namespace FEBuilderGBA.Avalonia.Views
                 catch (Exception inner)
                 {
                     _undoService.Rollback();
-                    Log.Error("MapSettingFE6View.OnExpandListClick inner failed: {0}", inner.ToString());
+                    Log.ErrorF("MapSettingFE6View.OnExpandListClick inner failed: {0}", inner.ToString());
                     CoreState.Services?.ShowError(R._("Map setting list expansion failed: {0}", inner.Message));
                 }
             }
             catch (Exception ex)
             {
-                Log.Error("MapSettingFE6View.OnExpandListClick failed: {0}", ex.ToString());
+                Log.ErrorF("MapSettingFE6View.OnExpandListClick failed: {0}", ex.ToString());
             }
         }
 
@@ -119,7 +119,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             if (_vm.CurrentAddr == 0) return;
             try { WindowManager.Instance.Navigate<MapEditorView>(_vm.CurrentAddr); }
-            catch (Exception ex) { Log.Error("MapSettingFE6View.JumpMapEditor failed: {0}", ex.ToString()); }
+            catch (Exception ex) { Log.ErrorF("MapSettingFE6View.JumpMapEditor failed: {0}", ex.ToString()); }
         }
 
         // 離脱ポイントへJump — map id -> exit-point table slot -> navigate.
@@ -138,7 +138,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 }
                 WindowManager.Instance.Navigate<MapExitPointView>(slot);
             }
-            catch (Exception ex) { Log.Error("MapSettingFE6View.JumpExitPoint failed: {0}", ex.ToString()); }
+            catch (Exception ex) { Log.ErrorF("MapSettingFE6View.JumpExitPoint failed: {0}", ex.ToString()); }
         }
 
         void LoadList()
@@ -151,7 +151,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapSettingFE6View.LoadList failed: {0}", ex.ToString());
+                Log.ErrorF("MapSettingFE6View.LoadList failed: {0}", ex.ToString());
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -166,7 +166,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapSettingFE6View.OnSelected failed: {0}", ex.ToString());
+                Log.ErrorF("MapSettingFE6View.OnSelected failed: {0}", ex.ToString());
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -384,7 +384,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("MapSettingFE6View.Write failed: {0}", ex.ToString());
+                Log.ErrorF("MapSettingFE6View.Write failed: {0}", ex.ToString());
                 CoreState.Services?.ShowError(
                     $"Failed to write Map Setting (FE6): {ex.Message}");
             }

--- a/FEBuilderGBA.Avalonia/Views/MapSettingFE7UView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapSettingFE7UView.axaml.cs
@@ -118,7 +118,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapSettingFE7UView.LoadList failed: {0}", ex.ToString());
+                Log.ErrorF("MapSettingFE7UView.LoadList failed: {0}", ex.ToString());
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -133,7 +133,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapSettingFE7UView.OnSelected failed: {0}", ex.ToString());
+                Log.ErrorF("MapSettingFE7UView.OnSelected failed: {0}", ex.ToString());
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -327,7 +327,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("MapSettingFE7UView.Write failed: {0}", ex.ToString());
+                Log.ErrorF("MapSettingFE7UView.Write failed: {0}", ex.ToString());
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/MapSettingFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapSettingFE7View.axaml.cs
@@ -118,7 +118,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapSettingFE7View.LoadList failed: {0}", ex.ToString());
+                Log.ErrorF("MapSettingFE7View.LoadList failed: {0}", ex.ToString());
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -133,7 +133,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapSettingFE7View.OnSelected failed: {0}", ex.ToString());
+                Log.ErrorF("MapSettingFE7View.OnSelected failed: {0}", ex.ToString());
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -321,7 +321,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("MapSettingFE7View.Write failed: {0}", ex.ToString());
+                Log.ErrorF("MapSettingFE7View.Write failed: {0}", ex.ToString());
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/MapSettingMainView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapSettingMainView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapSettingMainView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MapSettingMainView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapSettingMainView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MapSettingMainView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/MapSettingView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapSettingView.axaml.cs
@@ -120,7 +120,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapSettingView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MapSettingView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -135,7 +135,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapSettingView.OnMapSelected failed: {0}", ex.Message);
+                Log.ErrorF("MapSettingView.OnMapSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }

--- a/FEBuilderGBA.Avalonia/Views/MapStyleEditorAppendView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapStyleEditorAppendView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapStyleEditorAppendView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MapStyleEditorAppendView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapStyleEditorAppendView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MapStyleEditorAppendView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
@@ -169,7 +169,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapStyleEditorView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MapStyleEditorView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -212,7 +212,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _vm.IsLoading = false;
-                Log.Error("MapStyleEditorView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MapStyleEditorView.OnSelected failed: {0}", ex.Message);
             }
         }
 
@@ -362,7 +362,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("MapStyleEditorView.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("MapStyleEditorView.Write_Click failed: {0}", ex.Message);
             }
         }
 
@@ -407,7 +407,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("MapStyleEditorView.PaletteWrite_Click failed: {0}", ex.Message);
+                Log.ErrorF("MapStyleEditorView.PaletteWrite_Click failed: {0}", ex.Message);
             }
         }
 
@@ -721,7 +721,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("MapStyleEditorView.ConfigWrite_Click failed: {0}", ex.Message);
+                Log.ErrorF("MapStyleEditorView.ConfigWrite_Click failed: {0}", ex.Message);
             }
         }
 
@@ -841,7 +841,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapStyleEditorView.PaletteExport_Click failed: {0}", ex.Message);
+                Log.ErrorF("MapStyleEditorView.PaletteExport_Click failed: {0}", ex.Message);
                 CoreState.Services.ShowError(R._("Export palette failed: {0}", ex.Message));
             }
         }
@@ -886,7 +886,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapStyleEditorView.PaletteImport_Click failed: {0}", ex.Message);
+                Log.ErrorF("MapStyleEditorView.PaletteImport_Click failed: {0}", ex.Message);
                 CoreState.Services.ShowError(R._("Import palette failed: {0}", ex.Message));
             }
         }
@@ -945,7 +945,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapStyleEditorView.PaletteClipboard_Click failed: {0}", ex.Message);
+                Log.ErrorF("MapStyleEditorView.PaletteClipboard_Click failed: {0}", ex.Message);
                 CoreState.Services.ShowError(R._("Clipboard operation failed: {0}", ex.Message));
             }
         }
@@ -976,7 +976,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapStyleEditorView.ObjExport_Click failed: {0}", ex.Message);
+                Log.ErrorF("MapStyleEditorView.ObjExport_Click failed: {0}", ex.Message);
                 CoreState.Services.ShowError(R._("OBJ export failed: {0}", ex.Message));
             }
         }
@@ -1016,7 +1016,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapStyleEditorView.Undo_Click failed: {0}", ex.Message);
+                Log.ErrorF("MapStyleEditorView.Undo_Click failed: {0}", ex.Message);
                 CoreState.Services.ShowError(R._("Undo failed: {0}", ex.Message));
             }
         }
@@ -1063,7 +1063,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapStyleEditorView.Redo_Click failed: {0}", ex.Message);
+                Log.ErrorF("MapStyleEditorView.Redo_Click failed: {0}", ex.Message);
                 CoreState.Services.ShowError(R._("Redo failed: {0}", ex.Message));
             }
         }
@@ -1107,7 +1107,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapStyleEditorView.MapChipExport_Click failed: {0}", ex.Message);
+                Log.ErrorF("MapStyleEditorView.MapChipExport_Click failed: {0}", ex.Message);
                 CoreState.Services.ShowError(R._("Map Chip export failed: {0}", ex.Message));
             }
         }
@@ -1260,7 +1260,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 }
                 catch (Exception ex)
                 {
-                    Log.Error("MapStyleEditorView.ObjImport_Click decode failed: {0}", ex.Message);
+                    Log.ErrorF("MapStyleEditorView.ObjImport_Click decode failed: {0}", ex.Message);
                     CoreState.Services.ShowError(R._("Image decode error: {0}", ex.Message));
                     return;
                 }
@@ -1280,7 +1280,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 catch (Exception ex)
                 {
                     _undoService.Rollback();
-                    Log.Error("MapStyleEditorView.ObjImport_Click write failed: {0}", ex.Message);
+                    Log.ErrorF("MapStyleEditorView.ObjImport_Click write failed: {0}", ex.Message);
                     CoreState.Services.ShowError(R._("OBJ image import error: {0}", ex.Message));
                     return;
                 }
@@ -1299,14 +1299,14 @@ namespace FEBuilderGBA.Avalonia.Views
                 }
                 catch (Exception ex)
                 {
-                    Log.Error("MapStyleEditorView.ObjImport_Click UI refresh failed: {0}", ex.Message);
+                    Log.ErrorF("MapStyleEditorView.ObjImport_Click UI refresh failed: {0}", ex.Message);
                     CoreState.Services.ShowError(
                         R._("OBJ image imported but UI refresh failed: {0}. Re-select the Map Style entry to refresh the view.", ex.Message));
                 }
             }
             catch (Exception ex)
             {
-                Log.Error("MapStyleEditorView.ObjImport_Click failed: {0}", ex.Message);
+                Log.ErrorF("MapStyleEditorView.ObjImport_Click failed: {0}", ex.Message);
                 CoreState.Services.ShowError(R._("OBJ image import failed: {0}", ex.Message));
             }
         }
@@ -1358,7 +1358,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 }
                 catch (Exception ex)
                 {
-                    Log.Error("MapStyleEditorView.MapChipImport_Click read failed: {0}", ex.Message);
+                    Log.ErrorF("MapStyleEditorView.MapChipImport_Click read failed: {0}", ex.Message);
                     CoreState.Services.ShowError(R._("Failed to read file: {0}", ex.Message));
                     return;
                 }
@@ -1383,7 +1383,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 catch (Exception ex)
                 {
                     _undoService.Rollback();
-                    Log.Error("MapStyleEditorView.MapChipImport_Click write failed: {0}", ex.Message);
+                    Log.ErrorF("MapStyleEditorView.MapChipImport_Click write failed: {0}", ex.Message);
                     CoreState.Services.ShowError(R._("Import error: {0}", ex.Message));
                     return;
                 }
@@ -1415,14 +1415,14 @@ namespace FEBuilderGBA.Avalonia.Views
                 {
                     // Import succeeded but UI refresh failed — tell the user
                     // their data is safe and ask them to reload.
-                    Log.Error("MapStyleEditorView.MapChipImport_Click UI refresh failed: {0}", ex.Message);
+                    Log.ErrorF("MapStyleEditorView.MapChipImport_Click UI refresh failed: {0}", ex.Message);
                     CoreState.Services.ShowError(
                         R._("Import succeeded ({0} bytes) but UI refresh failed: {1}. Re-select the Map Style entry to refresh the view.", data.Length, ex.Message));
                 }
             }
             catch (Exception ex)
             {
-                Log.Error("MapStyleEditorView.MapChipImport_Click failed: {0}", ex.Message);
+                Log.ErrorF("MapStyleEditorView.MapChipImport_Click failed: {0}", ex.Message);
                 CoreState.Services.ShowError(R._("Map chip import failed: {0}", ex.Message));
             }
         }

--- a/FEBuilderGBA.Avalonia/Views/MapStyleEditorWarningView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapStyleEditorWarningView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapStyleEditorWarningView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MapStyleEditorWarningView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapStyleEditorWarningView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MapStyleEditorWarningView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/MapTerrainBGLookupView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapTerrainBGLookupView.axaml.cs
@@ -50,7 +50,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapTerrainBGLookupView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MapTerrainBGLookupView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -63,7 +63,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapTerrainBGLookupView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MapTerrainBGLookupView.OnSelected failed: {0}", ex.Message);
             }
         }
 
@@ -88,7 +88,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("MapTerrainBGLookupView.Write failed: {0}", ex.Message);
+                Log.ErrorF("MapTerrainBGLookupView.Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/MapTerrainFloorLookupView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapTerrainFloorLookupView.axaml.cs
@@ -31,7 +31,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapTerrainFloorLookupView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MapTerrainFloorLookupView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -44,7 +44,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapTerrainFloorLookupView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MapTerrainFloorLookupView.OnSelected failed: {0}", ex.Message);
             }
         }
 
@@ -69,7 +69,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("MapTerrainFloorLookupView.Write failed: {0}", ex.Message);
+                Log.ErrorF("MapTerrainFloorLookupView.Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/MapTerrainNameEngView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapTerrainNameEngView.axaml.cs
@@ -32,7 +32,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapTerrainNameEngView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MapTerrainNameEngView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -47,7 +47,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapTerrainNameEngView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MapTerrainNameEngView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -74,7 +74,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.MarkClean();
                 CoreState.Services?.ShowInfo("Terrain Name (English) data written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("MapTerrainNameEngView.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("MapTerrainNameEngView.Write: {0}", ex.Message); }
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/FEBuilderGBA.Avalonia/Views/MapTerrainNameView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapTerrainNameView.axaml.cs
@@ -30,7 +30,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapTerrainNameView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MapTerrainNameView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -47,7 +47,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _vm.IsLoading = false;
-                Log.Error("MapTerrainNameView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MapTerrainNameView.OnSelected failed: {0}", ex.Message);
             }
         }
 
@@ -88,7 +88,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("MapTerrainNameView.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("MapTerrainNameView.Write_Click failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/MapTileAnimation1View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapTileAnimation1View.axaml.cs
@@ -101,7 +101,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapTileAnimation1View.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MapTileAnimation1View.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -179,7 +179,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapTileAnimation1View.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MapTileAnimation1View.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -209,7 +209,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.MarkClean();
                 CoreState.Services?.ShowInfo("Tile Animation Type 1 data written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("MapTileAnimation1View.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("MapTileAnimation1View.Write: {0}", ex.Message); }
         }
 
         // -----------------------------------------------------------------

--- a/FEBuilderGBA.Avalonia/Views/MapTileAnimation2View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapTileAnimation2View.axaml.cs
@@ -79,7 +79,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapTileAnimation2View.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MapTileAnimation2View.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -183,7 +183,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapTileAnimation2View.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MapTileAnimation2View.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -305,7 +305,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 finally { _vm.IsLoading = false; _vm.MarkClean(); }
                 CoreState.Services?.ShowInfo("Tile Animation Type 2 data written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("MapTileAnimation2View.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("MapTileAnimation2View.Write: {0}", ex.Message); }
         }
 
         void NWrite_Click(object? sender, RoutedEventArgs e)
@@ -330,7 +330,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 UpdatePaletteSubList();
                 CoreState.Services?.ShowInfo("Palette row written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("MapTileAnimation2View.NWrite: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("MapTileAnimation2View.NWrite: {0}", ex.Message); }
         }
 
         // -----------------------------------------------------------------
@@ -369,7 +369,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("MapTileAnimation2View.ListExpand_Click: {0}", ex.Message);
+                Log.ErrorF("MapTileAnimation2View.ListExpand_Click: {0}", ex.Message);
             }
         }
 
@@ -408,7 +408,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("MapTileAnimation2View.NListExpand_Click: {0}", ex.Message);
+                Log.ErrorF("MapTileAnimation2View.NListExpand_Click: {0}", ex.Message);
             }
         }
 
@@ -456,12 +456,12 @@ namespace FEBuilderGBA.Avalonia.Views
                 catch (Exception inner)
                 {
                     _undoService.Rollback();
-                    Log.Error("MapTileAnimation2View.BulkImport: {0}", inner.Message);
+                    Log.ErrorF("MapTileAnimation2View.BulkImport: {0}", inner.Message);
                 }
             }
             catch (Exception ex)
             {
-                Log.Error("MapTileAnimation2View.BulkImport_Click: {0}", ex.Message);
+                Log.ErrorF("MapTileAnimation2View.BulkImport_Click: {0}", ex.Message);
             }
         }
 
@@ -493,7 +493,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapTileAnimation2View.BulkExport_Click: {0}", ex.Message);
+                Log.ErrorF("MapTileAnimation2View.BulkExport_Click: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/MapTileAnimationView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapTileAnimationView.axaml.cs
@@ -32,7 +32,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapTileAnimationView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MapTileAnimationView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -47,7 +47,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MapTileAnimationView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MapTileAnimationView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -75,7 +75,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.MarkClean();
                 CoreState.Services?.ShowInfo("Map Tile Animation data written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("MapTileAnimationView.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("MapTileAnimationView.Write: {0}", ex.Message); }
         }
 
         public void NavigateTo(uint address)

--- a/FEBuilderGBA.Avalonia/Views/MenuCommandView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MenuCommandView.axaml.cs
@@ -52,7 +52,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MenuCommandView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MenuCommandView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -97,7 +97,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MenuCommandView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MenuCommandView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -148,7 +148,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.MarkClean();
                 CoreState.Services?.ShowInfo("Menu command data written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("MenuCommandView.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("MenuCommandView.Write: {0}", ex.Message); }
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/FEBuilderGBA.Avalonia/Views/MenuDefinitionView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MenuDefinitionView.axaml.cs
@@ -32,7 +32,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MenuDefinitionView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MenuDefinitionView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -47,7 +47,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MenuDefinitionView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MenuDefinitionView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -92,7 +92,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.MarkClean();
                 CoreState.Services?.ShowInfo("Menu definition data written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("MenuDefinitionView.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("MenuDefinitionView.Write: {0}", ex.Message); }
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/FEBuilderGBA.Avalonia/Views/MonsterItemViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MonsterItemViewerView.axaml.cs
@@ -75,7 +75,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MonsterItemViewerView.LoadItemList failed: {0}", ex.Message);
+                Log.ErrorF("MonsterItemViewerView.LoadItemList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -90,7 +90,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MonsterItemViewerView.OnItemSelected failed: {0}", ex.Message);
+                Log.ErrorF("MonsterItemViewerView.OnItemSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -101,7 +101,7 @@ namespace FEBuilderGBA.Avalonia.Views
             ItemSelectedAddrLabel.Text = $"0x{_vm.CurrentAddr:X08}";
             ItemIdBox.Value = _vm.ItemId;
             try { ItemIdBox.NameText = NameResolver.GetItemName(_vm.ItemId); }
-            catch (Exception ex) { Log.Error("MonsterItemViewerView.UpdateItemUI ItemName: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("MonsterItemViewerView.UpdateItemUI ItemName: {0}", ex.Message); }
             // #950 T4: Item 2..5 (B1..B4) are item IDs; populate the IdFieldControl
             // value + inline item-name preview just like slot-1 ItemIdBox.
             DropRateBox.Value = _vm.DropRate;
@@ -115,7 +115,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 Unknown2Box.NameText = NameResolver.GetItemName(_vm.Unknown2);
                 Unknown3Box.NameText = NameResolver.GetItemName(_vm.Unknown3);
             }
-            catch (Exception ex) { Log.Error("MonsterItemViewerView.UpdateItemUI ItemName 2..5: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("MonsterItemViewerView.UpdateItemUI ItemName 2..5: {0}", ex.Message); }
             ItemCommentBox.Text = ReadComment(_vm.CurrentAddr);
         }
 
@@ -146,7 +146,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("MonsterItemViewerView.ItemWrite: {0}", ex.Message);
+                Log.ErrorF("MonsterItemViewerView.ItemWrite: {0}", ex.Message);
             }
         }
 
@@ -181,7 +181,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("MonsterItemViewerView.ItemExpand: {0}", ex.Message);
+                Log.ErrorF("MonsterItemViewerView.ItemExpand: {0}", ex.Message);
             }
         }
 
@@ -206,7 +206,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MonsterItemViewerView.LoadProbList failed: {0}", ex.Message);
+                Log.ErrorF("MonsterItemViewerView.LoadProbList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -221,7 +221,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MonsterItemViewerView.OnProbSelected failed: {0}", ex.Message);
+                Log.ErrorF("MonsterItemViewerView.OnProbSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -270,7 +270,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("MonsterItemViewerView.ProbabilityWrite: {0}", ex.Message);
+                Log.ErrorF("MonsterItemViewerView.ProbabilityWrite: {0}", ex.Message);
             }
         }
 
@@ -305,7 +305,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("MonsterItemViewerView.ProbExpand: {0}", ex.Message);
+                Log.ErrorF("MonsterItemViewerView.ProbExpand: {0}", ex.Message);
             }
         }
 
@@ -330,7 +330,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MonsterItemViewerView.LoadHoldList failed: {0}", ex.Message);
+                Log.ErrorF("MonsterItemViewerView.LoadHoldList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -345,7 +345,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MonsterItemViewerView.OnHoldingSelected failed: {0}", ex.Message);
+                Log.ErrorF("MonsterItemViewerView.OnHoldingSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -356,7 +356,7 @@ namespace FEBuilderGBA.Avalonia.Views
             HoldSelectedAddrLabel.Text = $"0x{_vm.HoldingAddr:X08}";
             HoldClassIdBox.Value = _vm.ClassId;
             try { HoldClassIdBox.NameText = NameResolver.GetClassName(_vm.ClassId); }
-            catch (Exception ex) { Log.Error("MonsterItemViewerView.UpdateHoldingUI ClassName: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("MonsterItemViewerView.UpdateHoldingUI ClassName: {0}", ex.Message); }
 
             HoldItem1Box.Value = _vm.HoldingItem1;
             HoldItem2Box.Value = _vm.HoldingItem2;
@@ -462,7 +462,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("MonsterItemViewerView.HoldingsWrite: {0}", ex.Message);
+                Log.ErrorF("MonsterItemViewerView.HoldingsWrite: {0}", ex.Message);
             }
         }
 
@@ -497,7 +497,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("MonsterItemViewerView.HoldExpand: {0}", ex.Message);
+                Log.ErrorF("MonsterItemViewerView.HoldExpand: {0}", ex.Message);
             }
         }
 
@@ -529,7 +529,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 }
                 EntryList.SelectByIndex((int)(value - 1));
             }
-            catch (Exception ex) { Log.Error("MonsterItemViewerView.JumpToItemRow: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("MonsterItemViewerView.JumpToItemRow: {0}", ex.Message); }
         }
 
         /// <summary>
@@ -550,7 +550,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 }
                 ProbEntryList.SelectByIndex((int)(value - 1));
             }
-            catch (Exception ex) { Log.Error("MonsterItemViewerView.JumpToProbRow: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("MonsterItemViewerView.JumpToProbRow: {0}", ex.Message); }
         }
 
         // 10 holding-item jump handlers (B1..B10 -> Item tab).
@@ -623,7 +623,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (result != null)
                     box.Value = (uint)result.Index;
             }
-            catch (Exception ex) { Log.Error("MonsterItemViewerView.PickItemIdInto: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("MonsterItemViewerView.PickItemIdInto: {0}", ex.Message); }
         }
 
         void ItemId_Jump(object? sender, RoutedEventArgs e)
@@ -637,7 +637,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 else
                     WindowManager.Instance.Navigate<ItemEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("MonsterItemViewerView.ItemId_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("MonsterItemViewerView.ItemId_Jump failed: {0}", ex.Message); }
         }
 
         async void ItemId_Pick(object? sender, RoutedEventArgs e) => await PickItemIdInto(ItemIdBox);
@@ -668,7 +668,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 else
                     WindowManager.Instance.Navigate<ItemEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("MonsterItemViewerView.JumpToItemEditor: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("MonsterItemViewerView.JumpToItemEditor: {0}", ex.Message); }
         }
 
         void Item2_Jump(object? sender, RoutedEventArgs e) => JumpToItemEditor(DropRateBox);
@@ -732,7 +732,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (addr == 0) return;
                 WindowManager.Instance.Navigate<ClassEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("MonsterItemViewerView.HoldClassId_Jump: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("MonsterItemViewerView.HoldClassId_Jump: {0}", ex.Message); }
         }
 
         async void HoldClassId_Pick(object? sender, RoutedEventArgs e)
@@ -743,13 +743,13 @@ namespace FEBuilderGBA.Avalonia.Views
                 var result = await WindowManager.Instance.PickFromEditor<ClassEditorView>(addr, this);
                 if (result != null) HoldClassIdBox.Value = (uint)result.Index;
             }
-            catch (Exception ex) { Log.Error("MonsterItemViewerView.HoldClassId_Pick: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("MonsterItemViewerView.HoldClassId_Pick: {0}", ex.Message); }
         }
 
         void HoldClassId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
         {
             try { HoldClassIdBox.NameText = NameResolver.GetClassName(e.NewValue); }
-            catch (Exception ex) { Log.Error("MonsterItemViewerView.HoldClassId_ValueChanged: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("MonsterItemViewerView.HoldClassId_ValueChanged: {0}", ex.Message); }
         }
 
         // ============================================================
@@ -804,7 +804,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     CoreState.CommentCache.TryGetValue(addr, out string value))
                     return value ?? string.Empty;
             }
-            catch (Exception ex) { Log.Error("MonsterItemViewerView.ReadComment: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("MonsterItemViewerView.ReadComment: {0}", ex.Message); }
             return string.Empty;
         }
 
@@ -822,7 +822,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 CoreState.CommentCache?.Update(addr, comment ?? string.Empty);
             }
-            catch (Exception ex) { Log.Error("MonsterItemViewerView.WriteComment: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("MonsterItemViewerView.WriteComment: {0}", ex.Message); }
         }
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/MonsterProbabilityViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MonsterProbabilityViewerView.axaml.cs
@@ -43,7 +43,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MonsterProbabilityViewerView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MonsterProbabilityViewerView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
 
@@ -65,7 +65,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MonsterProbabilityViewerView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MonsterProbabilityViewerView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -87,7 +87,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 ClassId4Box.NameText = NameResolver.GetClassName(_vm.ClassId4);
                 ClassId5Box.NameText = NameResolver.GetClassName(_vm.ClassId5);
             }
-            catch (Exception ex) { Log.Error("MonsterProbabilityViewerView.UpdateUI ClassName: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("MonsterProbabilityViewerView.UpdateUI ClassName: {0}", ex.Message); }
             Prob1Box.Value = _vm.Prob1;
             Prob2Box.Value = _vm.Prob2;
             Prob3Box.Value = _vm.Prob3;
@@ -121,7 +121,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.MarkClean();
                 CoreState.Services?.ShowInfo("Monster probability data written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("MonsterProbabilityViewerView.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("MonsterProbabilityViewerView.Write: {0}", ex.Message); }
         }
 
         // ============================================================
@@ -158,7 +158,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 else
                     WindowManager.Instance.Navigate<ClassEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("MonsterProbabilityViewerView.JumpToClassEditor: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("MonsterProbabilityViewerView.JumpToClassEditor: {0}", ex.Message); }
         }
 
         async System.Threading.Tasks.Task PickClassIdInto(IdFieldControl box)
@@ -173,7 +173,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     result = await WindowManager.Instance.PickFromEditor<ClassEditorView>(addr, this);
                 if (result != null) box.Value = (uint)result.Index;
             }
-            catch (Exception ex) { Log.Error("MonsterProbabilityViewerView.PickClassIdInto: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("MonsterProbabilityViewerView.PickClassIdInto: {0}", ex.Message); }
         }
 
         static void RefreshClassName(IdFieldControl box, uint value)

--- a/FEBuilderGBA.Avalonia/Views/MoveCostEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MoveCostEditorView.axaml.cs
@@ -100,7 +100,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MoveCostEditorView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MoveCostEditorView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -122,7 +122,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     }
                     catch (Exception ex)
                     {
-                        Log.Error("MoveCostEditorView.OnCostTypeChanged failed: {0}", ex.Message);
+                        Log.ErrorF("MoveCostEditorView.OnCostTypeChanged failed: {0}", ex.Message);
                     }
                 }
             }
@@ -137,7 +137,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MoveCostEditorView.OnClassSelected failed: {0}", ex.Message);
+                Log.ErrorF("MoveCostEditorView.OnClassSelected failed: {0}", ex.Message);
             }
         }
 
@@ -268,7 +268,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("MoveCostEditorView.OnWriteClick failed: {0}", ex.Message);
+                Log.ErrorF("MoveCostEditorView.OnWriteClick failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/MoveCostFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MoveCostFE6View.axaml.cs
@@ -41,7 +41,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MoveCostFE6View.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("MoveCostFE6View.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -54,7 +54,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("MoveCostFE6View.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("MoveCostFE6View.OnSelected failed: {0}", ex.Message);
             }
         }
 
@@ -75,7 +75,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     }
                     catch (Exception ex)
                     {
-                        Log.Error("MoveCostFE6View.OnCostTypeChanged failed: {0}", ex.Message);
+                        Log.ErrorF("MoveCostFE6View.OnCostTypeChanged failed: {0}", ex.Message);
                     }
                 }
             }
@@ -117,7 +117,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("MoveCostFE6View.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("MoveCostFE6View.Write_Click failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/NotifyDirectInjectionView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/NotifyDirectInjectionView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("NotifyDirectInjectionView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("NotifyDirectInjectionView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("NotifyDirectInjectionView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("NotifyDirectInjectionView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/NotifyWriteView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/NotifyWriteView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("NotifyWriteView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("NotifyWriteView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("NotifyWriteView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("NotifyWriteView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/OAMSpriteViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OAMSpriteViewerView.axaml.cs
@@ -38,7 +38,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("OAMSpriteViewerView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("OAMSpriteViewerView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -51,7 +51,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("OAMSpriteViewerView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("OAMSpriteViewerView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/OPClassAlphaNameFE6ExtraView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OPClassAlphaNameFE6ExtraView.axaml.cs
@@ -32,7 +32,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("OPClassAlphaNameFE6ExtraView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("OPClassAlphaNameFE6ExtraView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -45,7 +45,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("OPClassAlphaNameFE6ExtraView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("OPClassAlphaNameFE6ExtraView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/OPClassAlphaNameFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OPClassAlphaNameFE6View.axaml.cs
@@ -37,7 +37,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("OPClassAlphaNameFE6View.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("OPClassAlphaNameFE6View.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -52,7 +52,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("OPClassAlphaNameFE6View.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("OPClassAlphaNameFE6View.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -76,7 +76,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.MarkClean();
                 CoreState.Services?.ShowInfo("OP Class Alpha Name (FE6) data written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("OPClassAlphaNameFE6View.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("OPClassAlphaNameFE6View.Write: {0}", ex.Message); }
         }
 
         static uint ParseHexText(string? text)

--- a/FEBuilderGBA.Avalonia/Views/OPClassAlphaNameView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OPClassAlphaNameView.axaml.cs
@@ -34,7 +34,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("OPClassAlphaNameView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("OPClassAlphaNameView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -49,7 +49,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("OPClassAlphaNameView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("OPClassAlphaNameView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -72,7 +72,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.MarkClean();
                 CoreState.Services?.ShowInfo("OP Class Alpha Name data written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("OPClassAlphaNameView.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("OPClassAlphaNameView.Write: {0}", ex.Message); }
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/FEBuilderGBA.Avalonia/Views/OPClassDemoFE7UView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OPClassDemoFE7UView.axaml.cs
@@ -104,7 +104,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("OPClassDemoFE7UView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("OPClassDemoFE7UView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -119,7 +119,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("OPClassDemoFE7UView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("OPClassDemoFE7UView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -261,7 +261,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 UpdateUI();
                 CoreState.Services?.ShowInfo("OP Class Demo (FE7U) data written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("OPClassDemoFE7UView.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("OPClassDemoFE7UView.Write: {0}", ex.Message); }
         }
 
         void NWrite_Click(object? sender, RoutedEventArgs e)
@@ -285,7 +285,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 RebuildN2ListBox();
                 CoreState.Services?.ShowInfo("Animation command written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("OPClassDemoFE7UView.NWrite: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("OPClassDemoFE7UView.NWrite: {0}", ex.Message); }
         }
 
         // -- IdFieldControl handlers (#360 final) ---------------------------
@@ -317,7 +317,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 else
                     WindowManager.Instance.Navigate<ClassEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("OPClassDemoFE7UView.ClassId_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("OPClassDemoFE7UView.ClassId_Jump failed: {0}", ex.Message); }
         }
 
         async void ClassId_Pick(object? sender, RoutedEventArgs e)
@@ -332,7 +332,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     result = await WindowManager.Instance.PickFromEditor<ClassEditorView>(addr, this);
                 if (result != null) ClassIdBox.Value = (uint)result.Index;
             }
-            catch (Exception ex) { Log.Error("OPClassDemoFE7UView.ClassId_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("OPClassDemoFE7UView.ClassId_Pick failed: {0}", ex.Message); }
         }
 
         void ClassId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/OPClassDemoFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OPClassDemoFE7View.axaml.cs
@@ -107,7 +107,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("OPClassDemoFE7View.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("OPClassDemoFE7View.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -122,7 +122,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("OPClassDemoFE7View.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("OPClassDemoFE7View.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -273,7 +273,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 UpdateUI();
                 CoreState.Services?.ShowInfo("OP Class Demo (FE7) data written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("OPClassDemoFE7View.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("OPClassDemoFE7View.Write: {0}", ex.Message); }
         }
 
         void NWrite_Click(object? sender, RoutedEventArgs e)
@@ -297,7 +297,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 RebuildN2ListBox();
                 CoreState.Services?.ShowInfo("Animation command written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("OPClassDemoFE7View.NWrite: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("OPClassDemoFE7View.NWrite: {0}", ex.Message); }
         }
 
         // -- IdFieldControl handlers (#360 final) ---------------------------
@@ -329,7 +329,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 else
                     WindowManager.Instance.Navigate<ClassEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("OPClassDemoFE7View.ClassId_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("OPClassDemoFE7View.ClassId_Jump failed: {0}", ex.Message); }
         }
 
         async void ClassId_Pick(object? sender, RoutedEventArgs e)
@@ -344,7 +344,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     result = await WindowManager.Instance.PickFromEditor<ClassEditorView>(addr, this);
                 if (result != null) ClassIdBox.Value = (uint)result.Index;
             }
-            catch (Exception ex) { Log.Error("OPClassDemoFE7View.ClassId_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("OPClassDemoFE7View.ClassId_Pick failed: {0}", ex.Message); }
         }
 
         void ClassId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/OPClassDemoFE8UView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OPClassDemoFE8UView.axaml.cs
@@ -46,7 +46,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("OPClassDemoFE8UView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("OPClassDemoFE8UView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -61,7 +61,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("OPClassDemoFE8UView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("OPClassDemoFE8UView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -106,7 +106,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.MarkClean();
                 CoreState.Services?.ShowInfo("OP Class Demo (FE8U) data written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("OPClassDemoFE8UView.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("OPClassDemoFE8UView.Write: {0}", ex.Message); }
         }
 
         // -- IdFieldControl handlers (#360) ----------------------------------
@@ -138,7 +138,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 else
                     WindowManager.Instance.Navigate<ClassEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("OPClassDemoFE8UView.ClassId_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("OPClassDemoFE8UView.ClassId_Jump failed: {0}", ex.Message); }
         }
 
         async void ClassId_Pick(object? sender, RoutedEventArgs e)
@@ -153,7 +153,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     result = await WindowManager.Instance.PickFromEditor<ClassEditorView>(addr, this);
                 if (result != null) ClassIdBox.Value = (uint)result.Index;
             }
-            catch (Exception ex) { Log.Error("OPClassDemoFE8UView.ClassId_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("OPClassDemoFE8UView.ClassId_Pick failed: {0}", ex.Message); }
         }
 
         void ClassId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/OPClassFontFE8UView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OPClassFontFE8UView.axaml.cs
@@ -37,7 +37,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("OPClassFontFE8UView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("OPClassFontFE8UView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -52,7 +52,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("OPClassFontFE8UView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("OPClassFontFE8UView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -75,7 +75,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.MarkClean();
                 CoreState.Services?.ShowInfo("OP Class Font (FE8U) data written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("OPClassFontFE8UView.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("OPClassFontFE8UView.Write: {0}", ex.Message); }
         }
 
         static uint ParseHexText(string? text)

--- a/FEBuilderGBA.Avalonia/Views/OPPrologueViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OPPrologueViewerView.axaml.cs
@@ -28,7 +28,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             _vm.IsLoading = true;
             try { var items = _vm.LoadOPPrologueList(); EntryList.SetItems(items); }
-            catch (Exception ex) { Log.Error("OPPrologueViewerView.LoadList: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("OPPrologueViewerView.LoadList: {0}", ex.Message); }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
 
@@ -41,7 +41,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 UpdateUI();
                 LoadImage();
             }
-            catch (Exception ex) { Log.Error("OPPrologueViewerView.OnSelected: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("OPPrologueViewerView.OnSelected: {0}", ex.Message); }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
 
@@ -75,7 +75,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.MarkClean();
                 CoreState.Services?.ShowInfo("OP Prologue data written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("OPPrologueViewerView.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("OPPrologueViewerView.Write: {0}", ex.Message); }
         }
 
         async void ExportPng_Click(object? sender, RoutedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/PatchManagerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/PatchManagerView.axaml.cs
@@ -34,7 +34,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("PatchManagerView.LoadPatches failed: {0}", ex.Message);
+                Log.ErrorF("PatchManagerView.LoadPatches failed: {0}", ex.Message);
             }
         }
 
@@ -203,7 +203,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("PatchManagerView.JumpTo failed: {0}", ex.Message);
+                Log.ErrorF("PatchManagerView.JumpTo failed: {0}", ex.Message);
             }
         }
     }

--- a/FEBuilderGBA.Avalonia/Views/PatchUninstallDialogView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/PatchUninstallDialogView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("PatchUninstallDialogView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("PatchUninstallDialogView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("PatchUninstallDialogView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("PatchUninstallDialogView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/PointerToolCopyToView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/PointerToolCopyToView.axaml.cs
@@ -115,7 +115,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("PointerToolCopyToView.HexButton_Click: {0}", ex.Message);
+                Log.ErrorF("PointerToolCopyToView.HexButton_Click: {0}", ex.Message);
             }
         }
 
@@ -150,7 +150,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("PointerToolCopyToView.SetClipboardAsync failed: {0}", ex.Message);
+                Log.ErrorF("PointerToolCopyToView.SetClipboardAsync failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/PortraitViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/PortraitViewerView.axaml.cs
@@ -37,7 +37,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("PortraitViewerView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("PortraitViewerView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -53,7 +53,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("PortraitViewerView.OnPortraitSelected failed: {0}", ex.Message);
+                Log.ErrorF("PortraitViewerView.OnPortraitSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -119,7 +119,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("TryShowPortraitImage main failed: {0}", ex.Message);
+                Log.ErrorF("TryShowPortraitImage main failed: {0}", ex.Message);
                 MainPortraitImage.SetImage(null);
             }
 
@@ -129,7 +129,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("TryShowPortraitImage map failed: {0}", ex.Message);
+                Log.ErrorF("TryShowPortraitImage map failed: {0}", ex.Message);
                 MapPortraitImage.SetImage(null);
             }
 
@@ -139,7 +139,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("TryShowPortraitImage class failed: {0}", ex.Message);
+                Log.ErrorF("TryShowPortraitImage class failed: {0}", ex.Message);
                 ClassPortraitImage.SetImage(null);
             }
         }

--- a/FEBuilderGBA.Avalonia/Views/SMEPromoListView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SMEPromoListView.axaml.cs
@@ -60,7 +60,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SMEPromoListView.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("SMEPromoListView.Write_Click failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassCSkillSysView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassCSkillSysView.axaml.cs
@@ -79,7 +79,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillAssignmentClassCSkillSysView.Initialize failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentClassCSkillSysView.Initialize failed: {0}", ex.Message);
             }
             finally { _vm.IsLoaded = true; }
         }
@@ -113,7 +113,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillAssignmentClassCSkillSysView.LoadClassList failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentClassCSkillSysView.LoadClassList failed: {0}", ex.Message);
             }
         }
 
@@ -176,7 +176,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillAssignmentClassCSkillSysView.OnClassSelected failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentClassCSkillSysView.OnClassSelected failed: {0}", ex.Message);
             }
         }
 
@@ -198,7 +198,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillAssignmentClassCSkillSysView.LoadN1Sublist failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentClassCSkillSysView.LoadN1Sublist failed: {0}", ex.Message);
             }
         }
 
@@ -226,7 +226,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillAssignmentClassCSkillSysView.OnN1Selected failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentClassCSkillSysView.OnN1Selected failed: {0}", ex.Message);
             }
         }
 
@@ -320,7 +320,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SkillAssignmentClassCSkillSysView.OnWrite failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentClassCSkillSysView.OnWrite failed: {0}", ex.Message);
             }
         }
 
@@ -339,7 +339,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SkillAssignmentClassCSkillSysView.OnN1Write failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentClassCSkillSysView.OnN1Write failed: {0}", ex.Message);
             }
         }
 
@@ -363,7 +363,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SkillAssignmentClassCSkillSysView.OnIndependence failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentClassCSkillSysView.OnIndependence failed: {0}", ex.Message);
             }
         }
 
@@ -389,7 +389,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SkillAssignmentClassCSkillSysView.OnN1Expand failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentClassCSkillSysView.OnN1Expand failed: {0}", ex.Message);
             }
         }
 
@@ -503,7 +503,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillAssignmentClassCSkillSysView.OnLearnInfo failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentClassCSkillSysView.OnLearnInfo failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassSkillSystemView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassSkillSystemView.axaml.cs
@@ -48,7 +48,7 @@ namespace FEBuilderGBA.Avalonia.Views
         static void DisposeBitmap(ref Bitmap bmp)
         {
             if (bmp == null) return;
-            try { bmp.Dispose(); } catch (System.Exception ex) { Log.Debug("SkillAssignmentClassSkillSystemView dispose bmp: {0}", ex.Message); }
+            try { bmp.Dispose(); } catch (System.Exception ex) { Log.DebugF("SkillAssignmentClassSkillSystemView dispose bmp: {0}", ex.Message); }
             bmp = null;
         }
 
@@ -71,7 +71,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillAssignmentClassSkillSystemView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentClassSkillSystemView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -95,7 +95,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillAssignmentClassSkillSystemView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentClassSkillSystemView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -160,7 +160,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             if (_classIconBitmap != null && !ReferenceEquals(_classIconBitmap, bmp))
             {
-                try { _classIconBitmap.Dispose(); } catch (System.Exception ex) { Log.Debug("SkillAssignmentClassSkillSystemView dispose class icon: {0}", ex.Message); }
+                try { _classIconBitmap.Dispose(); } catch (System.Exception ex) { Log.DebugF("SkillAssignmentClassSkillSystemView dispose class icon: {0}", ex.Message); }
             }
             _classIconBitmap = bmp;
             SkillIconImage.Source = bmp;
@@ -189,7 +189,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             if (_n1IconBitmap != null && !ReferenceEquals(_n1IconBitmap, bmp))
             {
-                try { _n1IconBitmap.Dispose(); } catch (System.Exception ex) { Log.Debug("SkillAssignmentClassSkillSystemView dispose n1 icon: {0}", ex.Message); }
+                try { _n1IconBitmap.Dispose(); } catch (System.Exception ex) { Log.DebugF("SkillAssignmentClassSkillSystemView dispose n1 icon: {0}", ex.Message); }
             }
             _n1IconBitmap = bmp;
             N1SkillIconImage.Source = bmp;
@@ -218,7 +218,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SkillAssignmentClassSkillSystemView.MasterWrite failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentClassSkillSystemView.MasterWrite failed: {0}", ex.Message);
             }
         }
 
@@ -233,7 +233,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillAssignmentClassSkillSystemView.N1EntryList_SelectionChanged failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentClassSkillSystemView.N1EntryList_SelectionChanged failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; }
         }
@@ -287,7 +287,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SkillAssignmentClassSkillSystemView.N1Write failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentClassSkillSystemView.N1Write failed: {0}", ex.Message);
             }
         }
 
@@ -306,7 +306,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillAssignmentClassSkillSystemView.N1ReloadList failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentClassSkillSystemView.N1ReloadList failed: {0}", ex.Message);
             }
         }
 
@@ -331,7 +331,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SkillAssignmentClassSkillSystemView.N1ListExpand failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentClassSkillSystemView.N1ListExpand failed: {0}", ex.Message);
             }
         }
 
@@ -379,7 +379,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SkillAssignmentClassSkillSystemView.Independence failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentClassSkillSystemView.Independence failed: {0}", ex.Message);
             }
         }
 
@@ -449,7 +449,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillAssignmentClassSkillSystemView.LearnInfo failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentClassSkillSystemView.LearnInfo failed: {0}", ex.Message);
             }
         }
 
@@ -477,7 +477,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillAssignmentClassSkillSystemView.BulkExport failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentClassSkillSystemView.BulkExport failed: {0}", ex.Message);
             }
         }
 
@@ -523,12 +523,12 @@ namespace FEBuilderGBA.Avalonia.Views
                 catch (Exception ex)
                 {
                     _undoService.Rollback();
-                    Log.Error("SkillAssignmentClassSkillSystemView.BulkImport failed: {0}", ex.Message);
+                    Log.ErrorF("SkillAssignmentClassSkillSystemView.BulkImport failed: {0}", ex.Message);
                 }
             }
             catch (Exception ex)
             {
-                Log.Error("SkillAssignmentClassSkillSystemView.BulkImport file picker failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentClassSkillSystemView.BulkImport file picker failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentUnitSkillSystemView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentUnitSkillSystemView.axaml.cs
@@ -53,7 +53,7 @@ namespace FEBuilderGBA.Avalonia.Views
         static void DisposeBitmap(ref Bitmap bmp)
         {
             if (bmp == null) return;
-            try { bmp.Dispose(); } catch (System.Exception ex) { Log.Debug("SkillAssignmentUnitSkillSystemView dispose bmp: {0}", ex.Message); }
+            try { bmp.Dispose(); } catch (System.Exception ex) { Log.DebugF("SkillAssignmentUnitSkillSystemView dispose bmp: {0}", ex.Message); }
             bmp = null;
         }
 
@@ -92,7 +92,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillAssignmentUnitSkillSystemView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentUnitSkillSystemView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -114,7 +114,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillAssignmentUnitSkillSystemView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentUnitSkillSystemView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -169,7 +169,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             if (_unitIconBitmap != null && !ReferenceEquals(_unitIconBitmap, bmp))
             {
-                try { _unitIconBitmap.Dispose(); } catch (System.Exception ex) { Log.Debug("SkillAssignmentUnitSkillSystemView dispose unit icon: {0}", ex.Message); }
+                try { _unitIconBitmap.Dispose(); } catch (System.Exception ex) { Log.DebugF("SkillAssignmentUnitSkillSystemView dispose unit icon: {0}", ex.Message); }
             }
             _unitIconBitmap = bmp;
             SkillIconImage.Source = bmp;
@@ -198,7 +198,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             if (_n1IconBitmap != null && !ReferenceEquals(_n1IconBitmap, bmp))
             {
-                try { _n1IconBitmap.Dispose(); } catch (System.Exception ex) { Log.Debug("SkillAssignmentUnitSkillSystemView dispose n1 icon: {0}", ex.Message); }
+                try { _n1IconBitmap.Dispose(); } catch (System.Exception ex) { Log.DebugF("SkillAssignmentUnitSkillSystemView dispose n1 icon: {0}", ex.Message); }
             }
             _n1IconBitmap = bmp;
             N1SkillIconImage.Source = bmp;
@@ -222,7 +222,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SkillAssignmentUnitSkillSystemView.MasterWrite failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentUnitSkillSystemView.MasterWrite failed: {0}", ex.Message);
             }
         }
 
@@ -237,7 +237,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillAssignmentUnitSkillSystemView.N1EntryList_SelectionChanged failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentUnitSkillSystemView.N1EntryList_SelectionChanged failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; }
         }
@@ -274,7 +274,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SkillAssignmentUnitSkillSystemView.N1Write failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentUnitSkillSystemView.N1Write failed: {0}", ex.Message);
             }
         }
 
@@ -293,7 +293,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillAssignmentUnitSkillSystemView.N1ReloadList failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentUnitSkillSystemView.N1ReloadList failed: {0}", ex.Message);
             }
         }
 
@@ -464,7 +464,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillAssignmentUnitSkillSystemView.LearnInfo failed: {0}", ex.Message);
+                Log.ErrorF("SkillAssignmentUnitSkillSystemView.LearnInfo failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NSkillView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NSkillView.axaml.cs
@@ -121,7 +121,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillConfigFE8NSkillView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SkillConfigFE8NSkillView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -169,7 +169,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillConfigFE8NSkillView.FilterComboBox_SelectionChanged failed: {0}", ex.Message);
+                Log.ErrorF("SkillConfigFE8NSkillView.FilterComboBox_SelectionChanged failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -205,7 +205,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillConfigFE8NSkillView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("SkillConfigFE8NSkillView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -379,7 +379,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SkillConfigFE8NSkillView.Write failed: {0}", ex.Message);
+                Log.ErrorF("SkillConfigFE8NSkillView.Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer2SkillView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer2SkillView.axaml.cs
@@ -107,7 +107,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillConfigFE8NVer2SkillView.OnSubListChanged failed: {0}", ex.Message);
+                Log.ErrorF("SkillConfigFE8NVer2SkillView.OnSubListChanged failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -149,7 +149,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillConfigFE8NVer2SkillView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SkillConfigFE8NVer2SkillView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -172,7 +172,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillConfigFE8NVer2SkillView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("SkillConfigFE8NVer2SkillView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -294,7 +294,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SkillConfigFE8NVer2SkillView.Write failed: {0}", ex.Message);
+                Log.ErrorF("SkillConfigFE8NVer2SkillView.Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer3SkillView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer3SkillView.axaml.cs
@@ -114,7 +114,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillConfigFE8NVer3SkillView.OnSubListChanged failed: {0}", ex.Message);
+                Log.ErrorF("SkillConfigFE8NVer3SkillView.OnSubListChanged failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -152,7 +152,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillConfigFE8NVer3SkillView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SkillConfigFE8NVer3SkillView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -175,7 +175,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillConfigFE8NVer3SkillView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("SkillConfigFE8NVer3SkillView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -296,7 +296,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SkillConfigFE8NVer3SkillView.Write failed: {0}", ex.Message);
+                Log.ErrorF("SkillConfigFE8NVer3SkillView.Write failed: {0}", ex.Message);
             }
         }
 
@@ -458,7 +458,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillConfigFE8NVer3SkillView.JumpToCombatArt_Click failed: {0}", ex.Message);
+                Log.ErrorF("SkillConfigFE8NVer3SkillView.JumpToCombatArt_Click failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8UCSkillSys09xView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8UCSkillSys09xView.axaml.cs
@@ -76,7 +76,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillConfigFE8UCSkillSys09xView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SkillConfigFE8UCSkillSys09xView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -99,7 +99,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillConfigFE8UCSkillSys09xView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("SkillConfigFE8UCSkillSys09xView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -183,7 +183,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SkillConfigFE8UCSkillSys09xView.Write failed: {0}", ex.Message);
+                Log.ErrorF("SkillConfigFE8UCSkillSys09xView.Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigSkillSystemView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigSkillSystemView.axaml.cs
@@ -86,7 +86,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillConfigSkillSystemView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SkillConfigSkillSystemView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -109,7 +109,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillConfigSkillSystemView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("SkillConfigSkillSystemView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -204,7 +204,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SkillConfigSkillSystemView.Write failed: {0}", ex.Message);
+                Log.ErrorF("SkillConfigSkillSystemView.Write failed: {0}", ex.Message);
             }
         }
 
@@ -396,7 +396,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     }
                     catch (Exception ex)
                     {
-                        Log.Error("SkillConfigSkillSystemView.BulkImport image load failed: {0}", ex.Message);
+                        Log.ErrorF("SkillConfigSkillSystemView.BulkImport image load failed: {0}", ex.Message);
                         return null;
                     }
                 };

--- a/FEBuilderGBA.Avalonia/Views/SkillSubListEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillSubListEditorView.axaml.cs
@@ -145,7 +145,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 undoService.Rollback();
-                Log.Error("SkillSubListEditorView.{0} failed: {1}", label, ex.Message);
+                Log.ErrorF("SkillSubListEditorView.{0} failed: {1}", label, ex.Message);
                 CoreState.Services?.ShowError(ex.Message);
             }
         }

--- a/FEBuilderGBA.Avalonia/Views/SkillSystemsCSkillRechainView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillSystemsCSkillRechainView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillSystemsCSkillRechainView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SkillSystemsCSkillRechainView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SkillSystemsCSkillRechainView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("SkillSystemsCSkillRechainView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/SomeClassListView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SomeClassListView.axaml.cs
@@ -94,7 +94,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SomeClassListView.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("SomeClassListView.Write_Click failed: {0}", ex.Message);
             }
         }
     }

--- a/FEBuilderGBA.Avalonia/Views/SongExchangeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SongExchangeView.axaml.cs
@@ -37,7 +37,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongExchangeView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SongExchangeView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -49,7 +49,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongExchangeView.LoadCurrentSongs failed: {0}", ex.Message);
+                Log.ErrorF("SongExchangeView.LoadCurrentSongs failed: {0}", ex.Message);
             }
         }
 
@@ -62,7 +62,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongExchangeView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("SongExchangeView.OnSelected failed: {0}", ex.Message);
             }
         }
 
@@ -93,7 +93,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongExchangeView.OpenOtherRom_Click failed: {0}", ex.Message);
+                Log.ErrorF("SongExchangeView.OpenOtherRom_Click failed: {0}", ex.Message);
                 CoreState.Services.ShowError(R._("Failed to open ROM: {0}", ex.Message));
             }
         }
@@ -161,7 +161,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SongExchangeView.Convert_Click failed: {0}", ex.Message);
+                Log.ErrorF("SongExchangeView.Convert_Click failed: {0}", ex.Message);
                 CoreState.Services.ShowError(R._("Convert failed: {0}", ex.Message));
             }
         }

--- a/FEBuilderGBA.Avalonia/Views/SongInstrumentDirectSoundView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SongInstrumentDirectSoundView.axaml.cs
@@ -31,7 +31,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongInstrumentDirectSoundView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SongInstrumentDirectSoundView.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -50,7 +50,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongInstrumentDirectSoundView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("SongInstrumentDirectSoundView.OnSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -87,7 +87,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SongInstrumentDirectSoundView.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("SongInstrumentDirectSoundView.Write_Click failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/SongInstrumentView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SongInstrumentView.axaml.cs
@@ -122,7 +122,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongInstrumentView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SongInstrumentView.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -147,7 +147,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongInstrumentView.JumpToAddr failed: {0}", ex.Message);
+                Log.ErrorF("SongInstrumentView.JumpToAddr failed: {0}", ex.Message);
             }
             finally
             {
@@ -166,7 +166,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongInstrumentView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("SongInstrumentView.OnSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -239,7 +239,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SongInstrumentView.ListExpand_Click failed: {0}", ex.Message);
+                Log.ErrorF("SongInstrumentView.ListExpand_Click failed: {0}", ex.Message);
             }
         }
 
@@ -479,7 +479,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SongInstrumentView.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("SongInstrumentView.Write_Click failed: {0}", ex.Message);
             }
         }
 
@@ -584,7 +584,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongInstrumentView.ExportWaveGated failed: {0}", ex.Message);
+                Log.ErrorF("SongInstrumentView.ExportWaveGated failed: {0}", ex.Message);
                 CoreState.Services.ShowError(R._("Wave export failed: {0}", ex.Message));
             }
         }
@@ -644,7 +644,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 catch (Exception ex)
                 {
                     _undoService.Rollback();
-                    Log.Error("SongInstrumentView.ImportWaveGated failed: {0}", ex.Message);
+                    Log.ErrorF("SongInstrumentView.ImportWaveGated failed: {0}", ex.Message);
                     CoreState.Services.ShowError(R._("Wave import failed: {0}", ex.Message));
                 }
             }
@@ -654,7 +654,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // (permissions, missing/locked file) BEFORE _undoService.Begin, so
                 // no undo scope is open here and no Rollback is needed. Surface a
                 // user-facing error instead of failing silently (Copilot review).
-                Log.Error("SongInstrumentView.ImportWaveGated: {0}", ex.Message);
+                Log.ErrorF("SongInstrumentView.ImportWaveGated: {0}", ex.Message);
                 CoreState.Services?.ShowError(R._("Wave import failed: {0}", ex.Message));
             }
         }
@@ -704,7 +704,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongInstrumentView.InstExport_Click failed: {0}", ex.Message);
+                Log.ErrorF("SongInstrumentView.InstExport_Click failed: {0}", ex.Message);
                 CoreState.Services.ShowError(R._("Instrument set export failed: {0}", ex.Message));
             }
         }
@@ -788,7 +788,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 catch (Exception ex)
                 {
                     _undoService.Rollback();
-                    Log.Error("SongInstrumentView.InstImport_Click failed: {0}", ex.Message);
+                    Log.ErrorF("SongInstrumentView.InstImport_Click failed: {0}", ex.Message);
                     CoreState.Services.ShowError(R._("Instrument set import failed: {0}", ex.Message));
                 }
             }
@@ -796,7 +796,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 // Pre-Begin scope: the file dialog can throw BEFORE _undoService.Begin,
                 // so no undo scope is open here and no Rollback is needed.
-                Log.Error("SongInstrumentView.InstImport_Click: {0}", ex.Message);
+                Log.ErrorF("SongInstrumentView.InstImport_Click: {0}", ex.Message);
                 CoreState.Services?.ShowError(R._("Instrument set import failed: {0}", ex.Message));
             }
         }

--- a/FEBuilderGBA.Avalonia/Views/SongTableMainView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SongTableMainView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongTableMainView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SongTableMainView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongTableMainView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("SongTableMainView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/SongTableView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SongTableView.axaml.cs
@@ -34,7 +34,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongTableView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SongTableView.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -56,7 +56,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongTableView.OnSongSelected failed: {0}", ex.Message);
+                Log.ErrorF("SongTableView.OnSongSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -116,7 +116,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SongTableView.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("SongTableView.Write_Click failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/SongTrackAllChangeTrackView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SongTrackAllChangeTrackView.axaml.cs
@@ -33,7 +33,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongTrackAllChangeTrackView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SongTrackAllChangeTrackView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -88,7 +88,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SongTrackAllChangeTrackView.Apply_Click failed: {0}", ex.Message);
+                Log.ErrorF("SongTrackAllChangeTrackView.Apply_Click failed: {0}", ex.Message);
                 CoreState.Services.ShowError(R._("Apply failed: {0}", ex.Message));
             }
         }

--- a/FEBuilderGBA.Avalonia/Views/SongTrackChangeTrackView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SongTrackChangeTrackView.axaml.cs
@@ -33,7 +33,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongTrackChangeTrackView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SongTrackChangeTrackView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -87,7 +87,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SongTrackChangeTrackView.Apply_Click failed: {0}", ex.Message);
+                Log.ErrorF("SongTrackChangeTrackView.Apply_Click failed: {0}", ex.Message);
                 CoreState.Services.ShowError(R._("Apply failed: {0}", ex.Message));
             }
         }

--- a/FEBuilderGBA.Avalonia/Views/SongTrackImportMidiView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SongTrackImportMidiView.axaml.cs
@@ -32,7 +32,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongTrackImportMidiView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SongTrackImportMidiView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -51,7 +51,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongTrackImportMidiView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("SongTrackImportMidiView.OnSelected failed: {0}", ex.Message);
             }
         }
 
@@ -117,7 +117,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("BrowseMidi_Click failed: {0}", ex.Message);
+                Log.ErrorF("BrowseMidi_Click failed: {0}", ex.Message);
             }
         }
 
@@ -196,7 +196,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongTrackImportMidiView.SelectInstrument_Click pick failed: {0}", ex.Message);
+                Log.ErrorF("SongTrackImportMidiView.SelectInstrument_Click pick failed: {0}", ex.Message);
                 CoreState.Services.ShowError(R._("Instrument selection failed: {0}", ex.Message));
                 return;
             }

--- a/FEBuilderGBA.Avalonia/Views/SongTrackImportSelectInstrumentView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SongTrackImportSelectInstrumentView.axaml.cs
@@ -43,7 +43,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongTrackImportSelectInstrumentView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SongTrackImportSelectInstrumentView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -56,7 +56,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongTrackImportSelectInstrumentView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("SongTrackImportSelectInstrumentView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/SongTrackView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SongTrackView.axaml.cs
@@ -101,7 +101,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongTrackView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SongTrackView.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -141,7 +141,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongTrackView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("SongTrackView.OnSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -212,7 +212,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongTrackView.OnTopBarReloadRequested failed: {0}", ex.Message);
+                Log.ErrorF("SongTrackView.OnTopBarReloadRequested failed: {0}", ex.Message);
             }
         }
 
@@ -242,7 +242,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SongTrackView.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("SongTrackView.Write_Click failed: {0}", ex.Message);
             }
         }
 
@@ -261,7 +261,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongTrackView.SongExchange_Click failed: {0}", ex.Message);
+                Log.ErrorF("SongTrackView.SongExchange_Click failed: {0}", ex.Message);
             }
         }
 
@@ -282,7 +282,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongTrackView.AllTracks_Click failed: {0}", ex.Message);
+                Log.ErrorF("SongTrackView.AllTracks_Click failed: {0}", ex.Message);
             }
         }
 
@@ -319,7 +319,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongTrackView.TrackLabel_Click failed: {0}", ex.Message);
+                Log.ErrorF("SongTrackView.TrackLabel_Click failed: {0}", ex.Message);
             }
         }
 
@@ -551,7 +551,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 }
                 catch (Exception exPick)
                 {
-                    Log.Error("SongTrackView.ImportMidi_Click pick failed: {0}", exPick.Message);
+                    Log.ErrorF("SongTrackView.ImportMidi_Click pick failed: {0}", exPick.Message);
                     CoreState.Services.ShowError(R._("MIDI import failed: {0}", exPick.Message));
                     return;
                 }
@@ -671,7 +671,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 // File read can throw (permissions / missing) BEFORE any undo
                 // scope is open — surface the error, no Rollback needed.
-                Log.Error("SongTrackView.ImportWaveAsSong read failed: {0}", ex.Message);
+                Log.ErrorF("SongTrackView.ImportWaveAsSong read failed: {0}", ex.Message);
                 CoreState.Services.ShowError(R._("Wave import failed: {0}", ex.Message));
                 return;
             }
@@ -709,7 +709,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SongTrackView.ImportWaveAsSong failed: {0}", ex.Message);
+                Log.ErrorF("SongTrackView.ImportWaveAsSong failed: {0}", ex.Message);
                 CoreState.Services.ShowError(R._("Wave import failed: {0}", ex.Message));
             }
         }
@@ -806,7 +806,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SongTrackView.ImportInstrumentSet failed: {0}", ex.Message);
+                Log.ErrorF("SongTrackView.ImportInstrumentSet failed: {0}", ex.Message);
                 CoreState.Services.ShowError(R._("Instrument set import failed: {0}", ex.Message));
             }
         }
@@ -862,7 +862,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongTrackView.ImportSondFontSource pick failed: {0}", ex.Message);
+                Log.ErrorF("SongTrackView.ImportSondFontSource pick failed: {0}", ex.Message);
                 CoreState.Services.ShowError(R._(".s import failed: {0}", ex.Message));
                 return;
             }
@@ -911,7 +911,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SongTrackView.ImportSondFontSource failed: {0}", ex.Message);
+                Log.ErrorF("SongTrackView.ImportSondFontSource failed: {0}", ex.Message);
                 CoreState.Services.ShowError(R._(".s import failed: {0}", ex.Message));
             }
         }
@@ -980,7 +980,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongTrackView.OpenSource_Click: {0}", ex.Message);
+                Log.ErrorF("SongTrackView.OpenSource_Click: {0}", ex.Message);
                 CoreState.Services?.ShowError($"Failed to open source file: {ex.Message}");
             }
         }
@@ -1019,7 +1019,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SongTrackView.SelectSource_Click: {0}", ex.Message);
+                Log.ErrorF("SongTrackView.SelectSource_Click: {0}", ex.Message);
                 CoreState.Services?.ShowError($"Failed to open source folder: {ex.Message}");
             }
         }

--- a/FEBuilderGBA.Avalonia/Views/SoundBossBGMViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SoundBossBGMViewerView.axaml.cs
@@ -32,7 +32,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SoundBossBGMViewerView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SoundBossBGMViewerView.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -51,7 +51,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SoundBossBGMViewerView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("SoundBossBGMViewerView.OnSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -90,7 +90,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SoundBossBGMViewerView.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("SoundBossBGMViewerView.Write_Click failed: {0}", ex.Message);
             }
         }
 
@@ -123,7 +123,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("JumpToSong failed: {0}", ex.Message);
+                Log.ErrorF("JumpToSong failed: {0}", ex.Message);
             }
         }
 
@@ -139,7 +139,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("JumpToUnit failed: {0}", ex.Message);
+                Log.ErrorF("JumpToUnit failed: {0}", ex.Message);
             }
         }
 
@@ -156,7 +156,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("PickUnit failed: {0}", ex.Message);
+                Log.ErrorF("PickUnit failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/SoundRoomCGView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SoundRoomCGView.axaml.cs
@@ -31,7 +31,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SoundRoomCGView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SoundRoomCGView.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -50,7 +50,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SoundRoomCGView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("SoundRoomCGView.OnSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -81,7 +81,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SoundRoomCGView.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("SoundRoomCGView.Write_Click failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/SoundRoomFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SoundRoomFE6View.axaml.cs
@@ -31,7 +31,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SoundRoomFE6View.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SoundRoomFE6View.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -50,7 +50,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SoundRoomFE6View.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("SoundRoomFE6View.OnSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -87,7 +87,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SoundRoomFE6View.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("SoundRoomFE6View.Write_Click failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/SoundRoomViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SoundRoomViewerView.axaml.cs
@@ -45,7 +45,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SoundRoomViewerView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SoundRoomViewerView.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -197,7 +197,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SoundRoomViewerView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("SoundRoomViewerView.OnSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -238,7 +238,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SoundRoomViewerView.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("SoundRoomViewerView.Write_Click failed: {0}", ex.Message);
             }
         }
 
@@ -274,7 +274,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (addr == 0) return;
                 WindowManager.Instance.Navigate<SongTableView>(addr);
             }
-            catch (Exception ex) { Log.Error("SoundRoomViewerView.SongId_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SoundRoomViewerView.SongId_Jump failed: {0}", ex.Message); }
         }
 
         async void SongId_Pick(object? sender, RoutedEventArgs e)
@@ -285,7 +285,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var result = await WindowManager.Instance.PickFromEditor<SongTableView>(addr, this);
                 if (result != null) SongIdBox.Value = (uint)result.Index;
             }
-            catch (Exception ex) { Log.Error("SoundRoomViewerView.SongId_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SoundRoomViewerView.SongId_Pick failed: {0}", ex.Message); }
         }
 
         void SongId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/StatusOptionOrderView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/StatusOptionOrderView.axaml.cs
@@ -33,7 +33,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("StatusOptionOrderView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("StatusOptionOrderView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -48,7 +48,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("StatusOptionOrderView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("StatusOptionOrderView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -71,7 +71,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.MarkClean();
                 CoreState.Services?.ShowInfo("Status option order data written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("StatusOptionOrderView.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("StatusOptionOrderView.Write: {0}", ex.Message); }
         }
 
         // リストの拡張 — expand the 1-byte-per-entry game-option-order list by a

--- a/FEBuilderGBA.Avalonia/Views/StatusOptionView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/StatusOptionView.axaml.cs
@@ -171,7 +171,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("StatusOptionView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("StatusOptionView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -186,7 +186,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("StatusOptionView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("StatusOptionView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -255,7 +255,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.MarkClean();
                 CoreState.Services?.ShowInfo("Status option data written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("StatusOptionView.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("StatusOptionView.Write: {0}", ex.Message); }
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/FEBuilderGBA.Avalonia/Views/StatusParamView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/StatusParamView.axaml.cs
@@ -48,7 +48,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("StatusParamView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("StatusParamView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -63,7 +63,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("StatusParamView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("StatusParamView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -99,7 +99,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.MarkClean();
                 CoreState.Services?.ShowInfo("Status parameter data written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("StatusParamView.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("StatusParamView.Write: {0}", ex.Message); }
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/FEBuilderGBA.Avalonia/Views/StatusRMenuView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/StatusRMenuView.axaml.cs
@@ -74,7 +74,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("StatusRMenuView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("StatusRMenuView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -89,7 +89,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("StatusRMenuView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("StatusRMenuView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -130,7 +130,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.MarkClean();
                 CoreState.Services?.ShowInfo("Status R-Menu data written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("StatusRMenuView.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("StatusRMenuView.Write: {0}", ex.Message); }
         }
 
         static uint ParseHexText(string? text)

--- a/FEBuilderGBA.Avalonia/Views/StatusUnitsMenuView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/StatusUnitsMenuView.axaml.cs
@@ -51,7 +51,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("StatusUnitsMenuView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("StatusUnitsMenuView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -66,7 +66,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("StatusUnitsMenuView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("StatusUnitsMenuView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -99,7 +99,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.MarkClean();
                 CoreState.Services?.ShowInfo("Status units menu data written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("StatusUnitsMenuView.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("StatusUnitsMenuView.Write: {0}", ex.Message); }
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/FEBuilderGBA.Avalonia/Views/SummonUnitViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SummonUnitViewerView.axaml.cs
@@ -35,7 +35,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SummonUnitViewerView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SummonUnitViewerView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
 
@@ -66,7 +66,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SummonUnitViewerView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("SummonUnitViewerView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -100,7 +100,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.MarkClean();
                 CoreState.Services?.ShowInfo("Summon unit data written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("SummonUnitViewerView.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("SummonUnitViewerView.Write: {0}", ex.Message); }
         }
 
         // リストの拡張 — expand the 2-byte summon_unit_pointer table by a prompted
@@ -203,7 +203,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (addr == 0) return;
                 WindowManager.Instance.Navigate<UnitEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("SummonUnitViewerView.UnitId_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SummonUnitViewerView.UnitId_Jump failed: {0}", ex.Message); }
         }
 
         async void UnitId_Pick(object? sender, RoutedEventArgs e)
@@ -218,7 +218,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     UnitIdBox.Value = SupportUnitNavigation.OneBasedIdFromPickIndex(result.Index);
                 }
             }
-            catch (Exception ex) { Log.Error("SummonUnitViewerView.UnitId_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SummonUnitViewerView.UnitId_Pick failed: {0}", ex.Message); }
         }
 
         void UnitId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -241,7 +241,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (addr == 0) return;
                 WindowManager.Instance.Navigate<UnitEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("SummonUnitViewerView.SummonedUnit_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SummonUnitViewerView.SummonedUnit_Jump failed: {0}", ex.Message); }
         }
 
         async void SummonedUnit_Pick(object? sender, RoutedEventArgs e)
@@ -255,7 +255,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     UnknownBox.Value = SupportUnitNavigation.OneBasedIdFromPickIndex(result.Index);
                 }
             }
-            catch (Exception ex) { Log.Error("SummonUnitViewerView.SummonedUnit_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SummonUnitViewerView.SummonedUnit_Pick failed: {0}", ex.Message); }
         }
 
         void SummonedUnit_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/SummonsDemonKingViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SummonsDemonKingViewerView.axaml.cs
@@ -53,7 +53,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SummonsDemonKingViewerView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("SummonsDemonKingViewerView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -229,7 +229,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (addr == 0) return;
                 WindowManager.Instance.Navigate<UnitEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("SummonsDemonKingViewerView.UnitId_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SummonsDemonKingViewerView.UnitId_Jump failed: {0}", ex.Message); }
         }
 
         async void UnitId_Pick(object? sender, RoutedEventArgs e)
@@ -241,7 +241,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // PickResult.Index is 0-based; UnitId is 1-based (#937).
                 if (result != null) UnitIdBox.Value = SupportUnitNavigation.OneBasedIdFromPickIndex(result.Index);
             }
-            catch (Exception ex) { Log.Error("SummonsDemonKingViewerView.UnitId_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SummonsDemonKingViewerView.UnitId_Pick failed: {0}", ex.Message); }
         }
 
         void UnitId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -262,7 +262,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 else
                     WindowManager.Instance.Navigate<ClassEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("SummonsDemonKingViewerView.ClassId_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SummonsDemonKingViewerView.ClassId_Jump failed: {0}", ex.Message); }
         }
 
         async void ClassId_Pick(object? sender, RoutedEventArgs e)
@@ -277,7 +277,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     result = await WindowManager.Instance.PickFromEditor<ClassEditorView>(addr, this);
                 if (result != null) ClassIdBox.Value = (uint)result.Index;
             }
-            catch (Exception ex) { Log.Error("SummonsDemonKingViewerView.ClassId_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SummonsDemonKingViewerView.ClassId_Pick failed: {0}", ex.Message); }
         }
 
         void ClassId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/SupportAttributeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SupportAttributeView.axaml.cs
@@ -33,7 +33,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SupportAttributeView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SupportAttributeView.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -52,7 +52,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SupportAttributeView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("SupportAttributeView.OnSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -115,7 +115,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SupportAttributeView.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("SupportAttributeView.Write_Click failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/SupportTalkFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SupportTalkFE6View.axaml.cs
@@ -39,7 +39,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SupportTalkFE6View.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SupportTalkFE6View.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -58,7 +58,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SupportTalkFE6View.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("SupportTalkFE6View.OnSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -123,7 +123,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SupportTalkFE6View.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("SupportTalkFE6View.Write_Click failed: {0}", ex.Message);
             }
         }
 
@@ -237,7 +237,7 @@ namespace FEBuilderGBA.Avalonia.Views
         void SupportPartner1_Jump(object? sender, RoutedEventArgs e)
         {
             try { uint addr = SupportUnitNavigation.UnitAddrForOneBased(CoreState.ROM, SupportPartner1Nud.Value); if (addr != 0) WindowManager.Instance.Navigate<UnitEditorView>(addr); }
-            catch (Exception ex) { Log.Error("SupportTalkFE6View.SupportPartner1_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SupportTalkFE6View.SupportPartner1_Jump failed: {0}", ex.Message); }
         }
 
         async void SupportPartner1_Pick(object? sender, RoutedEventArgs e)
@@ -249,7 +249,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // PickResult.Index is 0-based; SupportPartner is 1-based (#937).
                 if (result != null) SupportPartner1Nud.Value = SupportUnitNavigation.OneBasedIdFromPickIndex(result.Index);
             }
-            catch (Exception ex) { Log.Error("SupportTalkFE6View.SupportPartner1_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SupportTalkFE6View.SupportPartner1_Pick failed: {0}", ex.Message); }
         }
 
         void SupportPartner1_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -261,7 +261,7 @@ namespace FEBuilderGBA.Avalonia.Views
         void SupportPartner2_Jump(object? sender, RoutedEventArgs e)
         {
             try { uint addr = SupportUnitNavigation.UnitAddrForOneBased(CoreState.ROM, SupportPartner2Nud.Value); if (addr != 0) WindowManager.Instance.Navigate<UnitEditorView>(addr); }
-            catch (Exception ex) { Log.Error("SupportTalkFE6View.SupportPartner2_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SupportTalkFE6View.SupportPartner2_Jump failed: {0}", ex.Message); }
         }
 
         async void SupportPartner2_Pick(object? sender, RoutedEventArgs e)
@@ -273,7 +273,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // PickResult.Index is 0-based; SupportPartner is 1-based (#937).
                 if (result != null) SupportPartner2Nud.Value = SupportUnitNavigation.OneBasedIdFromPickIndex(result.Index);
             }
-            catch (Exception ex) { Log.Error("SupportTalkFE6View.SupportPartner2_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SupportTalkFE6View.SupportPartner2_Pick failed: {0}", ex.Message); }
         }
 
         void SupportPartner2_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -285,7 +285,7 @@ namespace FEBuilderGBA.Avalonia.Views
         void TextC_Jump(object? sender, RoutedEventArgs e)
         {
             try { uint addr = TextAddrFor(TextCNud.Value); if (addr != 0) WindowManager.Instance.Navigate<TextViewerView>(addr); }
-            catch (Exception ex) { Log.Error("SupportTalkFE6View.TextC_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SupportTalkFE6View.TextC_Jump failed: {0}", ex.Message); }
         }
 
         void TextC_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -296,7 +296,7 @@ namespace FEBuilderGBA.Avalonia.Views
         void TextB_Jump(object? sender, RoutedEventArgs e)
         {
             try { uint addr = TextAddrFor(TextBNud.Value); if (addr != 0) WindowManager.Instance.Navigate<TextViewerView>(addr); }
-            catch (Exception ex) { Log.Error("SupportTalkFE6View.TextB_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SupportTalkFE6View.TextB_Jump failed: {0}", ex.Message); }
         }
 
         void TextB_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -307,7 +307,7 @@ namespace FEBuilderGBA.Avalonia.Views
         void TextA_Jump(object? sender, RoutedEventArgs e)
         {
             try { uint addr = TextAddrFor(TextANud.Value); if (addr != 0) WindowManager.Instance.Navigate<TextViewerView>(addr); }
-            catch (Exception ex) { Log.Error("SupportTalkFE6View.TextA_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SupportTalkFE6View.TextA_Jump failed: {0}", ex.Message); }
         }
 
         void TextA_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/SupportTalkFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SupportTalkFE7View.axaml.cs
@@ -39,7 +39,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SupportTalkFE7View.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SupportTalkFE7View.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -58,7 +58,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SupportTalkFE7View.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("SupportTalkFE7View.OnSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -127,7 +127,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SupportTalkFE7View.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("SupportTalkFE7View.Write_Click failed: {0}", ex.Message);
             }
         }
 
@@ -244,7 +244,7 @@ namespace FEBuilderGBA.Avalonia.Views
         void SupportPartner1_Jump(object? sender, RoutedEventArgs e)
         {
             try { uint addr = SupportUnitNavigation.UnitAddrForOneBased(CoreState.ROM, SupportPartner1Nud.Value); if (addr != 0) WindowManager.Instance.Navigate<UnitEditorView>(addr); }
-            catch (Exception ex) { Log.Error("SupportTalkFE7View.SupportPartner1_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SupportTalkFE7View.SupportPartner1_Jump failed: {0}", ex.Message); }
         }
 
         async void SupportPartner1_Pick(object? sender, RoutedEventArgs e)
@@ -256,7 +256,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // PickResult.Index is 0-based; SupportPartner is 1-based (#937).
                 if (result != null) SupportPartner1Nud.Value = SupportUnitNavigation.OneBasedIdFromPickIndex(result.Index);
             }
-            catch (Exception ex) { Log.Error("SupportTalkFE7View.SupportPartner1_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SupportTalkFE7View.SupportPartner1_Pick failed: {0}", ex.Message); }
         }
 
         void SupportPartner1_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -268,7 +268,7 @@ namespace FEBuilderGBA.Avalonia.Views
         void SupportPartner2_Jump(object? sender, RoutedEventArgs e)
         {
             try { uint addr = SupportUnitNavigation.UnitAddrForOneBased(CoreState.ROM, SupportPartner2Nud.Value); if (addr != 0) WindowManager.Instance.Navigate<UnitEditorView>(addr); }
-            catch (Exception ex) { Log.Error("SupportTalkFE7View.SupportPartner2_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SupportTalkFE7View.SupportPartner2_Jump failed: {0}", ex.Message); }
         }
 
         async void SupportPartner2_Pick(object? sender, RoutedEventArgs e)
@@ -280,7 +280,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // PickResult.Index is 0-based; SupportPartner is 1-based (#937).
                 if (result != null) SupportPartner2Nud.Value = SupportUnitNavigation.OneBasedIdFromPickIndex(result.Index);
             }
-            catch (Exception ex) { Log.Error("SupportTalkFE7View.SupportPartner2_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SupportTalkFE7View.SupportPartner2_Pick failed: {0}", ex.Message); }
         }
 
         void SupportPartner2_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -292,7 +292,7 @@ namespace FEBuilderGBA.Avalonia.Views
         void TextC_Jump(object? sender, RoutedEventArgs e)
         {
             try { uint addr = TextAddrFor(TextCNud.Value); if (addr != 0) WindowManager.Instance.Navigate<TextViewerView>(addr); }
-            catch (Exception ex) { Log.Error("SupportTalkFE7View.TextC_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SupportTalkFE7View.TextC_Jump failed: {0}", ex.Message); }
         }
 
         void TextC_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -303,7 +303,7 @@ namespace FEBuilderGBA.Avalonia.Views
         void TextB_Jump(object? sender, RoutedEventArgs e)
         {
             try { uint addr = TextAddrFor(TextBNud.Value); if (addr != 0) WindowManager.Instance.Navigate<TextViewerView>(addr); }
-            catch (Exception ex) { Log.Error("SupportTalkFE7View.TextB_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SupportTalkFE7View.TextB_Jump failed: {0}", ex.Message); }
         }
 
         void TextB_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -314,7 +314,7 @@ namespace FEBuilderGBA.Avalonia.Views
         void TextA_Jump(object? sender, RoutedEventArgs e)
         {
             try { uint addr = TextAddrFor(TextANud.Value); if (addr != 0) WindowManager.Instance.Navigate<TextViewerView>(addr); }
-            catch (Exception ex) { Log.Error("SupportTalkFE7View.TextA_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SupportTalkFE7View.TextA_Jump failed: {0}", ex.Message); }
         }
 
         void TextA_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/SupportTalkView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SupportTalkView.axaml.cs
@@ -39,7 +39,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SupportTalkView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SupportTalkView.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -58,7 +58,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SupportTalkView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("SupportTalkView.OnSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -127,7 +127,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SupportTalkView.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("SupportTalkView.Write_Click failed: {0}", ex.Message);
             }
         }
 
@@ -273,7 +273,7 @@ namespace FEBuilderGBA.Avalonia.Views
         void SupportPartner1_Jump(object? sender, RoutedEventArgs e)
         {
             try { uint addr = UnitAddrFor(SupportPartner1Nud.Value); if (addr != 0) WindowManager.Instance.Navigate<UnitEditorView>(addr); }
-            catch (Exception ex) { Log.Error("SupportTalkView.SupportPartner1_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SupportTalkView.SupportPartner1_Jump failed: {0}", ex.Message); }
         }
 
         async void SupportPartner1_Pick(object? sender, RoutedEventArgs e)
@@ -285,7 +285,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // PickResult.Index is 0-based; SupportPartner is 1-based (#725).
                 if (result != null) SupportPartner1Nud.Value = (uint)result.Index + 1;
             }
-            catch (Exception ex) { Log.Error("SupportTalkView.SupportPartner1_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SupportTalkView.SupportPartner1_Pick failed: {0}", ex.Message); }
         }
 
         void SupportPartner1_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -297,7 +297,7 @@ namespace FEBuilderGBA.Avalonia.Views
         void SupportPartner2_Jump(object? sender, RoutedEventArgs e)
         {
             try { uint addr = UnitAddrFor(SupportPartner2Nud.Value); if (addr != 0) WindowManager.Instance.Navigate<UnitEditorView>(addr); }
-            catch (Exception ex) { Log.Error("SupportTalkView.SupportPartner2_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SupportTalkView.SupportPartner2_Jump failed: {0}", ex.Message); }
         }
 
         async void SupportPartner2_Pick(object? sender, RoutedEventArgs e)
@@ -309,7 +309,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // PickResult.Index is 0-based; SupportPartner is 1-based (#725).
                 if (result != null) SupportPartner2Nud.Value = (uint)result.Index + 1;
             }
-            catch (Exception ex) { Log.Error("SupportTalkView.SupportPartner2_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SupportTalkView.SupportPartner2_Pick failed: {0}", ex.Message); }
         }
 
         void SupportPartner2_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -321,7 +321,7 @@ namespace FEBuilderGBA.Avalonia.Views
         void TextIdC_Jump(object? sender, RoutedEventArgs e)
         {
             try { uint addr = TextAddrFor(TextIdCNud.Value); if (addr != 0) WindowManager.Instance.Navigate<TextViewerView>(addr); }
-            catch (Exception ex) { Log.Error("SupportTalkView.TextIdC_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SupportTalkView.TextIdC_Jump failed: {0}", ex.Message); }
         }
 
         void TextIdC_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -332,7 +332,7 @@ namespace FEBuilderGBA.Avalonia.Views
         void TextIdB_Jump(object? sender, RoutedEventArgs e)
         {
             try { uint addr = TextAddrFor(TextIdBNud.Value); if (addr != 0) WindowManager.Instance.Navigate<TextViewerView>(addr); }
-            catch (Exception ex) { Log.Error("SupportTalkView.TextIdB_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SupportTalkView.TextIdB_Jump failed: {0}", ex.Message); }
         }
 
         void TextIdB_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -343,7 +343,7 @@ namespace FEBuilderGBA.Avalonia.Views
         void TextIdA_Jump(object? sender, RoutedEventArgs e)
         {
             try { uint addr = TextAddrFor(TextIdANud.Value); if (addr != 0) WindowManager.Instance.Navigate<TextViewerView>(addr); }
-            catch (Exception ex) { Log.Error("SupportTalkView.TextIdA_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SupportTalkView.TextIdA_Jump failed: {0}", ex.Message); }
         }
 
         void TextIdA_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/SupportUnitEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SupportUnitEditorView.axaml.cs
@@ -77,7 +77,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SupportUnitEditorView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SupportUnitEditorView.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -96,7 +96,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SupportUnitEditorView.OnSupportSelected failed: {0}", ex.Message);
+                Log.ErrorF("SupportUnitEditorView.OnSupportSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -190,7 +190,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SupportUnitEditorView.JumpToSourceUnit failed: {0}", ex.Message);
+                Log.ErrorF("SupportUnitEditorView.JumpToSourceUnit failed: {0}", ex.Message);
             }
         }
 
@@ -225,7 +225,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SupportUnitEditorView.JumpToTalk failed: {0}", ex.Message);
+                Log.ErrorF("SupportUnitEditorView.JumpToTalk failed: {0}", ex.Message);
             }
         }
 
@@ -300,7 +300,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SupportUnitEditorView.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("SupportUnitEditorView.Write_Click failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/SupportUnitFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SupportUnitFE6View.axaml.cs
@@ -67,7 +67,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SupportUnitFE6View.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("SupportUnitFE6View.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -86,7 +86,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SupportUnitFE6View.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("SupportUnitFE6View.OnSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -181,7 +181,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SupportUnitFE6View.JumpToSourceUnit failed: {0}", ex.Message);
+                Log.ErrorF("SupportUnitFE6View.JumpToSourceUnit failed: {0}", ex.Message);
             }
         }
 
@@ -199,7 +199,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("SupportUnitFE6View.JumpToTalk failed: {0}", ex.Message);
+                Log.ErrorF("SupportUnitFE6View.JumpToTalk failed: {0}", ex.Message);
             }
         }
 
@@ -275,7 +275,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SupportUnitFE6View.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("SupportUnitFE6View.Write_Click failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/SystemHoverColorViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SystemHoverColorViewerView.axaml.cs
@@ -56,7 +56,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 GBAColorBox.Value = _vm.GBAColor;
                 RefreshSwatch();
             }
-            catch (Exception ex) { Log.Error("SystemHoverColorViewerView.OnSelected: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SystemHoverColorViewerView.OnSelected: {0}", ex.Message); }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
 
@@ -104,7 +104,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("SystemHoverColorViewerView.Write_Click: {0}", ex.Message);
+                Log.ErrorF("SystemHoverColorViewerView.Write_Click: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/SystemIconViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SystemIconViewerView.axaml.cs
@@ -28,7 +28,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             _vm.IsLoading = true;
             try { var items = _vm.LoadSystemIconList(); EntryList.SetItems(items); }
-            catch (Exception ex) { Log.Error("SystemIconViewerView.LoadList: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SystemIconViewerView.LoadList: {0}", ex.Message); }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 UpdateUI();
                 LoadImage();
             }
-            catch (Exception ex) { Log.Error("SystemIconViewerView.OnSelected: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("SystemIconViewerView.OnSelected: {0}", ex.Message); }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/TerrainNameEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/TerrainNameEditorView.axaml.cs
@@ -32,7 +32,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("TerrainNameEditorView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("TerrainNameEditorView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -47,7 +47,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("TerrainNameEditorView.OnTerrainSelected failed: {0}", ex.Message);
+                Log.ErrorF("TerrainNameEditorView.OnTerrainSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
         }
@@ -99,7 +99,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.MarkClean();
                 CoreState.Services?.ShowInfo("Terrain name written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("TerrainNameEditorView.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("TerrainNameEditorView.Write: {0}", ex.Message); }
         }
 
         public void SelectFirstItem()

--- a/FEBuilderGBA.Avalonia/Views/TextDicView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/TextDicView.axaml.cs
@@ -78,7 +78,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("TextDicView.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("TextDicView.Write_Click failed: {0}", ex.Message);
             }
         }
 
@@ -94,7 +94,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (addr == 0) return;
                 WindowManager.Instance.Navigate<UnitEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("OnUnitIdLinkClick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("OnUnitIdLinkClick failed: {0}", ex.Message); }
         }
 
         void OnClassIdLinkClick(object? sender, PointerPressedEventArgs e)
@@ -112,7 +112,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 else
                     WindowManager.Instance.Navigate<ClassEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("OnClassIdLinkClick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("OnClassIdLinkClick failed: {0}", ex.Message); }
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/FEBuilderGBA.Avalonia/Views/TextEscapeEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/TextEscapeEditorView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("TextEscapeEditorView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("TextEscapeEditorView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("TextEscapeEditorView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("TextEscapeEditorView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/TextMainView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/TextMainView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("TextMainView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("TextMainView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("TextMainView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("TextMainView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/TextViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/TextViewerView.axaml.cs
@@ -144,7 +144,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("TextViewerView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("TextViewerView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -179,7 +179,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("TextViewerView.OnTextSelected failed: {0}", ex.Message);
+                Log.ErrorF("TextViewerView.OnTextSelected failed: {0}", ex.Message);
             }
         }
 
@@ -241,7 +241,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("TextViewerView.UpdatePointerDisplay: {0}", ex.Message);
+                Log.ErrorF("TextViewerView.UpdatePointerDisplay: {0}", ex.Message);
                 PointerValueBox.Text = R._("(invalid)");
                 RefsCountBox.Text = "0";
             }
@@ -338,7 +338,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("TextViewerView.OnAddReferenceClick failed: {0}", ex.Message);
+                Log.ErrorF("TextViewerView.OnAddReferenceClick failed: {0}", ex.Message);
                 ReferencesTabStatusLabel.Text = R._("Error: {0}", ex.Message);
             }
         }
@@ -521,7 +521,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("Export failed: {0}", ex.Message);
+                Log.ErrorF("Export failed: {0}", ex.Message);
                 await MessageBoxWindow.Show(this, $"Export failed: {ex.Message}", "Error", MessageBoxMode.Ok);
             }
         }
@@ -546,7 +546,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("Import failed: {0}", ex.Message);
+                Log.ErrorF("Import failed: {0}", ex.Message);
                 await MessageBoxWindow.Show(this, $"Import failed: {ex.Message}", "Error", MessageBoxMode.Ok);
             }
         }
@@ -646,7 +646,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 _undoService.Rollback();
                 WriteStatusLabel.Text = $"Write failed: {ex.Message}";
-                Log.Error("WriteText failed: {0}", ex.Message);
+                Log.ErrorF("WriteText failed: {0}", ex.Message);
             }
             finally
             {
@@ -727,7 +727,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 SearchResultLabel.Text = $"Error: {ex.Message}";
-                Log.Error("SearchContent failed: {0}", ex.Message);
+                Log.ErrorF("SearchContent failed: {0}", ex.Message);
             }
         }
 
@@ -774,7 +774,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 FreeAreaStatusLabel.Text = R._("Error: {0}", ex.Message);
-                Log.Error("SearchFreeArea failed: {0}", ex.Message);
+                Log.ErrorF("SearchFreeArea failed: {0}", ex.Message);
             }
         }
 
@@ -822,7 +822,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("TextViewerView.PopulateTranslateCombos failed: {0}", ex.Message);
+                Log.ErrorF("TextViewerView.PopulateTranslateCombos failed: {0}", ex.Message);
             }
         }
 
@@ -901,7 +901,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // an empty or error-shaped string.
                 if (string.IsNullOrWhiteSpace(result))
                 {
-                    Log.Error("TextViewerView.OnTranslateClick: translation returned empty for {0}->{1}", fromCode, toCode);
+                    Log.ErrorF("TextViewerView.OnTranslateClick: translation returned empty for {0}->{1}", fromCode, toCode);
                     CoreState.Services?.ShowError(R._("Translation failed: the service returned no result."));
                     return;
                 }
@@ -912,12 +912,12 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (System.Net.WebException wex)
             {
-                Log.Error("TextViewerView.OnTranslateClick WebException: {0}", wex.Message);
+                Log.ErrorF("TextViewerView.OnTranslateClick WebException: {0}", wex.Message);
                 CoreState.Services?.ShowError(R._("Google translation returned an error. You may have sent too many requests.\r\n\r\n{0}", wex.Message));
             }
             catch (Exception ex)
             {
-                Log.Error("TextViewerView.OnTranslateClick failed: {0}", ex.Message);
+                Log.ErrorF("TextViewerView.OnTranslateClick failed: {0}", ex.Message);
                 CoreState.Services?.ShowError(R._("Translation failed: {0}", ex.Message));
             }
             finally

--- a/FEBuilderGBA.Avalonia/Views/ToolASMEditView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolASMEditView.axaml.cs
@@ -185,9 +185,9 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             finally
             {
-                try { if (File.Exists(tempAsm)) File.Delete(tempAsm); } catch (Exception ex) { Log.Error("ToolASMEditView temp asm cleanup: {0}", ex.Message); }
-                try { if (File.Exists(tempObj)) File.Delete(tempObj); } catch (Exception ex) { Log.Error("ToolASMEditView temp obj cleanup: {0}", ex.Message); }
-                try { if (File.Exists(tempBin)) File.Delete(tempBin); } catch (Exception ex) { Log.Error("ToolASMEditView temp bin cleanup: {0}", ex.Message); }
+                try { if (File.Exists(tempAsm)) File.Delete(tempAsm); } catch (Exception ex) { Log.ErrorF("ToolASMEditView temp asm cleanup: {0}", ex.Message); }
+                try { if (File.Exists(tempObj)) File.Delete(tempObj); } catch (Exception ex) { Log.ErrorF("ToolASMEditView temp obj cleanup: {0}", ex.Message); }
+                try { if (File.Exists(tempBin)) File.Delete(tempBin); } catch (Exception ex) { Log.ErrorF("ToolASMEditView temp bin cleanup: {0}", ex.Message); }
             }
         }
         void Close_Click(object? sender, RoutedEventArgs e) => Close();

--- a/FEBuilderGBA.Avalonia/Views/ToolAnimationCreatorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolAnimationCreatorView.axaml.cs
@@ -248,7 +248,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ToolAnimationCreatorView.BrowseImage_Click failed: {0}", ex.Message);
+                Log.ErrorF("ToolAnimationCreatorView.BrowseImage_Click failed: {0}", ex.Message);
             }
         }
 
@@ -283,7 +283,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ToolAnimationCreatorView.Create_Click failed: {0}", ex.Message);
+                Log.ErrorF("ToolAnimationCreatorView.Create_Click failed: {0}", ex.Message);
                 CoreState.Services.ShowError(R._("Save failed: {0}", ex.Message));
             }
         }
@@ -326,7 +326,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ToolAnimationCreatorView.DoWriteToFile picker: {0}", ex.Message);
+                Log.ErrorF("ToolAnimationCreatorView.DoWriteToFile picker: {0}", ex.Message);
             }
             if (string.IsNullOrEmpty(saveTo)) return;
 

--- a/FEBuilderGBA.Avalonia/Views/ToolTranslateROMView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolTranslateROMView.axaml.cs
@@ -50,7 +50,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var path = await FileDialogHelper.OpenRomFile(this);
                 if (!string.IsNullOrEmpty(path)) _vm.FromRomPath = path;
             }
-            catch (Exception ex) { Log.Error("ToolTranslateROMView.SimpleFromRomBrowse: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ToolTranslateROMView.SimpleFromRomBrowse: {0}", ex.Message); }
         }
 
         async void SimpleToRomBrowse_Click(object? sender, RoutedEventArgs e)
@@ -60,7 +60,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var path = await FileDialogHelper.OpenRomFile(this);
                 if (!string.IsNullOrEmpty(path)) _vm.ToRomPath = path;
             }
-            catch (Exception ex) { Log.Error("ToolTranslateROMView.SimpleToRomBrowse: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ToolTranslateROMView.SimpleToRomBrowse: {0}", ex.Message); }
         }
 
         async void ExtraFontRomBrowse_Click(object? sender, RoutedEventArgs e)
@@ -70,7 +70,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var path = await FileDialogHelper.OpenRomFile(this);
                 if (!string.IsNullOrEmpty(path)) _vm.ExtraFontRomPath = path;
             }
-            catch (Exception ex) { Log.Error("ToolTranslateROMView.ExtraFontRomBrowse: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ToolTranslateROMView.ExtraFontRomBrowse: {0}", ex.Message); }
         }
 
         async void TranslateDataBrowse_Click(object? sender, RoutedEventArgs e)
@@ -81,7 +81,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     R._("Translation Data"), "*.txt");
                 if (!string.IsNullOrEmpty(path)) _vm.TranslateDataPath = path;
             }
-            catch (Exception ex) { Log.Error("ToolTranslateROMView.TranslateDataBrowse: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ToolTranslateROMView.TranslateDataBrowse: {0}", ex.Message); }
         }
 
         // ---------- Detail tab browse handlers ----------
@@ -93,7 +93,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var path = await FileDialogHelper.OpenRomFile(this);
                 if (!string.IsNullOrEmpty(path)) _vm.FromRomPath = path;
             }
-            catch (Exception ex) { Log.Error("ToolTranslateROMView.DetailFromRomBrowse: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ToolTranslateROMView.DetailFromRomBrowse: {0}", ex.Message); }
         }
 
         async void DetailToRomBrowse_Click(object? sender, RoutedEventArgs e)
@@ -103,7 +103,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var path = await FileDialogHelper.OpenRomFile(this);
                 if (!string.IsNullOrEmpty(path)) _vm.ToRomPath = path;
             }
-            catch (Exception ex) { Log.Error("ToolTranslateROMView.DetailToRomBrowse: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ToolTranslateROMView.DetailToRomBrowse: {0}", ex.Message); }
         }
 
         async void FontRomBrowse_Click(object? sender, RoutedEventArgs e)
@@ -113,7 +113,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var path = await FileDialogHelper.OpenRomFile(this);
                 if (!string.IsNullOrEmpty(path)) _vm.FontRomPath = path;
             }
-            catch (Exception ex) { Log.Error("ToolTranslateROMView.FontRomBrowse: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ToolTranslateROMView.FontRomBrowse: {0}", ex.Message); }
         }
 
         // ---------- Real action handlers (#536 wires Core helpers) ----------
@@ -220,7 +220,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 _vm.UndoService.Rollback();
                 await ShowError("Translation failed: " + ex.Message);
-                Log.Error("ToolTranslateROMView.SimpleFire: {0}", ex.Message);
+                Log.ErrorF("ToolTranslateROMView.SimpleFire: {0}", ex.Message);
             }
         }
 
@@ -269,7 +269,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 await ShowError("Export failed: " + ex.Message);
-                Log.Error("ToolTranslateROMView.ExportAllText: {0}", ex.Message);
+                Log.ErrorF("ToolTranslateROMView.ExportAllText: {0}", ex.Message);
             }
         }
 
@@ -315,7 +315,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 _vm.UndoService.Rollback();
                 await ShowError("Import failed: " + ex.Message);
-                Log.Error("ToolTranslateROMView.ImportAllText: {0}", ex.Message);
+                Log.ErrorF("ToolTranslateROMView.ImportAllText: {0}", ex.Message);
             }
         }
 
@@ -382,7 +382,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 _vm.UndoService.Rollback();
                 await ShowError("Import Font failed: " + ex.Message);
-                Log.Error("ToolTranslateROMView.ImportFont: {0}", ex.Message);
+                Log.ErrorF("ToolTranslateROMView.ImportFont: {0}", ex.Message);
             }
         }
 
@@ -429,7 +429,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ToolTranslateROMView.UseFontName: {0}", ex.Message);
+                Log.ErrorF("ToolTranslateROMView.UseFontName: {0}", ex.Message);
             }
         }
 
@@ -465,7 +465,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ToolTranslateROMView.ShowInfo: {0}", ex.Message);
+                Log.ErrorF("ToolTranslateROMView.ShowInfo: {0}", ex.Message);
             }
         }
 
@@ -503,7 +503,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ToolTranslateROMView.ShowChapterNameTextRecommendation: {0}", ex.Message);
+                Log.ErrorF("ToolTranslateROMView.ShowChapterNameTextRecommendation: {0}", ex.Message);
             }
         }
 
@@ -549,7 +549,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ToolTranslateROMView.InstallChapterNameToTextPatch: {0}", ex.Message);
+                Log.ErrorF("ToolTranslateROMView.InstallChapterNameToTextPatch: {0}", ex.Message);
                 return ex.Message;
             }
         }

--- a/FEBuilderGBA.Avalonia/Views/ToolUpdateDialogView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolUpdateDialogView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ToolUpdateDialogView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("ToolUpdateDialogView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("ToolUpdateDialogView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("ToolUpdateDialogView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/UnitEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/UnitEditorView.axaml.cs
@@ -87,7 +87,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("UnitEditor.JumpToSupportUnit failed: {0}", ex.Message);
+                Log.ErrorF("UnitEditor.JumpToSupportUnit failed: {0}", ex.Message);
             }
         }
 
@@ -258,7 +258,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("UnitEditorView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("UnitEditorView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -284,7 +284,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _vm.IsLoading = false;
-                Log.Error("UnitEditorView.OnUnitSelected failed: {0}", ex.Message);
+                Log.ErrorF("UnitEditorView.OnUnitSelected failed: {0}", ex.Message);
             }
         }
 
@@ -468,7 +468,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("UnitEditorView.TryShowPortrait failed: {0}", ex.Message);
+                Log.ErrorF("UnitEditorView.TryShowPortrait failed: {0}", ex.Message);
                 PortraitImage.SetImage(null);
             }
         }
@@ -529,7 +529,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("Write failed: {0}", ex.Message);
+                Log.ErrorF("Write failed: {0}", ex.Message);
             }
         }
 
@@ -602,7 +602,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("JumpToClass failed: {0}", ex.Message);
+                Log.ErrorF("JumpToClass failed: {0}", ex.Message);
             }
         }
 
@@ -622,7 +622,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("JumpToPortrait failed: {0}", ex.Message);
+                Log.ErrorF("JumpToPortrait failed: {0}", ex.Message);
             }
         }
 
@@ -654,7 +654,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("PickClass failed: {0}", ex.Message);
+                Log.ErrorF("PickClass failed: {0}", ex.Message);
             }
         }
 
@@ -681,7 +681,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("PickPortrait failed: {0}", ex.Message);
+                Log.ErrorF("PickPortrait failed: {0}", ex.Message);
             }
         }
 
@@ -838,7 +838,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("GetAllUnitAddresses failed: {0}", ex.Message);
+                Log.ErrorF("GetAllUnitAddresses failed: {0}", ex.Message);
                 return Array.Empty<uint>();
             }
         }
@@ -853,7 +853,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (addrs.Length == 0) return;
                 await MakeCsvManager().ExportAllAsync(this, rom, addrs);
             }
-            catch (Exception ex) { Log.Error("ExportAll_Click failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ExportAll_Click failed: {0}", ex.Message); }
         }
 
         async void ExportSelected_Click(object? sender, RoutedEventArgs e)
@@ -871,7 +871,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 uint uid = idx >= 0 ? (uint)idx : 0u;
                 await MakeCsvManager().ExportSelectedAsync(this, rom, _vm.CurrentAddr, uid);
             }
-            catch (Exception ex) { Log.Error("ExportSelected_Click failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ExportSelected_Click failed: {0}", ex.Message); }
         }
 
         async void ImportAll_Click(object? sender, RoutedEventArgs e)
@@ -903,7 +903,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     UpdateUI();
                 }
             }
-            catch (Exception ex) { Log.Error("ImportAll_Click failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ImportAll_Click failed: {0}", ex.Message); }
         }
 
         async void ImportSelected_Click(object? sender, RoutedEventArgs e)
@@ -936,7 +936,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     UpdateUI();
                 }
             }
-            catch (Exception ex) { Log.Error("ImportSelected_Click failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("ImportSelected_Click failed: {0}", ex.Message); }
         }
 
         // ---- #413: Address-bar infrastructure ----
@@ -967,7 +967,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (SizeLabel != null)
                     SizeLabel.Text = $"0x{rom.RomInfo.unit_datasize:X}";
             }
-            catch (Exception ex) { Log.Error("UnitEditorView.UpdateAddressBarInfra failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("UnitEditorView.UpdateAddressBarInfra failed: {0}", ex.Message); }
         }
 
         // #649: routed event from the unified EditorTopBar Reload button.
@@ -1001,7 +1001,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("UnitEditorView.RefreshHardCodingWarning failed: {0}", ex.Message);
+                Log.ErrorF("UnitEditorView.RefreshHardCodingWarning failed: {0}", ex.Message);
                 HardCodingWarningLabel.IsVisible = false;
             }
         }
@@ -1016,7 +1016,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var pv = WindowManager.Instance.Open<PatchManagerView>();
                 pv.JumpTo($"HARDCODING_UNIT={unitId:X2}", 0);
             }
-            catch (Exception ex) { Log.Error("UnitEditorView.HardCodingWarning_Click failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("UnitEditorView.HardCodingWarning_Click failed: {0}", ex.Message); }
         }
 
         public void EnablePickMode() => UnitList.EnablePickMode();

--- a/FEBuilderGBA.Avalonia/Views/UnitFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/UnitFE6View.axaml.cs
@@ -84,7 +84,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("UnitFE6View.JumpToSupportUnit failed: {0}", ex.Message);
+                Log.ErrorF("UnitFE6View.JumpToSupportUnit failed: {0}", ex.Message);
             }
         }
 
@@ -97,7 +97,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("UnitFE6View.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("UnitFE6View.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -121,7 +121,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _vm.IsLoading = false;
-                Log.Error("UnitFE6View.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("UnitFE6View.OnSelected failed: {0}", ex.Message);
             }
         }
 
@@ -292,7 +292,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("UnitFE6View.TryShowPortrait failed: {0}", ex.Message);
+                Log.ErrorF("UnitFE6View.TryShowPortrait failed: {0}", ex.Message);
                 PortraitImage.SetImage(null);
             }
         }
@@ -357,7 +357,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (addr == 0) return;
                 WindowManager.Instance.Navigate<ClassFE6View>(addr);
             }
-            catch (Exception ex) { Log.Error("UnitFE6View.ClassId_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("UnitFE6View.ClassId_Jump failed: {0}", ex.Message); }
         }
 
         async void ClassId_Pick(object? sender, RoutedEventArgs e)
@@ -372,7 +372,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     // NameText refresh via ValueChanged.
                 }
             }
-            catch (Exception ex) { Log.Error("UnitFE6View.ClassId_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("UnitFE6View.ClassId_Pick failed: {0}", ex.Message); }
         }
 
         void ClassId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -395,7 +395,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 uint addr = baseAddr + portraitId * dataSize;
                 WindowManager.Instance.Navigate<PortraitViewerView>(addr);
             }
-            catch (Exception ex) { Log.Error("OnPortraitLinkClick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("OnPortraitLinkClick failed: {0}", ex.Message); }
         }
 
         void Write_Click(object? sender, RoutedEventArgs e)
@@ -412,7 +412,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("UnitFE6View.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("UnitFE6View.Write_Click failed: {0}", ex.Message);
             }
         }
 
@@ -494,7 +494,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 }
                 if (TopBar != null) TopBar.StartAddressText = $"0x{baseAddr:X8}";
             }
-            catch (Exception ex) { Log.Error("UnitFE6View.UpdateAddressBarInfra failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("UnitFE6View.UpdateAddressBarInfra failed: {0}", ex.Message); }
         }
 
         /// <summary>
@@ -532,7 +532,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("UnitFE6View.RefreshHardCodingWarning failed: {0}", ex.Message);
+                Log.ErrorF("UnitFE6View.RefreshHardCodingWarning failed: {0}", ex.Message);
                 HardCodingWarningLabel.IsVisible = false;
             }
         }
@@ -551,7 +551,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var pv = WindowManager.Instance.Open<PatchManagerView>();
                 pv.JumpTo($"HARDCODING_UNIT={unitId:X2}", 0);
             }
-            catch (Exception ex) { Log.Error("UnitFE6View.HardCodingWarning_Click failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("UnitFE6View.HardCodingWarning_Click failed: {0}", ex.Message); }
         }
 
         // ---- #407: Weapon-rank letter labels -------------------------------
@@ -617,7 +617,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 SimLCKLabel.Text = sim.sim_luck.ToString();
                 SimTotalLabel.Text = sim.sim_sum_grow_rate.ToString();
             }
-            catch (Exception ex) { Log.Error("UnitFE6View.RefreshGrowthSim failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("UnitFE6View.RefreshGrowthSim failed: {0}", ex.Message); }
         }
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/UnitFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/UnitFE7View.axaml.cs
@@ -84,7 +84,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("UnitFE7View.JumpToSupportUnit failed: {0}", ex.Message);
+                Log.ErrorF("UnitFE7View.JumpToSupportUnit failed: {0}", ex.Message);
             }
         }
 
@@ -97,7 +97,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("UnitFE7View.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("UnitFE7View.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -121,7 +121,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _vm.IsLoading = false;
-                Log.Error("UnitFE7View.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("UnitFE7View.OnSelected failed: {0}", ex.Message);
             }
         }
 
@@ -288,7 +288,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (addr == 0) return;
                 WindowManager.Instance.Navigate<ClassEditorView>(addr);
             }
-            catch (Exception ex) { Log.Error("UnitFE7View.ClassId_Jump failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("UnitFE7View.ClassId_Jump failed: {0}", ex.Message); }
         }
 
         async void ClassId_Pick(object? sender, RoutedEventArgs e)
@@ -303,7 +303,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     // NameText refresh via ValueChanged.
                 }
             }
-            catch (Exception ex) { Log.Error("UnitFE7View.ClassId_Pick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("UnitFE7View.ClassId_Pick failed: {0}", ex.Message); }
         }
 
         void ClassId_ValueChanged(object? sender, IdFieldValueChangedEventArgs e)
@@ -326,7 +326,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 uint addr = baseAddr + portraitId * dataSize;
                 WindowManager.Instance.Navigate<PortraitViewerView>(addr);
             }
-            catch (Exception ex) { Log.Error("OnPortraitLinkClick failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("OnPortraitLinkClick failed: {0}", ex.Message); }
         }
 
         void Write_Click(object? sender, RoutedEventArgs e)
@@ -404,7 +404,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("Write failed: {0}", ex.Message);
+                Log.ErrorF("Write failed: {0}", ex.Message);
             }
         }
 
@@ -444,7 +444,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (SizeLabel != null)
                     SizeLabel.Text = $"0x{rom.RomInfo.unit_datasize:X}";
             }
-            catch (Exception ex) { Log.Error("UnitFE7View.UpdateAddressBarInfra failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("UnitFE7View.UpdateAddressBarInfra failed: {0}", ex.Message); }
         }
 
         /// <summary>
@@ -481,7 +481,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("UnitFE7View.RefreshHardCodingWarning failed: {0}", ex.Message);
+                Log.ErrorF("UnitFE7View.RefreshHardCodingWarning failed: {0}", ex.Message);
                 HardCodingWarningLabel.IsVisible = false;
             }
         }
@@ -500,7 +500,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var pv = WindowManager.Instance.Open<PatchManagerView>();
                 pv.JumpTo($"HARDCODING_UNIT={unitId:X2}", 0);
             }
-            catch (Exception ex) { Log.Error("UnitFE7View.HardCodingWarning_Click failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("UnitFE7View.HardCodingWarning_Click failed: {0}", ex.Message); }
         }
 
         // ---- #428: Weapon-rank letter labels -------------------------------
@@ -572,7 +572,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 SimMagicExtLabel.IsVisible = magicSplit;
                 if (magicSplit) SimMagicExtLabel.Text = sim.sim_ext_magic.ToString();
             }
-            catch (Exception ex) { Log.Error("UnitFE7View.RefreshGrowthSim failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("UnitFE7View.RefreshGrowthSim failed: {0}", ex.Message); }
         }
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/UnitMainView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/UnitMainView.axaml.cs
@@ -29,7 +29,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("UnitMainView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("UnitMainView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -42,7 +42,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("UnitMainView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("UnitMainView.OnSelected failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/UnitPaletteView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/UnitPaletteView.axaml.cs
@@ -30,7 +30,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("UnitPaletteView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("UnitPaletteView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -47,7 +47,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _vm.IsLoading = false;
-                Log.Error("UnitPaletteView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("UnitPaletteView.OnSelected failed: {0}", ex.Message);
             }
         }
 
@@ -86,7 +86,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("Write failed: {0}", ex.Message);
+                Log.ErrorF("Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/UnitsShortTextView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/UnitsShortTextView.axaml.cs
@@ -83,7 +83,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("Write failed: {0}", ex.Message);
+                Log.ErrorF("Write failed: {0}", ex.Message);
             }
         }
     }

--- a/FEBuilderGBA.Avalonia/Views/VennouWeaponLockView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/VennouWeaponLockView.axaml.cs
@@ -43,7 +43,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.LoadEntry(address);
                 UpdateUI();
             }
-            catch (Exception ex) { Log.Error("VennouWeaponLockView.OnSelected: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("VennouWeaponLockView.OnSelected: {0}", ex.Message); }
         }
 
         void UpdateUI()
@@ -68,7 +68,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 LoadList(); // Refresh list after write
                 CoreState.Services?.ShowInfo("Weapon lock data written.");
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.Error("VennouWeaponLockView.Write: {0}", ex.Message); }
+            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("VennouWeaponLockView.Write: {0}", ex.Message); }
         }
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/WelcomeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/WelcomeView.axaml.cs
@@ -73,7 +73,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("WelcomeView.LoadRecentFiles failed: {0}", ex.Message);
+                Log.ErrorF("WelcomeView.LoadRecentFiles failed: {0}", ex.Message);
                 NoRecentFilesLabel.IsVisible = true;
             }
         }

--- a/FEBuilderGBA.Avalonia/Views/WorldMapBGMView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapBGMView.axaml.cs
@@ -31,7 +31,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("WorldMapBGMView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("WorldMapBGMView.LoadList failed: {0}", ex.Message);
             }
             finally
             {
@@ -50,7 +50,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("WorldMapBGMView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("WorldMapBGMView.OnSelected failed: {0}", ex.Message);
             }
             finally
             {
@@ -83,7 +83,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("WorldMapBGMView.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("WorldMapBGMView.Write_Click failed: {0}", ex.Message);
             }
         }
 
@@ -105,7 +105,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("JumpToSong failed: {0}", ex.Message);
+                Log.ErrorF("JumpToSong failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/WorldMapEventPointerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapEventPointerView.axaml.cs
@@ -43,7 +43,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("WorldMapEventPointerView.InitialLoad failed: {0}", ex.Message);
+                Log.ErrorF("WorldMapEventPointerView.InitialLoad failed: {0}", ex.Message);
             }
             finally
             {
@@ -72,7 +72,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("WorldMapEventPointerView.ReloadBefore failed: {0}", ex.Message);
+                Log.ErrorF("WorldMapEventPointerView.ReloadBefore failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = prevLoading; _vm.MarkClean(); }
         }
@@ -89,7 +89,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("WorldMapEventPointerView.ReloadAfter failed: {0}", ex.Message);
+                Log.ErrorF("WorldMapEventPointerView.ReloadAfter failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = prevLoading; _vm.MarkClean(); }
         }
@@ -117,7 +117,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("WorldMapEventPointerView.OnBeforeSelected failed: {0}", ex.Message);
+                Log.ErrorF("WorldMapEventPointerView.OnBeforeSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = prevLoading; _vm.MarkClean(); }
         }
@@ -133,7 +133,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("WorldMapEventPointerView.OnAfterSelected failed: {0}", ex.Message);
+                Log.ErrorF("WorldMapEventPointerView.OnAfterSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = prevLoading; _vm.MarkClean(); }
         }
@@ -205,7 +205,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("WorldMapEventPointerView.Write_Click failed: {0}", ex.Message);
+                Log.ErrorF("WorldMapEventPointerView.Write_Click failed: {0}", ex.Message);
             }
         }
 
@@ -231,7 +231,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("WorldMapEventPointerView.WriteAfter_Click failed: {0}", ex.Message);
+                Log.ErrorF("WorldMapEventPointerView.WriteAfter_Click failed: {0}", ex.Message);
             }
         }
 
@@ -258,7 +258,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("WorldMapEventPointerView.WriteGlobalEvents_Click failed: {0}", ex.Message);
+                Log.ErrorF("WorldMapEventPointerView.WriteGlobalEvents_Click failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/WorldMapImageView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapImageView.axaml.cs
@@ -68,7 +68,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("WorldMapImageView.LoadAll failed: {0}", ex.Message);
+                Log.ErrorF("WorldMapImageView.LoadAll failed: {0}", ex.Message);
             }
             finally
             {
@@ -137,7 +137,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("WorldMapImageView.WriteAll failed: {0}", ex.Message);
+                Log.ErrorF("WorldMapImageView.WriteAll failed: {0}", ex.Message);
             }
         }
 
@@ -185,7 +185,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("WorldMapImageView.OnBorderSelected failed: {0}", ex.Message);
+                Log.ErrorF("WorldMapImageView.OnBorderSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = prevLoading; _vm.MarkClean(); }
             // #849 NV5c: render the border AP preview after loading the record.
@@ -232,7 +232,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("WorldMapImageView.BorderWrite failed: {0}", ex.Message);
+                Log.ErrorF("WorldMapImageView.BorderWrite failed: {0}", ex.Message);
             }
         }
 
@@ -389,7 +389,7 @@ namespace FEBuilderGBA.Avalonia.Views
         void OnBorderTopBarReloadRequested(object? sender, RoutedEventArgs e)
         {
             try { LoadBorderList(); }
-            catch (Exception ex) { Log.Error("BorderReload failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("BorderReload failed: {0}", ex.Message); }
         }
 
         // #825: list-expand for the border table (worldmap_county_border_pointer,
@@ -458,13 +458,13 @@ namespace FEBuilderGBA.Avalonia.Views
                 catch (Exception inner)
                 {
                     _undoService.Rollback();
-                    Log.Error("WorldMapImageView.BorderListExpand inner failed: {0}", inner.Message);
+                    Log.ErrorF("WorldMapImageView.BorderListExpand inner failed: {0}", inner.Message);
                     CoreState.Services?.ShowError(R._("List expansion failed: {0}", inner.Message));
                 }
             }
             catch (Exception ex)
             {
-                Log.Error("WorldMapImageView.BorderListExpand failed: {0}", ex.Message);
+                Log.ErrorF("WorldMapImageView.BorderListExpand failed: {0}", ex.Message);
             }
         }
 
@@ -541,7 +541,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("WorldMapImageView.OnIconSelected failed: {0}", ex.Message);
+                Log.ErrorF("WorldMapImageView.OnIconSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = prevLoading; _vm.MarkClean(); }
         }
@@ -577,7 +577,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("WorldMapImageView.IconWrite failed: {0}", ex.Message);
+                Log.ErrorF("WorldMapImageView.IconWrite failed: {0}", ex.Message);
             }
         }
 
@@ -585,7 +585,7 @@ namespace FEBuilderGBA.Avalonia.Views
         void OnIconDataTopBarReloadRequested(object? sender, RoutedEventArgs e)
         {
             try { LoadIconList(); }
-            catch (Exception ex) { Log.Error("IconDataReload failed: {0}", ex.Message); }
+            catch (Exception ex) { Log.ErrorF("IconDataReload failed: {0}", ex.Message); }
         }
 
         // #825: list-expand for the icon-data table (worldmap_icon_data_pointer,
@@ -645,13 +645,13 @@ namespace FEBuilderGBA.Avalonia.Views
                 catch (Exception inner)
                 {
                     _undoService.Rollback();
-                    Log.Error("WorldMapImageView.IconDataListExpand inner failed: {0}", inner.Message);
+                    Log.ErrorF("WorldMapImageView.IconDataListExpand inner failed: {0}", inner.Message);
                     CoreState.Services?.ShowError(R._("List expansion failed: {0}", inner.Message));
                 }
             }
             catch (Exception ex)
             {
-                Log.Error("WorldMapImageView.IconDataListExpand failed: {0}", ex.Message);
+                Log.ErrorF("WorldMapImageView.IconDataListExpand failed: {0}", ex.Message);
             }
         }
 
@@ -1301,7 +1301,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("WorldMapImageView.OpenSource_Click: {0}", ex.Message);
+                Log.ErrorF("WorldMapImageView.OpenSource_Click: {0}", ex.Message);
                 CoreState.Services?.ShowError($"Failed to open source file: {ex.Message}");
             }
         }
@@ -1340,7 +1340,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("WorldMapImageView.SelectSource_Click: {0}", ex.Message);
+                Log.ErrorF("WorldMapImageView.SelectSource_Click: {0}", ex.Message);
                 CoreState.Services?.ShowError($"Failed to open source folder: {ex.Message}");
             }
         }
@@ -1358,7 +1358,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
             catch (Exception ex)
             {
-                Log.Error("WorldMapImageView.Undo failed: {0}", ex.Message);
+                Log.ErrorF("WorldMapImageView.Undo failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/WorldMapPathView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapPathView.axaml.cs
@@ -34,7 +34,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _vm.IsLoading = false;
-                Log.Error("WorldMapPathView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("WorldMapPathView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -51,7 +51,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _vm.IsLoading = false;
-                Log.Error("WorldMapPathView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("WorldMapPathView.OnSelected failed: {0}", ex.Message);
             }
         }
 
@@ -90,7 +90,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("WorldMapPathView.Write failed: {0}", ex.Message);
+                Log.ErrorF("WorldMapPathView.Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/WorldMapPointView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapPointView.axaml.cs
@@ -44,7 +44,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _vm.IsLoading = false;
-                Log.Error("WorldMapPointView.LoadList failed: {0}", ex.Message);
+                Log.ErrorF("WorldMapPointView.LoadList failed: {0}", ex.Message);
             }
         }
 
@@ -61,7 +61,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _vm.IsLoading = false;
-                Log.Error("WorldMapPointView.OnSelected failed: {0}", ex.Message);
+                Log.ErrorF("WorldMapPointView.OnSelected failed: {0}", ex.Message);
             }
         }
 
@@ -124,7 +124,7 @@ namespace FEBuilderGBA.Avalonia.Views
             catch (Exception ex)
             {
                 _undoService.Rollback();
-                Log.Error("WorldMapPointView.Write failed: {0}", ex.Message);
+                Log.ErrorF("WorldMapPointView.Write failed: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.CLI/RomLoader.cs
+++ b/FEBuilderGBA.CLI/RomLoader.cs
@@ -155,7 +155,7 @@ namespace FEBuilderGBA.CLI
                 }
                 catch (Exception ex)
                 {
-                    Log.Error("Failed to init SystemTextEncoder, using headless fallback: {0}", ex.Message);
+                    Log.ErrorF("Failed to init SystemTextEncoder, using headless fallback: {0}", ex.Message);
                     // Use ROM-aware fallback so JP ROMs get Shift_JIS, not ISO-8859-1
                     CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(CoreState.ROM);
                 }
@@ -170,7 +170,7 @@ namespace FEBuilderGBA.CLI
                 }
                 catch (Exception ex)
                 {
-                    Log.Error("Failed to init FETextEncode (Huffman tree): {0}", ex.Message);
+                    Log.ErrorF("Failed to init FETextEncode (Huffman tree): {0}", ex.Message);
                 }
             }
 
@@ -187,7 +187,7 @@ namespace FEBuilderGBA.CLI
                 }
                 catch (Exception ex)
                 {
-                    Log.Error("Failed to init FlagCache: {0}", ex.Message);
+                    Log.ErrorF("Failed to init FlagCache: {0}", ex.Message);
                 }
             }
 
@@ -220,7 +220,7 @@ namespace FEBuilderGBA.CLI
             }
             catch (Exception ex)
             {
-                Log.Error("Failed to init EventScripts: {0}", ex.Message);
+                Log.ErrorF("Failed to init EventScripts: {0}", ex.Message);
             }
 
             // #1035: wire the patch-scan hardcode cache (replacing the no-op

--- a/FEBuilderGBA.Core.Tests/LogFormatOverloadTests.cs
+++ b/FEBuilderGBA.Core.Tests/LogFormatOverloadTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    /// <summary>
+    /// #1637 — behavioural coverage for the new <c>Log.ErrorF/NotifyF/DebugF</c>
+    /// <c>string.Format</c> overloads. The plain <c>Log.Error(params string[])</c> sink only
+    /// does <c>string.Join(" ", args)</c>, so a <c>{0}</c>-bearing call recorded the literal
+    /// token; the <c>*F</c> overloads must SUBSTITUTE it, and the malformed-format fallback must
+    /// never leave a literal <c>{N}</c> token behind.
+    ///
+    /// Uses a temp <see cref="CoreState.BaseDirectory"/> + the in-memory
+    /// <see cref="Log.NonWriteStringB"/> buffer so the suite does not pollute the real log;
+    /// serialises via the shared-state collection.
+    /// </summary>
+    [Collection("SharedState")]
+    public class LogFormatOverloadTests
+    {
+        private static string CaptureLast(Action logAction)
+        {
+            // Flush any pending content, then capture only what logAction writes.
+            Log.NonWriteStringB.Clear();
+            logAction();
+            string captured = Log.NonWriteStringB.ToString();
+            Log.NonWriteStringB.Clear();
+            return captured.TrimEnd('\r', '\n');
+        }
+
+        [Fact]
+        public void ErrorF_SubstitutesPlaceholders_NoLiteralToken()
+        {
+            string original = CoreState.BaseDirectory;
+            string tempDir = Path.Combine(Path.GetTempPath(), "febuilder_logfmt_" + Guid.NewGuid().ToString("N"));
+            try
+            {
+                Directory.CreateDirectory(tempDir);
+                CoreState.BaseDirectory = tempDir;
+
+                string line = CaptureLast(() => Log.ErrorF("Auto-save failed: {0}", "disk full"));
+
+                Assert.Contains("Auto-save failed: disk full", line);
+                Assert.DoesNotContain("{0}", line);
+            }
+            finally
+            {
+                CoreState.BaseDirectory = original;
+                try { if (Directory.Exists(tempDir)) Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void NotifyF_SubstitutesMultiplePlaceholders()
+        {
+            string line = CaptureLast(() => Log.NotifyF("{0}/{1} done", "3", "10"));
+            Assert.Contains("3/10 done", line);
+            Assert.DoesNotContain("{0}", line);
+            Assert.DoesNotContain("{1}", line);
+        }
+
+        [Fact]
+        public void ErrorF_MalformedFormat_DoesNotLeakLiteralPlaceholder()
+        {
+            // Too few args for {1}: must NOT throw and must NOT leave a literal {N} token.
+            string line = CaptureLast(() => Log.ErrorF("need {0} and {1}", "onlyone"));
+            Assert.DoesNotContain("{0}", line);
+            Assert.DoesNotContain("{1}", line);
+            Assert.Contains("onlyone", line);
+        }
+
+        [Fact]
+        public void ErrorF_NullArgs_DoesNotThrow_AndStripsPlaceholder()
+        {
+            // args == null path (explicit null array) — falls back, strips {0}.
+            string line = CaptureLast(() => Log.ErrorF("value {0}", (object[])null));
+            Assert.DoesNotContain("{0}", line);
+        }
+    }
+}

--- a/FEBuilderGBA.Core/FETextDecode.cs
+++ b/FEBuilderGBA.Core/FETextDecode.cs
@@ -366,7 +366,7 @@ namespace FEBuilderGBA
             {
                 if (addr + 4 > rom_length)
                 {
-                    Log.Error("String Tree Broken: {0}/{1} addr_start:{2}", U.ToHexString8(addr), U.ToHexString8(rom_length), U.ToHexString8(addr_start));
+                    Log.ErrorF("String Tree Broken: {0}/{1} addr_start:{2}", U.ToHexString8(addr), U.ToHexString8(rom_length), U.ToHexString8(addr_start));
                     out_DataSize = (int)(addr - addr_start);
                     return listbyte_to_string(str.ToArray(), str.Count);
                 }
@@ -375,7 +375,7 @@ namespace FEBuilderGBA
                 {
                     if (addr + 4 + 4 > rom_length)
                     {
-                        Log.Error("String Tree Broken2: {0}/{1} addr_start:{2}", U.ToHexString8(addr), U.ToHexString8(rom_length), U.ToHexString8(addr_start));
+                        Log.ErrorF("String Tree Broken2: {0}/{1} addr_start:{2}", U.ToHexString8(addr), U.ToHexString8(rom_length), U.ToHexString8(addr_start));
                         out_DataSize = (int)(addr - addr_start);
                         return listbyte_to_string(str.ToArray(), str.Count);
                     }
@@ -393,7 +393,7 @@ namespace FEBuilderGBA
                     uint tree_addr = tree_data + ((bit & 1) * 2);
                     if (tree_addr + 2 > rom_length)
                     {
-                        Log.Error("String Tree Broken3: {0}/{1} addr_start:{2}", U.ToHexString8(tree_addr), U.ToHexString8(rom_length), U.ToHexString8(addr_start));
+                        Log.ErrorF("String Tree Broken3: {0}/{1} addr_start:{2}", U.ToHexString8(tree_addr), U.ToHexString8(rom_length), U.ToHexString8(addr_start));
                         out_DataSize = 0;
                         return "";
                     }
@@ -407,7 +407,7 @@ namespace FEBuilderGBA
 
                     if (tree_data + 4 > rom_length)
                     {
-                        Log.Error("String Data Broken: {0}/{1} addr_start:{2}", U.ToHexString8(tree_data), U.ToHexString8(rom_length), U.ToHexString8(addr_start));
+                        Log.ErrorF("String Data Broken: {0}/{1} addr_start:{2}", U.ToHexString8(tree_data), U.ToHexString8(rom_length), U.ToHexString8(addr_start));
                         out_DataSize = 0;
                         return "";
                     }

--- a/FEBuilderGBA.Core/Log.cs
+++ b/FEBuilderGBA.Core/Log.cs
@@ -31,6 +31,75 @@ namespace FEBuilderGBA
             writeString("E:", args);
         }
 
+        // #1637: real string.Format overloads.
+        // The plain Debug/Notify/Error(params string[]) sink only does string.Join(" ", args),
+        // so a call like Error("... {0}", ex.Message) recorded the LITERAL "{0}" token
+        // instead of substituting it. These *F overloads do an actual string.Format so the
+        // {N} placeholders are substituted. Call sites that pass a {N}-bearing format string
+        // plus arguments must use these (the LogFormatPlaceholderTests regression guard enforces it).
+        [Conditional("DEBUG")]
+        public static void DebugF(string fmt, params object[] args)
+        {
+            writeString("D:", FormatSafe(fmt, args));
+        }
+
+        public static void NotifyF(string fmt, params object[] args)
+        {
+            writeString("N:", FormatSafe(fmt, args));
+        }
+
+        public static void ErrorF(string fmt, params object[] args)
+        {
+            writeString("E:", FormatSafe(fmt, args));
+        }
+
+        /// <summary>
+        /// #1637: string.Format that can never throw from a logging call. A malformed
+        /// format string (bad/extra placeholder) falls back to the raw format string —
+        /// with every <c>{N}</c> token stripped so the literal-placeholder bug can never
+        /// be reintroduced via the fallback path — followed by the joined arguments, so
+        /// logging stays diagnostic, never fatal and never polluted with <c>{N}</c>.
+        /// </summary>
+        private static string FormatSafe(string fmt, object[] args)
+        {
+            if (args == null || args.Length == 0)
+            {
+                return StripPlaceholders(fmt ?? string.Empty);
+            }
+            try
+            {
+                return string.Format(System.Globalization.CultureInfo.InvariantCulture, fmt ?? string.Empty, args);
+            }
+            catch (FormatException)
+            {
+                return FormatFallback(fmt, args);
+            }
+            catch (ArgumentNullException)
+            {
+                return FormatFallback(fmt, args);
+            }
+        }
+
+        private static string FormatFallback(string fmt, object[] args)
+        {
+            return StripPlaceholders(fmt ?? string.Empty)
+                + " " + string.Join(" ", System.Array.ConvertAll(args, a => a?.ToString() ?? string.Empty));
+        }
+
+        /// <summary>
+        /// Replaces every <c>{N}</c> indexed placeholder (e.g. <c>{0}</c>, <c>{1,5:X}</c>) with a
+        /// neutral <c>{}</c> token so a malformed-format fallback never records a literal
+        /// numbered placeholder in the log. Used only on the error path.
+        /// </summary>
+        private static string StripPlaceholders(string fmt)
+        {
+            if (string.IsNullOrEmpty(fmt) || fmt.IndexOf('{') < 0)
+            {
+                return fmt;
+            }
+            return System.Text.RegularExpressions.Regex.Replace(fmt, @"\{\d+(?:[,:][^}]*)?\}", "{}");
+        }
+
         private static void writeString(string type, params string[] args)
         {
             string str = string.Join(" ", args);

--- a/FEBuilderGBA.Core/MyTranslateBuild.cs
+++ b/FEBuilderGBA.Core/MyTranslateBuild.cs
@@ -1012,7 +1012,7 @@ namespace FEBuilderGBA
 
                 if (! U.isAsciiString(eq[0]))
                 {//トップが非アスキーなので危険.
-                    Log.Error("file;{0} {1} is not acsii",filename,eq[0]);
+                    Log.ErrorF("file;{0} {1} is not acsii",filename,eq[0]);
                     //全部書き換えましょう.
                     WriteDataFileALL(filename, langfilename);
                     return;

--- a/FEBuilderGBA.Core/MyTranslateBuild.cs
+++ b/FEBuilderGBA.Core/MyTranslateBuild.cs
@@ -1012,7 +1012,7 @@ namespace FEBuilderGBA
 
                 if (! U.isAsciiString(eq[0]))
                 {//トップが非アスキーなので危険.
-                    Log.ErrorF("file;{0} {1} is not acsii",filename,eq[0]);
+                    Log.ErrorF("file;{0} {1} is not ascii",filename,eq[0]);
                     //全部書き換えましょう.
                     WriteDataFileALL(filename, langfilename);
                     return;

--- a/FEBuilderGBA.Core/MyTranslateResource.cs
+++ b/FEBuilderGBA.Core/MyTranslateResource.cs
@@ -42,14 +42,14 @@ namespace FEBuilderGBA
             }
             catch (FormatException e)
             {
-                Log.Error("Translate Error! {0}->{1} @@ {2}" , src,trans , e.ToString() );
+                Log.ErrorF("Translate Error! {0}->{1} @@ {2}" , src,trans , e.ToString() );
                 try
                 {
                     return string.Format(src, args);
                 }
                 catch (FormatException e2)
                 {
-                    Log.Error("Translate Error2! {0} @@ {1}", src, e2.ToString());
+                    Log.ErrorF("Translate Error2! {0} @@ {1}", src, e2.ToString());
                     return src;
                 }
             }

--- a/FEBuilderGBA.Core/PatchMetadataCore.cs
+++ b/FEBuilderGBA.Core/PatchMetadataCore.cs
@@ -167,7 +167,7 @@ namespace FEBuilderGBA
             }
             catch (Exception ex)
             {
-                Log.Error("PatchMetadataCore: Failed to parse {0}: {1}", patchFilePath, ex.Message);
+                Log.ErrorF("PatchMetadataCore: Failed to parse {0}: {1}", patchFilePath, ex.Message);
             }
 
             return info;
@@ -339,7 +339,7 @@ namespace FEBuilderGBA
             }
             catch (Exception ex)
             {
-                Log.Error("PatchMetadataCore.GetPatchDependencies: {0}: {1}", patchFilePath, ex.Message);
+                Log.ErrorF("PatchMetadataCore.GetPatchDependencies: {0}: {1}", patchFilePath, ex.Message);
             }
 
             return result;

--- a/FEBuilderGBA.Core/SystemTextEncoder.cs
+++ b/FEBuilderGBA.Core/SystemTextEncoder.cs
@@ -80,7 +80,7 @@ namespace FEBuilderGBA
                 string resoucefilename = System.IO.Path.Combine(CoreState.BaseDirectory, "config", "translate", "zh_tbl", rom.RomInfo.TitleToFilename + ".tbl");
                 if (! File.Exists(resoucefilename))
                 {
-                    Log.Error("tbl not found. filename:{0}", resoucefilename);
+                    Log.ErrorF("tbl not found. filename:{0}", resoucefilename);
                     return false;
                 }
                 this.TBLEncode = new SystemTextEncoderTBLEncode(resoucefilename);
@@ -92,7 +92,7 @@ namespace FEBuilderGBA
                 string resoucefilename = System.IO.Path.Combine(CoreState.BaseDirectory, "config", "translate", "en_tbl", rom.RomInfo.TitleToFilename + ".tbl");
                 if (! File.Exists(resoucefilename))
                 {
-                    Log.Error("tbl not found. filename:{0}", resoucefilename);
+                    Log.ErrorF("tbl not found. filename:{0}", resoucefilename);
                     return false;
                 }
                 this.TBLEncode = new SystemTextEncoderTBLEncode(resoucefilename);
@@ -104,7 +104,7 @@ namespace FEBuilderGBA
                 string resoucefilename = System.IO.Path.Combine(CoreState.BaseDirectory, "config", "translate", "ko_tbl", rom.RomInfo.TitleToFilename + ".tbl");
                 if (!File.Exists(resoucefilename))
                 {
-                    Log.Error("tbl not found. filename:{0}", resoucefilename);
+                    Log.ErrorF("tbl not found. filename:{0}", resoucefilename);
                     return false;
                 }
                 this.TBLEncode = new SystemTextEncoderTBLEncode(resoucefilename);
@@ -116,7 +116,7 @@ namespace FEBuilderGBA
                 string resoucefilename = System.IO.Path.Combine(CoreState.BaseDirectory, "config", "translate", "ar_tbl", rom.RomInfo.TitleToFilename + ".arabic_tbl");
                 if (! File.Exists(resoucefilename))
                 {
-                    Log.Error("tbl not found. filename:{0}", resoucefilename);
+                    Log.ErrorF("tbl not found. filename:{0}", resoucefilename);
                     return false;
                 }
                 SystemTextEncoderTBLEncode inner = null;
@@ -138,7 +138,7 @@ namespace FEBuilderGBA
                 string resoucefilename = System.IO.Path.Combine(CoreState.BaseDirectory, "config", "translate", "kr_tbl", rom.RomInfo.TitleToFilename + ".tbl");
                 if (!File.Exists(resoucefilename))
                 {
-                    Log.Error("tbl not found. filename:{0}", resoucefilename);
+                    Log.ErrorF("tbl not found. filename:{0}", resoucefilename);
                     return false;
                 }
                 this.TBLEncode = new SystemTextEncoderTBLEncode(resoucefilename);

--- a/FEBuilderGBA.Tests/Unit/LogFormatPlaceholderTests.cs
+++ b/FEBuilderGBA.Tests/Unit/LogFormatPlaceholderTests.cs
@@ -1,0 +1,331 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace FEBuilderGBA.Tests.Unit
+{
+    /// <summary>
+    /// Regression guard for GitHub issue #1637.
+    ///
+    /// <para>The plain <c>Log.Error/Notify/Debug(params string[])</c> sink only does
+    /// <c>string.Join(" ", args)</c> — it has NO <c>string.Format</c>. So a call like
+    /// <c>Log.Error("... failed: {0}", ex.Message)</c> recorded the LITERAL <c>{0}</c>
+    /// token in the log instead of substituting it. The fix added real
+    /// <c>Log.ErrorF/NotifyF/DebugF(string fmt, params object[])</c> overloads that do an
+    /// actual <c>string.Format</c>, and every <c>{N}</c>-bearing call site was migrated to them.</para>
+    ///
+    /// <para>This test scans the four production source projects (Core, Avalonia, CLI, WinForms)
+    /// and FAILS the build if:</para>
+    /// <list type="number">
+    /// <item>A NON-<c>F</c> <c>Log.Error/Notify/Debug(...)</c> invocation contains a <c>{N}</c>
+    /// indexed placeholder in a string-literal argument (the original bug — would be silently
+    /// joined, not substituted), OR</item>
+    /// <item>A <c>Log.ErrorF/NotifyF/DebugF(...)</c> invocation's literal format string references
+    /// a placeholder index that exceeds the number of arguments supplied (a malformed format that
+    /// would land in <c>FormatSafe</c>'s fallback path).</item>
+    /// </list>
+    ///
+    /// <para>The scanner strips line/block comments and walks balanced parentheses so it catches
+    /// multi-line invocations and never trips on commented-out examples or string content outside
+    /// the call.</para>
+    /// </summary>
+    public class LogFormatPlaceholderTests
+    {
+        private static string SolutionDir
+        {
+            get
+            {
+                var dir = AppContext.BaseDirectory;
+                while (dir != null && !File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+                    dir = Path.GetDirectoryName(dir);
+                return dir ?? throw new InvalidOperationException("Cannot find solution root");
+            }
+        }
+
+        private static readonly string[] ScannedProjects =
+        {
+            "FEBuilderGBA.Core",
+            "FEBuilderGBA.Avalonia",
+            "FEBuilderGBA.CLI",
+            "FEBuilderGBA",
+        };
+
+        // {0}, {1,5}, {2:X4}, {3,-10:N2} — any indexed composite-format placeholder.
+        private static readonly Regex PlaceholderRx =
+            new(@"\{(\d+)(?:[,:][^{}]*)?\}", RegexOptions.Compiled);
+
+        // A Log.Error / Log.Notify / Log.Debug (+ optional trailing F) method call start.
+        private static readonly Regex LogCallStartRx =
+            new(@"\bLog\.(Error|Notify|Debug)(F?)\s*\(", RegexOptions.Compiled);
+
+        [Fact]
+        public void NoLiteralPlaceholderInPlainLogCalls()
+        {
+            var violations = new List<string>();
+
+            foreach (var proj in ScannedProjects)
+            {
+                var projDir = Path.Combine(SolutionDir, proj);
+                if (!Directory.Exists(projDir))
+                    continue;
+
+                foreach (var file in Directory.GetFiles(projDir, "*.cs", SearchOption.AllDirectories))
+                {
+                    // Skip generated designer files and the test project's own sources.
+                    if (file.Contains(".Tests", StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    var raw = File.ReadAllText(file);
+                    var stripped = StripComments(raw);
+                    var relPath = Path.GetRelativePath(SolutionDir, file);
+
+                    foreach (var call in EnumerateLogCalls(stripped))
+                    {
+                        int lineNum = LineOf(raw, stripped, call.StartIndex);
+
+                        if (!call.IsFormatOverload)
+                        {
+                            // Plain Log.Error/Notify/Debug: ANY {N} placeholder in a string
+                            // literal is the bug — it is joined, never substituted.
+                            foreach (var lit in call.StringLiterals)
+                            {
+                                var m = PlaceholderRx.Match(lit);
+                                if (m.Success)
+                                {
+                                    violations.Add(
+                                        $"{relPath}:{lineNum} => plain Log.{call.Method}(...) has literal placeholder " +
+                                        $"\"{m.Value}\"; use Log.{call.Method}F(...) so it is substituted.");
+                                    break;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            // Log.*F: the format string's highest placeholder index must be
+                            // satisfiable by the number of supplied arguments, else FormatSafe
+                            // would hit its fallback (a malformed-format smell).
+                            if (call.StringLiterals.Count == 0)
+                                continue; // non-literal format (a variable) — cannot statically check
+                            int maxIndex = -1;
+                            foreach (Match m in PlaceholderRx.Matches(call.StringLiterals[0]))
+                                maxIndex = Math.Max(maxIndex, int.Parse(m.Groups[1].Value));
+                            // argCount counts all top-level arguments; the format string is arg 0,
+                            // so substitution args available = ArgCount - 1.
+                            int substitutionArgs = call.ArgCount - 1;
+                            if (maxIndex >= 0 && maxIndex >= substitutionArgs)
+                            {
+                                violations.Add(
+                                    $"{relPath}:{lineNum} => Log.{call.Method}F(...) references placeholder " +
+                                    $"{{{maxIndex}}} but only {Math.Max(0, substitutionArgs)} argument(s) supplied.");
+                            }
+                        }
+                    }
+                }
+            }
+
+            Assert.True(violations.Count == 0,
+                $"Found {violations.Count} Log.* placeholder violation(s) (see issue #1637). " +
+                $"Plain Log.Error/Notify/Debug must NOT carry {{N}} placeholders — use the *F overloads. " +
+                $"Violations:\n" + string.Join("\n", violations));
+        }
+
+        /// <summary>Sanity check: the *F overloads exist in Core so the guidance above is actionable.</summary>
+        [Fact]
+        public void FormatOverloadsExist()
+        {
+            var logCs = File.ReadAllText(Path.Combine(SolutionDir, "FEBuilderGBA.Core", "Log.cs"));
+            Assert.Contains("void ErrorF(", logCs);
+            Assert.Contains("void NotifyF(", logCs);
+            Assert.Contains("void DebugF(", logCs);
+            Assert.Contains("string.Format(", logCs);
+        }
+
+        // ------------------------------------------------------------------
+        // Lightweight C# comment stripper. Replaces comment characters with
+        // spaces (preserving offsets so line numbers stay accurate) but keeps
+        // string/char literal contents intact.
+        // ------------------------------------------------------------------
+        private static string StripComments(string src)
+        {
+            var sb = new StringBuilder(src.Length);
+            int i = 0, n = src.Length;
+            while (i < n)
+            {
+                char c = src[i];
+
+                // Line comment
+                if (c == '/' && i + 1 < n && src[i + 1] == '/')
+                {
+                    while (i < n && src[i] != '\n') { sb.Append(' '); i++; }
+                    continue;
+                }
+                // Block comment
+                if (c == '/' && i + 1 < n && src[i + 1] == '*')
+                {
+                    while (i < n && !(src[i] == '*' && i + 1 < n && src[i + 1] == '/'))
+                    {
+                        sb.Append(src[i] == '\n' ? '\n' : ' ');
+                        i++;
+                    }
+                    if (i < n) { sb.Append(' '); i++; }       // '*'
+                    if (i < n) { sb.Append(' '); i++; }       // '/'
+                    continue;
+                }
+                // Verbatim string @"..."  ("" is an escaped quote)
+                if (c == '@' && i + 1 < n && src[i + 1] == '"')
+                {
+                    sb.Append(c); i++;
+                    sb.Append(src[i]); i++; // opening quote
+                    while (i < n)
+                    {
+                        if (src[i] == '"' && i + 1 < n && src[i + 1] == '"')
+                        {
+                            sb.Append(src[i]); sb.Append(src[i + 1]); i += 2; continue;
+                        }
+                        if (src[i] == '"') { sb.Append(src[i]); i++; break; }
+                        sb.Append(src[i]); i++;
+                    }
+                    continue;
+                }
+                // Regular string "..."  (\" escapes a quote)
+                if (c == '"')
+                {
+                    sb.Append(c); i++;
+                    while (i < n)
+                    {
+                        if (src[i] == '\\' && i + 1 < n) { sb.Append(src[i]); sb.Append(src[i + 1]); i += 2; continue; }
+                        if (src[i] == '"') { sb.Append(src[i]); i++; break; }
+                        sb.Append(src[i]); i++;
+                    }
+                    continue;
+                }
+                // Char literal '...'
+                if (c == '\'')
+                {
+                    sb.Append(c); i++;
+                    while (i < n)
+                    {
+                        if (src[i] == '\\' && i + 1 < n) { sb.Append(src[i]); sb.Append(src[i + 1]); i += 2; continue; }
+                        if (src[i] == '\'') { sb.Append(src[i]); i++; break; }
+                        sb.Append(src[i]); i++;
+                    }
+                    continue;
+                }
+
+                sb.Append(c);
+                i++;
+            }
+            return sb.ToString();
+        }
+
+        private sealed class LogCall
+        {
+            public string Method = "";          // Error / Notify / Debug
+            public bool IsFormatOverload;        // true => *F
+            public int StartIndex;
+            public int ArgCount;                 // count of top-level arguments
+            public List<string> StringLiterals = new();  // contents of any top-level string-literal args
+        }
+
+        // Enumerate every Log.(Error|Notify|Debug)(...) call in comment-stripped source,
+        // walking balanced parentheses so multi-line calls are captured whole.
+        private static IEnumerable<LogCall> EnumerateLogCalls(string src)
+        {
+            foreach (Match start in LogCallStartRx.Matches(src))
+            {
+                int open = start.Index + start.Length - 1; // index of '('
+                var call = new LogCall
+                {
+                    Method = start.Groups[1].Value,
+                    IsFormatOverload = start.Groups[2].Value == "F",
+                    StartIndex = start.Index,
+                };
+
+                int depth = 0;
+                int i = open;
+                int argStart = open + 1;
+                bool sawAnyToken = false;
+                var literalBuf = new StringBuilder();
+                bool argIsPureLiteral = true;
+                bool argHasNonWhitespace = false;
+
+                while (i < src.Length)
+                {
+                    char c = src[i];
+                    if (c == '"')
+                    {
+                        // capture string literal content (handles \" )
+                        int j = i + 1;
+                        var lit = new StringBuilder();
+                        while (j < src.Length)
+                        {
+                            if (src[j] == '\\' && j + 1 < src.Length) { lit.Append(src[j + 1]); j += 2; continue; }
+                            if (src[j] == '"') break;
+                            lit.Append(src[j]); j++;
+                        }
+                        if (depth == 1)
+                        {
+                            literalBuf.Append(lit);
+                            argHasNonWhitespace = true;
+                        }
+                        sawAnyToken = true;
+                        i = j + 1;
+                        continue;
+                    }
+                    if (c == '(') { depth++; i++; continue; }
+                    if (c == ')')
+                    {
+                        depth--;
+                        if (depth == 0)
+                        {
+                            // close last argument
+                            FlushArg(call, literalBuf, ref argIsPureLiteral, ref argHasNonWhitespace, sawAnyToken && argStart < i);
+                            break;
+                        }
+                        i++; continue;
+                    }
+                    if (c == ',' && depth == 1)
+                    {
+                        FlushArg(call, literalBuf, ref argIsPureLiteral, ref argHasNonWhitespace, true);
+                        argStart = i + 1;
+                        i++; continue;
+                    }
+                    if (depth == 1 && !char.IsWhiteSpace(c) && c != '+')
+                    {
+                        // token that isn't a string literal => arg is not a pure literal
+                        argIsPureLiteral = false;
+                        argHasNonWhitespace = true;
+                    }
+                    sawAnyToken = true;
+                    i++;
+                }
+
+                yield return call;
+            }
+        }
+
+        private static void FlushArg(LogCall call, StringBuilder literalBuf,
+            ref bool argIsPureLiteral, ref bool argHasNonWhitespace, bool argExists)
+        {
+            if (argExists)
+            {
+                call.ArgCount++;
+                if (argIsPureLiteral && argHasNonWhitespace)
+                    call.StringLiterals.Add(literalBuf.ToString());
+            }
+            literalBuf.Clear();
+            argIsPureLiteral = true;
+            argHasNonWhitespace = false;
+        }
+
+        // Line number of an index in the comment-stripped string maps 1:1 to the raw
+        // string because StripComments preserves '\n' positions.
+        private static int LineOf(string raw, string stripped, int index)
+        {
+            int count = 1;
+            int max = Math.Min(index, stripped.Length);
+            for (int k = 0; k < max; k++)
+                if (stripped[k] == '\n') count++;
+            return count;
+        }
+    }
+}

--- a/FEBuilderGBA/AutoSaveWinForms.cs
+++ b/FEBuilderGBA/AutoSaveWinForms.cs
@@ -110,7 +110,7 @@ namespace FEBuilderGBA
                 catch (Exception ex)
                 {
                     if (ctx != null)
-                        ctx.Post(_ => Log.Error("Auto-save failed: {0}", ex.Message), null);
+                        ctx.Post(_ => Log.ErrorF("Auto-save failed: {0}", ex.Message), null);
                 }
                 finally
                 {

--- a/FEBuilderGBA/EventUnitFE6Form.cs
+++ b/FEBuilderGBA/EventUnitFE6Form.cs
@@ -348,7 +348,7 @@ namespace FEBuilderGBA
             {
                 if (addr + 2 > rom_length)
                 {
-                    Log.Error("ROM Broken! Address after allocation is out of range. {0}+2/{1}", U.ToHexString8(addr), U.ToHexString8(rom_length));
+                    Log.ErrorF("ROM Broken! Address after allocation is out of range. {0}+2/{1}", U.ToHexString8(addr), U.ToHexString8(rom_length));
                     break;
                 }
                 if (Program.ROM.u8(addr + 0) == 0)

--- a/FEBuilderGBA/EventUnitFE7Form.cs
+++ b/FEBuilderGBA/EventUnitFE7Form.cs
@@ -479,7 +479,7 @@ namespace FEBuilderGBA
             {
                 if (addr + 2 > rom_length)
                 {
-                    Log.Error("ROM Broken! Address after allocation is out of range. {0}+2/{1}", U.ToHexString8(addr), U.ToHexString8(rom_length));
+                    Log.ErrorF("ROM Broken! Address after allocation is out of range. {0}+2/{1}", U.ToHexString8(addr), U.ToHexString8(rom_length));
                     break;
                 }
                 if (Program.ROM.u8(addr + 0) == 0)

--- a/FEBuilderGBA/EventUnitForm.cs
+++ b/FEBuilderGBA/EventUnitForm.cs
@@ -990,7 +990,7 @@ namespace FEBuilderGBA
             {
                 if (addr + 8 + 4 > rom_length)
                 {
-                    Log.Error("ROM Broken! Address after allocation is out of range. {0}+8+4/{1}", U.ToHexString8(addr), U.ToHexString8(rom_length));
+                    Log.ErrorF("ROM Broken! Address after allocation is out of range. {0}+8+4/{1}", U.ToHexString8(addr), U.ToHexString8(rom_length));
                     break;
                 }
 
@@ -1005,7 +1005,7 @@ namespace FEBuilderGBA
             {
                 if (addr + 8 + 4 > rom_length)
                 {
-                    Log.Error("ROM Broken! Address after allocation is out of range. {0}+8+4/{1}", U.ToHexString8(addr), U.ToHexString8(rom_length));
+                    Log.ErrorF("ROM Broken! Address after allocation is out of range. {0}+8+4/{1}", U.ToHexString8(addr), U.ToHexString8(rom_length));
                     break;
                 }
                 if (Program.ROM.u8(addr + 0) == 0)

--- a/FEBuilderGBA/ImageBattleAnimeForm.cs
+++ b/FEBuilderGBA/ImageBattleAnimeForm.cs
@@ -539,7 +539,7 @@ namespace FEBuilderGBA
            {
                if (addr + 4 > rom_length)
                {
-                   Log.Error("ROM Broken! Address after allocation is out of range. {0}+2/{1}", U.ToHexString8(addr), U.ToHexString8(rom_length));
+                   Log.ErrorF("ROM Broken! Address after allocation is out of range. {0}+2/{1}", U.ToHexString8(addr), U.ToHexString8(rom_length));
                    break;
                }
                if (Program.ROM.u32(addr + 0) == 0)

--- a/FEBuilderGBA/InputFormRef.cs
+++ b/FEBuilderGBA/InputFormRef.cs
@@ -6928,7 +6928,7 @@ namespace FEBuilderGBA
 
                     if (addr >= limitter)
                     {//終端を超えるので探索強制打ち切り.
-                        Log.ErrorF("アドレス({0}+{1})は、終端(2)を超えるので表示できません。", U.To0xHexString(addr), U.To0xHexString(this.BlockSize), U.To0xHexString(limitter));
+                        Log.ErrorF("アドレス({0}+{1})は、終端({2})を超えるので表示できません。", U.To0xHexString(addr), U.To0xHexString(this.BlockSize), U.To0xHexString(limitter));
                         break;
                     }
                     if (i >= 0xffff)

--- a/FEBuilderGBA/InputFormRef.cs
+++ b/FEBuilderGBA/InputFormRef.cs
@@ -6928,12 +6928,12 @@ namespace FEBuilderGBA
 
                     if (addr >= limitter)
                     {//終端を超えるので探索強制打ち切り.
-                        Log.Error("アドレス({0}+{1})は、終端(2)を超えるので表示できません。", U.To0xHexString(addr), U.To0xHexString(this.BlockSize), U.To0xHexString(limitter));
+                        Log.ErrorF("アドレス({0}+{1})は、終端(2)を超えるので表示できません。", U.To0xHexString(addr), U.To0xHexString(this.BlockSize), U.To0xHexString(limitter));
                         break;
                     }
                     if (i >= 0xffff)
                     {//65535個を超えるので探索強制打ち切り.
-                        Log.Error("アドレス({0}+{1})は、65535個のアイテムがあります。壊れています。", U.To0xHexString(addr), U.To0xHexString(this.BlockSize));
+                        Log.ErrorF("アドレス({0}+{1})は、65535個のアイテムがあります。壊れています。", U.To0xHexString(addr), U.To0xHexString(this.BlockSize));
                         break;
                     }
 

--- a/FEBuilderGBA/Log.cs
+++ b/FEBuilderGBA/Log.cs
@@ -30,6 +30,70 @@ namespace FEBuilderGBA
         {
             writeString("E:", args);
         }
+
+        // #1637: real string.Format overloads.
+        // The plain Debug/Notify/Error(params string[]) sink only does string.Join(" ", args),
+        // so a call like Error("... {0}", ex.Message) recorded the LITERAL "{0}" token
+        // instead of substituting it. These *F overloads do an actual string.Format so the
+        // {N} placeholders are substituted. (Mirrors FEBuilderGBA.Core/Log.cs; this WinForms
+        // Log class shadows the Core one for the WinForms assembly.)
+        [Conditional("DEBUG")]
+        public static void DebugF(string fmt, params object[] args)
+        {
+            writeString("D:", FormatSafe(fmt, args));
+        }
+
+        public static void NotifyF(string fmt, params object[] args)
+        {
+            writeString("N:", FormatSafe(fmt, args));
+        }
+
+        public static void ErrorF(string fmt, params object[] args)
+        {
+            writeString("E:", FormatSafe(fmt, args));
+        }
+
+        /// <summary>
+        /// #1637: string.Format that can never throw from a logging call. A malformed
+        /// format string falls back to the raw format string — with every {N} token
+        /// stripped so the literal-placeholder bug can never be reintroduced via the
+        /// fallback — followed by the joined arguments.
+        /// </summary>
+        private static string FormatSafe(string fmt, object[] args)
+        {
+            if (args == null || args.Length == 0)
+            {
+                return StripPlaceholders(fmt ?? string.Empty);
+            }
+            try
+            {
+                return string.Format(System.Globalization.CultureInfo.InvariantCulture, fmt ?? string.Empty, args);
+            }
+            catch (FormatException)
+            {
+                return FormatFallback(fmt, args);
+            }
+            catch (ArgumentNullException)
+            {
+                return FormatFallback(fmt, args);
+            }
+        }
+
+        private static string FormatFallback(string fmt, object[] args)
+        {
+            return StripPlaceholders(fmt ?? string.Empty)
+                + " " + string.Join(" ", Array.ConvertAll(args, a => a?.ToString() ?? string.Empty));
+        }
+
+        private static string StripPlaceholders(string fmt)
+        {
+            if (string.IsNullOrEmpty(fmt) || fmt.IndexOf('{') < 0)
+            {
+                return fmt;
+            }
+            return System.Text.RegularExpressions.Regex.Replace(fmt, @"\{\d+(?:[,:][^}]*)?\}", "{}");
+        }
+
         private static void writeString(string type, params string[] args)
         {
             string str = string.Join(" ", args);

--- a/FEBuilderGBA/MapEditorForm.cs
+++ b/FEBuilderGBA/MapEditorForm.cs
@@ -471,7 +471,7 @@ namespace FEBuilderGBA
                 uint p = addr + (uint)i;
                 if (p + 2 > rom_length)
                 {
-                    Log.ErrorF("ROM Broken! MappChange[{2}] is out of range. {0}+2/{1}", U.ToHexString8(addr), U.ToHexString8(rom_length), n.ToString());
+                    Log.ErrorF("ROM Broken! MapChange[{2}] is out of range. {0}+2/{1}", U.ToHexString8(addr), U.ToHexString8(rom_length), n.ToString());
                     break;
                 }
 

--- a/FEBuilderGBA/MapEditorForm.cs
+++ b/FEBuilderGBA/MapEditorForm.cs
@@ -471,7 +471,7 @@ namespace FEBuilderGBA
                 uint p = addr + (uint)i;
                 if (p + 2 > rom_length)
                 {
-                    Log.Error("ROM Broken! MappChange[{2}] is out of range. {0}+2/{1}", U.ToHexString8(addr), U.ToHexString8(rom_length), n.ToString());
+                    Log.ErrorF("ROM Broken! MappChange[{2}] is out of range. {0}+2/{1}", U.ToHexString8(addr), U.ToHexString8(rom_length), n.ToString());
                     break;
                 }
 

--- a/FEBuilderGBA/MyTranslateResource.cs
+++ b/FEBuilderGBA/MyTranslateResource.cs
@@ -42,14 +42,14 @@ namespace FEBuilderGBA
             }
             catch (FormatException e)
             {
-                Log.Error("Translate Error! {0}->{1} @@ {2}" , src,trans , e.ToString() );
+                Log.ErrorF("Translate Error! {0}->{1} @@ {2}" , src,trans , e.ToString() );
                 try
                 {
                     return string.Format(src, args);
                 }
                 catch (FormatException e2)
                 {
-                    Log.Error("Translate Error2! {0} @@ {1}", src, e2.ToString());
+                    Log.ErrorF("Translate Error2! {0} @@ {1}", src, e2.ToString());
                     return src;
                 }
             }

--- a/FEBuilderGBA/PatchForm.cs
+++ b/FEBuilderGBA/PatchForm.cs
@@ -8071,7 +8071,7 @@ namespace FEBuilderGBA
                     Program.CommentCache.Remove(addr);
                     if (addr >= current_rom_length)
                     {
-//                        Log.Error("OutOfRange: {0}/{1}", U.ToHexString8(addr), U.ToHexString8(current_rom_length));
+//                        Log.ErrorF("OutOfRange: {0}/{1}", U.ToHexString8(addr), U.ToHexString8(current_rom_length));
                         continue;
                     }
 

--- a/FEBuilderGBA/SongInstrumentForm.cs
+++ b/FEBuilderGBA/SongInstrumentForm.cs
@@ -912,7 +912,7 @@ namespace FEBuilderGBA
                 || instrumentCode == 0x0B
                 )
             {
-                Log.Debug("This is WaveMemory({0})", U.To0xHexString(instrumentCode));
+                Log.DebugF("This is WaveMemory({0})", U.To0xHexString(instrumentCode));
                 return true;
             }
             return false;
@@ -925,7 +925,7 @@ namespace FEBuilderGBA
                 || instrumentCode == 0x18
                 )
             {
-                Log.Debug("This is DirectSound({0})", U.To0xHexString(instrumentCode));
+                Log.DebugF("This is DirectSound({0})", U.To0xHexString(instrumentCode));
                 return true;
             }
             return false;

--- a/FEBuilderGBA/SystemTextEncoder.cs
+++ b/FEBuilderGBA/SystemTextEncoder.cs
@@ -78,7 +78,7 @@ namespace FEBuilderGBA
                 string resoucefilename = System.IO.Path.Combine(Program.BaseDirectory, "config", "translate", "zh_tbl", rom.RomInfo.TitleToFilename + ".tbl");
                 if (! File.Exists(resoucefilename))
                 {
-                    Log.Error("tbl not found. filename:{0}", resoucefilename);
+                    Log.ErrorF("tbl not found. filename:{0}", resoucefilename);
                     return false;
                 }
                 this.TBLEncode = new SystemTextEncoderTBLEncode(resoucefilename);
@@ -90,7 +90,7 @@ namespace FEBuilderGBA
                 string resoucefilename = System.IO.Path.Combine(Program.BaseDirectory, "config", "translate", "en_tbl", rom.RomInfo.TitleToFilename + ".tbl");
                 if (! File.Exists(resoucefilename))
                 {
-                    Log.Error("tbl not found. filename:{0}", resoucefilename);
+                    Log.ErrorF("tbl not found. filename:{0}", resoucefilename);
                     return false;
                 }
                 this.TBLEncode = new SystemTextEncoderTBLEncode(resoucefilename);
@@ -102,7 +102,7 @@ namespace FEBuilderGBA
                 string resoucefilename = System.IO.Path.Combine(Program.BaseDirectory, "config", "translate", "ko_tbl", rom.RomInfo.TitleToFilename + ".tbl");
                 if (!File.Exists(resoucefilename))
                 {
-                    Log.Error("tbl not found. filename:{0}", resoucefilename);
+                    Log.ErrorF("tbl not found. filename:{0}", resoucefilename);
                     return false;
                 }
                 this.TBLEncode = new SystemTextEncoderTBLEncode(resoucefilename);
@@ -114,7 +114,7 @@ namespace FEBuilderGBA
                 string resoucefilename = System.IO.Path.Combine(Program.BaseDirectory, "config", "translate", "ar_tbl", rom.RomInfo.TitleToFilename + ".arabic_tbl");
                 if (! File.Exists(resoucefilename))
                 {
-                    Log.Error("tbl not found. filename:{0}", resoucefilename);
+                    Log.ErrorF("tbl not found. filename:{0}", resoucefilename);
                     return false;
                 }
                 SystemTextEncoderTBLEncode inner = null;
@@ -136,7 +136,7 @@ namespace FEBuilderGBA
                 string resoucefilename = System.IO.Path.Combine(Program.BaseDirectory, "config", "translate", "kr_tbl", rom.RomInfo.TitleToFilename + ".tbl");
                 if (!File.Exists(resoucefilename))
                 {
-                    Log.Error("tbl not found. filename:{0}", resoucefilename);
+                    Log.ErrorF("tbl not found. filename:{0}", resoucefilename);
                     return false;
                 }
                 this.TBLEncode = new SystemTextEncoderTBLEncode(resoucefilename);

--- a/FEBuilderGBA/ToolWorkSupportForm.cs
+++ b/FEBuilderGBA/ToolWorkSupportForm.cs
@@ -753,7 +753,7 @@ namespace FEBuilderGBA
             }
 
             DateTime romDatetime = GetROMDateTime(romfilename);
-            Log.Notify("romDatetime:{0} vs datetime:{1}", romDatetime.ToString(), datetime.ToString());
+            Log.NotifyF("romDatetime:{0} vs datetime:{1}", romDatetime.ToString(), datetime.ToString());
             if (romDatetime < datetime)
             {//更新する必要あり!
                 return UPDATE_RESULT.UPDATEABLE;

--- a/FEBuilderGBA/U.cs
+++ b/FEBuilderGBA/U.cs
@@ -4900,7 +4900,7 @@ namespace FEBuilderGBA
         {
             string url = download_url;
             string contents = U.HttpGet(url);
-            Log.Debug("front page:{0}", contents);
+            Log.DebugF("front page:{0}", contents);
             contents = U.skip(contents, "name=\"token\"");
             string token = U.cut(contents, "value=\"", "\"");
             token = Uri.UnescapeDataString(token);
@@ -4914,18 +4914,18 @@ namespace FEBuilderGBA
             Dictionary<string, string> args = new Dictionary<string, string>();
             args["token"] = token;
             contents = U.HttpPost(download_url, args, download_url);
-            Log.Debug("download page:{0}", contents);
+            Log.DebugF("download page:{0}", contents);
             contents = U.skip(contents, "http-equiv=\"refresh\"");
             string durl = U.cut(contents, "URL=", "\"");
             durl = Uri.UnescapeDataString(durl);
             durl = U.unhtmlspecialchars(durl);
             if (durl == "" && durl.IndexOf("http") < 0)
             {
-                Log.Error("download url NOT FOUND:{0}", durl);
+                Log.ErrorF("download url NOT FOUND:{0}", durl);
                 return;
             }
 
-            Log.Notify("download url:{0}", durl);
+            Log.NotifyF("download url:{0}", durl);
             U.HttpDownload(save_filename, durl, download_url, pleaseWait);
         }
 
@@ -7496,7 +7496,7 @@ namespace FEBuilderGBA
                 }
                 catch (Exception e)
                 {
-                    Log.Error("ディレクトリを作成できませんでした。\r\n{0}\r\n\r\n{1}", destDirName, R.ExceptionToString(e));
+                    Log.ErrorF("ディレクトリを作成できませんでした。\r\n{0}\r\n\r\n{1}", destDirName, R.ExceptionToString(e));
                 }
             }
 
@@ -7520,7 +7520,7 @@ namespace FEBuilderGBA
                 }
                 catch (Exception e)
                 {
-                    Log.Error("ファイルをコピーできませんでした。\r\nSrc:{0}\r\nDest:{1}\r\n\r\n{2}", file, destfilename,R.ExceptionToString(e));
+                    Log.ErrorF("ファイルをコピーできませんでした。\r\nSrc:{0}\r\nDest:{1}\r\n\r\n{2}", file, destfilename,R.ExceptionToString(e));
                 }
             }
 

--- a/docs/CORE-SEAMS.md
+++ b/docs/CORE-SEAMS.md
@@ -143,6 +143,30 @@ the "### Graphics System" overview in `CLAUDE.md`.
 - `MapTileAnimation1ImageCore.cs` (Core, #1602; WF `MapTileAnimation1Form`) — Map Tile Animation Type 1 image surface (anime1 is the INVERSE of anime2: RAW 4bpp block at the entry's **+4** pointer, sized by **+2** u16 length, NOT LZ77): `CalcEntryHeight` (=`CalcHeight(256,len)`), `ResolvePaletteOffset` (parent map's `palette_plist`→PALETTE table via `MapChangeCore.PlistToOffsetAddr`), `RenderEntryImage` (R/O, `ByteToImage16Tile` 256×H), `ImportEntryImage` (single-PNG, **+2 length AUTHORITATIVE/unchanged** — reject unless `height==CalcEntryHeight(currentLen)`, remap→`EncodeDirectTiles4bpp`→`WriteRawToROM` to +4, snapshot byte-identical fault restore #885/#923, ambient undo), `ExportBatchTxt`/`ImportBatchTxt` (`.mapanime1.txt`; batch honours the explicit 3rd length column with truncate, all `<=0xFFFF` guarded, injected PNG save/load delegates keep Core decoder-free). Avalonia `MapTileAnimation1View` GbaImageControl preview + sample-palette combo + Export/Import/ExportAll/ImportAll. **Composited-map GIF (the #1602 deferred half):** `ResolveGifContext` (first map using the anime1 PLIST → OBJ/obj2/palette/config/mappointer offsets), `ReadFrameBytes` (RAW 4bpp `change_bitmap_bytes`), `ExportGif` composites each frame onto the chapter map via `MapRenderCore.RenderMapImage`'s new `animeOverlayBytes`/`ANIME1_OBJ_PATCH_OFFSET`(=8192, the WF `U.ArrayPatch` offset) → `GifEncoderCore.Encode` (`GameFrameSecToGifFrameSec` timing, IImage disposed per frame); R/O. ExportAll save dialog offers `.mapanime1.txt`|`.gif`.
 - `AIScriptPointerJumpCore.cs` (Core, #1600; WF `AIScriptForm.ParamLabel_Clicked`) — AIScript per-param `POINTER_AI*` jump to the 5 AI sub-editors: `ClassifyArg` (5 ArgTypes → `AiPointerKind`), `AllocIfNeed` (WF AllocIfNeed; alloc a fresh 4-byte ASM block for null/broken Coordinate/Range/CallTalk via the `MapExitPointCore.NewAlloc` seam — Units/Tiles never alloc), `IsBrokenData` (Coordinate `u16(off+2)!=0`), `WritePointerIntoBytes` (PURE — pointer into opcode `ByteData`, NO ROM). Avalonia `AIScriptViewModel.{TryGetParamArg,GetParam*,ClassifyParam,ParamNeedsAlloc,ApplyPointerJump}` write the resolved/allocated pointer into the selected row's IN-MEMORY `OneCode.ByteData` (clone-replace like `UpdateRow`) so a later `WriteScript` serializes it and pending row edits survive; `AIScriptView` 5 `Param*Label` clickable affordances (Cursor=Hand + PointerPressed) prompt-before-alloc (reuses WF JP key, no new translate) then `Navigate<>` the matching sub-editor seeded at the pointer; NavigationTargets manifest gains the 5 jump rows. Sub-Views' `NavigateTo` direct-load the supplied addr (#1414).
 
+## Logging — `Log.*` vs `Log.*F` (string.Format) overloads
+
+**Files:** `FEBuilderGBA.Core/Log.cs` (used by Core, Avalonia, CLI) and `FEBuilderGBA/Log.cs`
+(the WinForms `Log` class, which shadows the Core one inside the WinForms assembly).
+
+The base `Log.Debug/Notify/Error(params string[] args)` sink only does
+`string.Join(" ", args)` — it has **no `string.Format`**. So `Log.Error("... failed: {0}", ex.Message)`
+recorded the **literal `{0}` token** in the log instead of substituting the value (the value
+was still appended after a space, just un-substituted), polluting every such diagnostic line (#1637).
+
+Fix: real `Log.DebugF/NotifyF/ErrorF(string fmt, params object[] args)` overloads do an actual
+`string.Format(InvariantCulture, fmt, args)`. They route through the existing join sink with the
+single formatted string. `FormatSafe` never throws from a logging call — a malformed format string
+(bad/extra placeholder) falls back to the format string **with every `{N}` token stripped to `{}`**
+plus the joined args, so the literal-placeholder bug can never be reintroduced via the fallback.
+`DebugF` keeps `[Conditional("DEBUG")]` parity with `Debug`.
+
+**Convention:** any `Log.*` call carrying a `{N}` placeholder MUST use the `*F` overload.
+The `FEBuilderGBA.Tests/Unit/LogFormatPlaceholderTests` regression guard scans all four production
+projects (Core, Avalonia, CLI, WinForms), strips comments, walks balanced parens (so it catches
+multi-line calls), and FAILS the build if a plain `Log.Error/Notify/Debug(...)` carries a literal
+`{N}` placeholder, or if a `Log.*F(...)` references a placeholder index its argument list cannot
+satisfy. Runs in `check.yml` on every PR.
+
 ## Table Expansion Helpers (full prose)
 
 **File:** `FEBuilderGBA.Core/DataExpansionCore.cs`


### PR DESCRIPTION
## Summary

`Log.Debug/Notify/Error` are declared `params string[]` whose only sink does `string.Join(" ", args)` — there is **no `string.Format`**. So **1128** call sites passing `Log.Error("... failed: {0}", ex.Message)` recorded the **literal `{0}` token** instead of substituting it, polluting every such Avalonia/Core/CLI/WinForms diagnostic log line for the release.

This adds real `Log.DebugF/NotifyF/ErrorF(string fmt, params object[] args)` overloads (`string.Format`, InvariantCulture), migrates all 1128 `{N}`-bearing sites to them, and installs a build-failing regression guard.

Closes #1637 · Part of #1628 (release-readiness umbrella). [Plan & Copilot review](https://github.com/laqieer/FEBuilderGBA/issues/1637#issuecomment-4818589343).

## What changed

- **`FEBuilderGBA.Core/Log.cs`** + **`FEBuilderGBA/Log.cs`** — added `DebugF/NotifyF/ErrorF`. The WinForms `Log` class **shadows** the Core one inside the WinForms assembly, so both needed the overloads (this is why the Copilot-requested WinForms build mattered — it surfaced 18 `CS0117 'Log' does not contain 'ErrorF'` errors before they could reach CI). `FormatSafe` never throws from a logging call: a malformed format falls back to the format string with **every `{N}` token stripped to `{}`** plus joined args, so the bug can never re-enter via the fallback. `DebugF` keeps `[Conditional("DEBUG")]` parity.
- **1128 call-site migrations** `Log.Error/Notify/Debug(...)` → `Log.ErrorF/NotifyF/DebugF(...)` (Avalonia 218 files / Core 5 / CLI 1 / WinForms 13). The 6 `R.Error`/`R._`/`string.Format`-wrapped sites (already substituted) are **untouched**. Every migrated file is a clean N-for-N line swap (verified via `git diff --numstat`).
- **Regression guards** (2 new test files) + **`docs/CORE-SEAMS.md`** logging section.

## Fix count + evidence

| Metric | Value |
|---|---|
| `{N}`-bearing direct sites migrated to `*F` | **1128** |
| Remaining plain `Log.*("...{N}...", …)` bug sites | **0** |
| R-wrapped sites correctly left alone | 6 |
| Core / Avalonia / CLI / Tests(WinForms) build | **0 errors** |

```
$ git grep -cE 'Log\.(Error|Notify|Debug)\("[^"]*\{[0-9]\}' -- ...src...   # remaining bugs
0
$ dotnet build FEBuilderGBA.Core ... Avalonia ... CLI ... Tests(x86)       # all → 0 Error(s)
```

Negative-test proof that the guard actually catches violations (injected probe, then reverted):
```
Found 3 Log.* placeholder violation(s):
 __GuardProbe.cs:5  => plain Log.Error(...) has literal placeholder "{0}"; use Log.ErrorF(...)
 __GuardProbe.cs:7  => plain Log.Notify(...) ... (MULTI-LINE call caught)
 __GuardProbe.cs:12 => Log.ErrorF(...) references {1} but only 1 argument(s) supplied.
(commented-out `// Log.Error("nope {0}", a)` correctly NOT flagged)
```

## Copilot plan-review items — all addressed

1. **Statement-aware, multi-line, comment-stripping guard** — `LogFormatPlaceholderTests` strips line/block comments, walks balanced parens (catches multi-line `Log.Notify(\n "...{0}",\n y)`), and ignores commented examples. Verified above.
2. **CLI + WinForms build coverage** — built CLI explicitly and built the WinForms-compiling Tests project; the latter surfaced the shadowing WinForms `Log` class, now fixed.
3. **Fallback can't re-emit `{N}` + arg-count validation** — `FormatSafe` strips `{N}` on the fallback path; the guard additionally fails any `Log.*F` whose max placeholder index exceeds its supplied arg count.

## Test plan

- [x] `FEBuilderGBA.Core/Log.cs` + `FEBuilderGBA/Log.cs` build with 0 errors (Core, Avalonia, CLI, Tests/WinForms)
- [x] `FEBuilderGBA.Core.Tests/LogFormatOverloadTests` (4) — `*F` substitutes single/multiple placeholders; malformed-format and null-args fallback never leak `{N}` — **PASS**
- [x] `FEBuilderGBA.Tests/Unit/LogFormatPlaceholderTests` (2) — static guard passes on the clean tree; `*F` overloads exist — **PASS**
- [x] Guard negative test — injected plain / multi-line / bad-arg-count probe → guard FAILS with exactly those 3 violations; commented-out call NOT flagged — **PASS**
- [x] `git grep` confirms **0** remaining plain `Log.*("...{N}...", …)` bug sites across Core/Avalonia/CLI/WinForms

## Screenshots

Non-GUI change (logging Core seam + mechanical call-site rename + tests). Proof is the CLI/test output above. No GUI behaviour changed.

Original request: _"find all gaps to release a new version and track them in issues"_.

🤖 Generated with Claude Code (Opus 4.8, 1M context)
