### PR TITLE
test(avalonia): un-skip passing jump-parity tests (Closes #1643)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/AvaloniaJumpParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/AvaloniaJumpParityTests.cs
@@ -200,19 +200,40 @@ public class AvaloniaJumpParityTests
         }
     }
 
-    [Fact(Skip = "Tracked in #360 — id/address fields need jump/pick/preview.")]
+    [Fact]
     [Trait("KnownGap", "360")]
     public void Issue360_SupportTalk_UnitIdJumpsImplemented()
     {
-        // When fixed: SupportTalk's Partner1/Partner2 unit-id fields will
-        // each have a working Jump-to-Unit button.
+        // Fixed in #360 (PR #638): SupportTalk's Partner1/Partner2 unit-id
+        // fields each have a working Jump-to-Unit button (the Avalonia view
+        // wires SupportPartner1/2_Jump → UnitEditorView). This test asserts
+        // both invariants (mirroring the #359 case):
+        //   (1) no SupportTalk Partner row still carries IssueRef = "#360"
+        //   (2) both Partner commands exist and target UnitEditorView, so a
+        //       regression that drops the tag but removes/retargets the row
+        //       still fails.
         var manifests = JumpParityScanner.ScanAvManifests(typeof(INavigationTargetSource).Assembly);
-        var stillBroken = manifests.Where(m =>
-                m.SourceVm == "SupportTalkViewModel"
-                && (m.Command == "JumpToPartner1" || m.Command == "JumpToPartner2")
-                && m.IssueRef == "#360")
+        var partnerEntries = manifests
+            .Where(m => m.SourceVm == "SupportTalkViewModel"
+                && (m.Command == "JumpToPartner1" || m.Command == "JumpToPartner2"))
             .ToList();
+
+        // (1) No remaining IssueRef = "#360".
+        var stillBroken = partnerEntries.Where(e => e.IssueRef == "#360").ToList();
         Assert.Empty(stillBroken);
+
+        // (2) Both Partner jump commands exist and land in UnitEditorView.
+        var expected = new[]
+        {
+            ("JumpToPartner1", "UnitEditorView"),
+            ("JumpToPartner2", "UnitEditorView"),
+        };
+        foreach (var (command, expectedView) in expected)
+        {
+            var entry = partnerEntries.SingleOrDefault(e => e.Command == command);
+            Assert.True(entry != null, $"Manifest missing entry for command {command}");
+            Assert.Equal(expectedView, entry!.TargetView);
+        }
     }
 
     [Fact]
@@ -234,34 +255,66 @@ public class AvaloniaJumpParityTests
         Assert.Empty(stillBroken);
     }
 
-    [Fact(Skip = "Tracked in #363 — Item Effectiveness jump uses wrong address + preview icons.")]
+    [Fact]
     [Trait("KnownGap", "363")]
     public void Issue363_ItemEditor_EffectivenessAddressAndIcons()
     {
-        // When fixed: the vanilla Item Effectiveness jump will compute the
-        // correct address and the class preview icons will render correctly.
+        // Fixed in #363 (PR #461/#466): the vanilla Item Effectiveness jump
+        // computes the correct address (the receiver enumerates items by their
+        // P16 pointer) and the class preview icons render correctly. This test
+        // asserts both invariants (mirroring the #359 case):
+        //   (1) the vanilla Effectiveness row no longer carries IssueRef = "#363"
+        //   (2) the JumpToEffectivenessVanilla command exists and targets
+        //       ItemEffectivenessViewerView.
         var manifests = JumpParityScanner.ScanAvManifests(typeof(INavigationTargetSource).Assembly);
-        var stillBroken = manifests.Where(m =>
-                m.SourceVm == "ItemEditorViewModel"
-                && m.Command == "JumpToEffectivenessVanilla"
-                && m.IssueRef == "#363")
+        var vanillaEntries = manifests
+            .Where(m => m.SourceVm == "ItemEditorViewModel"
+                && m.Command == "JumpToEffectivenessVanilla")
             .ToList();
+
+        // (1) No remaining IssueRef = "#363".
+        var stillBroken = vanillaEntries.Where(e => e.IssueRef == "#363").ToList();
         Assert.Empty(stillBroken);
+
+        // (2) The vanilla Effectiveness jump exists and lands in the viewer.
+        var entry = vanillaEntries.SingleOrDefault();
+        Assert.True(entry != null, "Manifest missing entry for command JumpToEffectivenessVanilla");
+        Assert.Equal("ItemEffectivenessViewerView", entry!.TargetView);
     }
 
-    [Fact(Skip = "Tracked in #365 — CC Branch Editor shows wrong Upstream Chain.")]
+    [Fact]
     [Trait("KnownGap", "365")]
     public void Issue365_CCBranchEditor_UpstreamChainCorrect()
     {
-        // When fixed: the Upstream Chain panel will compute the correct
-        // before-promotion list AND the Promotion Class fields will gain
-        // jump buttons.
+        // Fixed in #365 (PR #460): the Upstream Chain panel computes the
+        // correct before-promotion list AND the Promotion Class fields gained
+        // jump buttons (Promo1/2_Jump → ClassEditorView). This test asserts
+        // both invariants (mirroring the #359 case):
+        //   (1) no CCBranch row still carries IssueRef = "#365"
+        //   (2) both Promotion-class commands exist and target ClassEditorView,
+        //       so a regression that drops the tag but removes/retargets the
+        //       row still fails.
         var manifests = JumpParityScanner.ScanAvManifests(typeof(INavigationTargetSource).Assembly);
-        var stillBroken = manifests.Where(m =>
-                m.SourceVm == "CCBranchEditorViewModel"
-                && m.IssueRef == "#365")
+        var ccBranchEntries = manifests
+            .Where(m => m.SourceVm == "CCBranchEditorViewModel")
             .ToList();
+
+        // (1) No remaining IssueRef = "#365".
+        var stillBroken = ccBranchEntries.Where(e => e.IssueRef == "#365").ToList();
         Assert.Empty(stillBroken);
+
+        // (2) Both Promotion-class jump commands exist and land in ClassEditorView.
+        var expected = new[]
+        {
+            ("JumpToPromotionClass1", "ClassEditorView"),
+            ("JumpToPromotionClass2", "ClassEditorView"),
+        };
+        foreach (var (command, expectedView) in expected)
+        {
+            var entry = ccBranchEntries.SingleOrDefault(e => e.Command == command);
+            Assert.True(entry != null, $"Manifest missing entry for command {command}");
+            Assert.Equal(expectedView, entry!.TargetView);
+        }
     }
 
     static string? FindRepoRoot()

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/JumpParityScannerTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/JumpParityScannerTests.cs
@@ -452,9 +452,10 @@ class ItemForm {
         // The repo has hundreds of InputFormRef.JumpForm callsites; expect
         // a non-trivial row count.
         Assert.NotEmpty(rows);
-        // We seeded 7 VMs with INavigationTargetSource; at LEAST one
-        // KnownGap entry should be present (the #359/#360/#362/#363/#365
-        // backlog).
+        // We seeded several VMs with INavigationTargetSource; at LEAST one
+        // KnownGap entry should be present. The #359/#360/#362/#363/#365
+        // gaps are now closed (their IssueRef tags dropped); the remaining
+        // open IssueRef-backed gaps are #374/#385/#500.
         Assert.Contains(rows, r => r.Status == JumpRowStatus.KnownGap);
     }
 

--- a/FEBuilderGBA.Avalonia/ViewModels/CCBranchEditorViewModel.NavigationTargets.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/CCBranchEditorViewModel.NavigationTargets.cs
@@ -15,29 +15,27 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         // INavigationTargetSource — Phase 4 (#374). The CC Branch editor's
         // Promotion Class fields are class-id references whose natural jump
         // target is the Class editor (the WinForms CCBranchForm wires both
-        // to ClassForm via InputFormRef). Issue #365 reports a related bug:
-        // the Upstream Chain panel computation is wrong. Although #365 is
-        // a DATA-DISPLAY bug (not a navigation bug), it's still surfaced as
-        // a known-gap here so the meta tracking can route through Phase 4's
-        // skipped tests.
+        // to ClassForm via InputFormRef). Issue #365 reported a related bug:
+        // the Upstream Chain panel computation was wrong AND the promotion
+        // fields lacked jump buttons. Both are now fixed (Fixed in #365 /
+        // PR #460): Promo1/2_Jump → ClassEditorView and BuildUpstreamChain
+        // computes the before-promotion list, so the IssueRef tags are dropped.
         // ----------------------------------------------------------------
         public IReadOnlyList<NavigationTarget> GetNavigationTargets()
         {
             return new[]
             {
-                // Known-broken (#365): Upstream chain display is wrong;
-                // navigation to source class is also missing. Target view
+                // Fixed in #365 (PR #460): Upstream chain display now correct
+                // and navigation to the promotion class is wired. Target view
                 // is ClassEditorView (FE8 — CCBranch is FE8-only).
                 new NavigationTarget(
                     CommandName: "JumpToPromotionClass1",
                     TargetViewType: typeof(ClassEditorView),
-                    TargetAddress: null,
-                    IssueRef: "#365"),
+                    TargetAddress: null),
                 new NavigationTarget(
                     CommandName: "JumpToPromotionClass2",
                     TargetViewType: typeof(ClassEditorView),
-                    TargetAddress: null,
-                    IssueRef: "#365"),
+                    TargetAddress: null),
             };
         }
     }

--- a/FEBuilderGBA.Avalonia/ViewModels/SupportTalkViewModel.NavigationTargets.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SupportTalkViewModel.NavigationTargets.cs
@@ -13,8 +13,9 @@ namespace FEBuilderGBA.Avalonia.ViewModels
     {
         // ----------------------------------------------------------------
         // INavigationTargetSource — Phase 4 (#374). Mirror navigation callsites
-        // in SupportTalkView.axaml.cs and flag the missing unit-id jumps from
-        // issue #360 ("Add jump, pick, and preview for all id/address fields").
+        // in SupportTalkView.axaml.cs. The unit-id jumps from issue #360
+        // ("Add jump, pick, and preview for all id/address fields") are now
+        // wired (Fixed in #360 / PR #638), so the IssueRef tags are dropped.
         // ----------------------------------------------------------------
         public IReadOnlyList<NavigationTarget> GetNavigationTargets()
         {
@@ -34,19 +35,18 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                     TargetViewType: typeof(TextViewerView),
                     TargetAddress: null),
 
-                // Known-broken (#360): Support Partner 1 / Partner 2 unit-id
-                // fields have no jump-to-unit button (the WinForms
-                // SupportTalkForm wires both to UnitForm via InputFormRef).
+                // Fixed in #360 (PR #638): Support Partner 1 / Partner 2 unit-id
+                // fields now have a jump-to-unit button (the WinForms
+                // SupportTalkForm wires both to UnitForm via InputFormRef;
+                // the Avalonia view wires SupportPartner1/2_Jump → UnitEditorView).
                 new NavigationTarget(
                     CommandName: "JumpToPartner1",
                     TargetViewType: typeof(UnitEditorView),
-                    TargetAddress: null,
-                    IssueRef: "#360"),
+                    TargetAddress: null),
                 new NavigationTarget(
                     CommandName: "JumpToPartner2",
                     TargetViewType: typeof(UnitEditorView),
-                    TargetAddress: null,
-                    IssueRef: "#360"),
+                    TargetAddress: null),
             };
         }
     }


### PR DESCRIPTION
## Summary
Three jump-parity regression tests in `AvaloniaJumpParityTests.cs` were `[Fact(Skip=...)]` against issues #360/#363/#365 — all **CLOSED as COMPLETED** (PRs #638, #461/#466, #460) with the jump features shipped on master, leaving those fixes unguarded. This PR un-skips them, strengthens each to a real regression assertion, and reconciles the stale `IssueRef` manifest tags so no jump-parity test is skipped against a closed issue.

Closes #1643. Part of #1628 (release-readiness umbrella).

## Changes (declarative manifest metadata + tests only — no VM behavior change)
- **Un-skipped 3 tests** (`[Fact(Skip)]` → `[Fact]`): `Issue360_SupportTalk_UnitIdJumpsImplemented`, `Issue363_ItemEditor_EffectivenessAddressAndIcons`, `Issue365_CCBranchEditor_UpstreamChainCorrect`.
- **Strengthened each body to the #359 two-invariant pattern** (per Copilot plan review): assert (1) no stale `IssueRef` AND (2) the expected source-VM/command rows exist and target the expected view (`SupportTalk` Partner1/2 → `UnitEditorView`; `ItemEditor` JumpToEffectivenessVanilla → `ItemEffectivenessViewerView`; `CCBranch` PromotionClass1/2 → `ClassEditorView`) — so deleting/retargeting a manifest row fails the test (no tautology).
- **Dropped stale tags**: `IssueRef:"#360"` ×2 in `SupportTalkViewModel.NavigationTargets.cs`, `IssueRef:"#365"` ×2 in `CCBranchEditorViewModel.NavigationTargets.cs` (#363's tag was already removed in PR #461); refreshed "Known-broken (#N)" comments to "Fixed in #N (PR #M)".
- **Minor cleanup** (Copilot review): retargeted the stale KnownGap-backlog comment in `JumpParityScannerTests.cs` from closed `#359/#360/#362/#363/#365` to the remaining open IssueRef-backed gaps `#374/#385/#500`.

## Counts
- **Un-skipped: 3** (all now passing). **Still-skipped jump-parity tests: 0.**
- No jump-parity test in `AvaloniaJumpParityTests.cs` remains skipped against a closed issue.

## Test plan
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests --filter "FullyQualifiedName~AvaloniaJumpParityTests"` → **150 passed, 0 skipped** (the 3 ex-skipped tests now run + pass).
- [x] Expanded targeted run (`AvaloniaJumpParityTests` + `ItemEditorParityTests` + `CCBranchEditorUpstreamChainTests` + `JumpParityScannerTests`) → **210 passed, 0 failed, 0 skipped** — proves behavior via the existing targeted #363/#365 suites, not just metadata cleanup.
- [x] Verified `git grep 'Fact(Skip'` shows no remaining skip attribute (only doc-comment references) and no `IssueRef:"#360"`/`"#365"` tags remain in source.

## Test evidence
```
Passed!  - Failed:  0, Passed: 150, Skipped: 0, Total: 150  (AvaloniaJumpParityTests)
Passed!  - Failed:  0, Passed: 210, Skipped: 0, Total: 210  (expanded targeted suite)
```

Non-GUI change (test project + declarative VM manifest metadata only); CLI/test output is the proof per workflow.

---
🤖 Generated with Claude Code (Opus 4.8, 1M context). Original request: _"find all gaps to release a new version and track them in issues"_.
