### PR TITLE
ci: conditional codesign/notarize Win+macOS artifacts (Closes #1634)

### DIFF
--- a/.github/workflows/crossplatform.yml
+++ b/.github/workflows/crossplatform.yml
@@ -204,7 +204,19 @@ jobs:
         KEYCHAIN="$RUNNER_TEMP/codesign.keychain-db"
         KEYCHAIN_PASS="$(openssl rand -base64 24)"
         CERT_P12="$RUNNER_TEMP/codesign.p12"
-        printf '%s' "$APPLE_CERT_BASE64" | base64 --decode > "$CERT_P12"
+
+        # Delete the throwaway keychain (with the imported private key) on ANY
+        # exit — `set -e` would otherwise skip a trailing cleanup line on the
+        # first codesign/notarize failure and leave the key on the runner.
+        cleanup() {
+          security delete-keychain "$KEYCHAIN" 2>/dev/null || true
+          rm -f "$CERT_P12"
+        }
+        trap cleanup EXIT
+
+        # macOS /usr/bin/base64 does NOT accept GNU's `--decode`; use `-D`
+        # (the BSD/macOS decode flag). This step only ever runs on macos-latest.
+        printf '%s' "$APPLE_CERT_BASE64" | base64 -D > "$CERT_P12"
 
         security create-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN"
         security set-keychain-settings -lut 21600 "$KEYCHAIN"
@@ -228,14 +240,22 @@ jobs:
         fi
         echo "Using signing identity: $IDENTITY"
 
+        codesign_one() {
+          codesign --force --options runtime --timestamp \
+            --keychain "$KEYCHAIN" --sign "$IDENTITY" "$1"
+        }
+
         sign_dir() {
           local dir="$1"
-          # Recursively sign every Mach-O file, libraries/dylibs FIRST and the
-          # main executable LAST (nested code must be signed before its parent).
-          # Detect Mach-O via `file`, not just by extension, to catch the
-          # extension-less apphost executable and bundled native libs.
+          # Recursively sign every loose Mach-O file, libraries/dylibs FIRST and
+          # the main executable LAST (nested code must be signed before its
+          # parent). Detect Mach-O via `file`, not just by extension, to catch the
+          # extension-less apphost executable and bundled native libs. Skip files
+          # INSIDE a .app bundle here — the bundle is signed as a unit afterwards
+          # (codesign signs its nested payloads when sealing the bundle).
           local machos=()
           while IFS= read -r f; do
+            case "$f" in *.app/*) continue ;; esac
             if file "$f" | grep -q 'Mach-O'; then machos+=("$f"); fi
           done < <(find "$dir" -type f)
 
@@ -248,9 +268,15 @@ jobs:
             esac
           done
           for f in "${libs[@]}" "${exes[@]}"; do
-            codesign --force --options runtime --timestamp \
-              --keychain "$KEYCHAIN" --sign "$IDENTITY" "$f"
+            codesign_one "$f"
           done
+
+          # Sign each .app bundle DIRECTORY as a unit, last — this seals the
+          # bundle (and its nested payloads) so it is staple-able and assessable.
+          while IFS= read -r app; do
+            [ -n "$app" ] || continue
+            codesign_one "$app"
+          done < <(find "$dir" -maxdepth 2 -name '*.app' -type d)
         }
 
         notarize_dir() {
@@ -261,7 +287,8 @@ jobs:
             --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_PASSWORD" \
             --wait
           # Staple ONLY a real .app bundle (a raw dir / CLI binary cannot be
-          # stapled; it relies on Apple's online ticket instead).
+          # stapled; it relies on Apple's online ticket instead). The .app was
+          # codesigned as a unit in sign_dir above, so it is staple-able here.
           local app
           app="$(find "$dir" -maxdepth 2 -name '*.app' -type d | head -n 1 || true)"
           if [ -n "$app" ]; then
@@ -276,8 +303,7 @@ jobs:
           notarize_dir "publish/${target}-${{ matrix.rid }}" "${target}-${{ matrix.rid }}"
         done
 
-        # Remove the throwaway keychain.
-        security delete-keychain "$KEYCHAIN" || true
+        # The throwaway keychain is removed by the EXIT trap above.
         echo "macOS bundles codesigned + notarized."
 
     # ------------------------------------------------------------------------

--- a/.github/workflows/crossplatform.yml
+++ b/.github/workflows/crossplatform.yml
@@ -125,6 +125,232 @@ jobs:
           cp THIRD-PARTY-NOTICES.md "publish/${target}-${{ matrix.rid }}/THIRD-PARTY-NOTICES.md"
         done
 
+    # ------------------------------------------------------------------------
+    # Conditional macOS codesign + notarization (#1634).
+    #
+    # Mirrors the conditional-signing pattern from #1654: signing activates ONLY
+    # when the maintainer adds Apple Developer credentials to GitHub Actions
+    # secrets. With the secrets ABSENT — the fork's current CI — the unsigned
+    # bundles are uploaded exactly as before, so no existing CI breaks.
+    # Documented (with the `xattr -dr com.apple.quarantine` Gatekeeper workaround)
+    # in docs/RELEASE.md.
+    #
+    # `secrets.*` cannot be referenced in a step-level `if:`, so presence is
+    # classified once into a step output (macsign.outputs.present). All five Apple
+    # secrets must be set together: all empty => unsigned fallback; all set =>
+    # codesign + notarize; a PARTIAL set fails fast.
+    #
+    # ARTIFACT SHAPE NOTE: this job uploads raw `dotnet publish` directories (not
+    # `.app`/`.pkg`/`.dmg`), so `stapler staple` of a bare directory is not valid.
+    # We codesign every Mach-O payload (libraries first, the main executable
+    # last), then submit a `ditto` zip to notarytool. Apple serves the
+    # notarization ticket online, so the extracted directory passes Gatekeeper via
+    # online validation; if a `.app` bundle is present we additionally staple it.
+    # This is the honest behaviour for a directory artifact (see #1634 plan).
+    - name: Detect macOS signing secrets
+      id: macsign
+      if: matrix.rid == 'osx-arm64'
+      env:
+        APPLE_CERT_BASE64: ${{ secrets.APPLE_CERT_BASE64 }}
+        APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+        APPLE_ID: ${{ secrets.APPLE_ID }}
+        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+      shell: bash
+      run: |
+        set_count=0
+        missing=""
+        for name in APPLE_CERT_BASE64 APPLE_CERT_PASSWORD APPLE_ID APPLE_TEAM_ID APPLE_APP_PASSWORD; do
+          # Safe bash indirect expansion (NOT eval) so secret metacharacters
+          # cannot be executed.
+          val="${!name}"
+          if [ -n "$val" ]; then
+            set_count=$((set_count + 1))
+          else
+            missing="$missing $name"
+          fi
+        done
+        if [ "$set_count" -eq 5 ]; then
+          echo "present=true" >> "$GITHUB_OUTPUT"
+          echo "All Apple signing secrets detected — codesigning + notarizing the macOS bundles."
+        elif [ "$set_count" -eq 0 ]; then
+          echo "present=false" >> "$GITHUB_OUTPUT"
+          echo "No Apple signing secrets — uploading the unsigned macOS bundles (unchanged)."
+        else
+          echo "::error::Partial Apple signing secrets configured. Set ALL of APPLE_CERT_BASE64, APPLE_CERT_PASSWORD, APPLE_ID, APPLE_TEAM_ID, APPLE_APP_PASSWORD (or none). Missing:$missing"
+          exit 1
+        fi
+
+    - name: Codesign + notarize macOS bundles
+      # Runs ONLY on osx-arm64 with all Apple secrets present. Imports the .p12
+      # into a throwaway keychain, recursively codesigns every Mach-O (libs
+      # first, executable last) with the hardened runtime, then notarizes a
+      # `ditto` zip of each bundle (--wait). Credentials are passed via env: only.
+      if: matrix.rid == 'osx-arm64' && steps.macsign.outputs.present == 'true'
+      env:
+        APPLE_CERT_BASE64: ${{ secrets.APPLE_CERT_BASE64 }}
+        APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+        APPLE_ID: ${{ secrets.APPLE_ID }}
+        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+        # Optional explicit signing identity; otherwise the first codesigning
+        # identity imported into the keychain is auto-detected.
+        APPLE_SIGN_IDENTITY: ${{ secrets.APPLE_SIGN_IDENTITY }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        # --- Throwaway keychain + cert import -------------------------------
+        KEYCHAIN="$RUNNER_TEMP/codesign.keychain-db"
+        KEYCHAIN_PASS="$(openssl rand -base64 24)"
+        CERT_P12="$RUNNER_TEMP/codesign.p12"
+        printf '%s' "$APPLE_CERT_BASE64" | base64 --decode > "$CERT_P12"
+
+        security create-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN"
+        security set-keychain-settings -lut 21600 "$KEYCHAIN"
+        security unlock-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN"
+        security import "$CERT_P12" -k "$KEYCHAIN" -P "$APPLE_CERT_PASSWORD" \
+          -T /usr/bin/codesign -T /usr/bin/security
+        security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASS" "$KEYCHAIN" >/dev/null
+        # Prepend to the search list so codesign finds the identity.
+        security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | sed s/\"//g)
+        rm -f "$CERT_P12"
+
+        # Resolve the signing identity (explicit override or first available).
+        if [ -n "${APPLE_SIGN_IDENTITY:-}" ]; then
+          IDENTITY="$APPLE_SIGN_IDENTITY"
+        else
+          IDENTITY="$(security find-identity -v -p codesigning "$KEYCHAIN" | awk -F'"' 'NR==1{print $2}')"
+        fi
+        if [ -z "$IDENTITY" ]; then
+          echo "::error::No codesigning identity found in the imported keychain."
+          exit 1
+        fi
+        echo "Using signing identity: $IDENTITY"
+
+        sign_dir() {
+          local dir="$1"
+          # Recursively sign every Mach-O file, libraries/dylibs FIRST and the
+          # main executable LAST (nested code must be signed before its parent).
+          # Detect Mach-O via `file`, not just by extension, to catch the
+          # extension-less apphost executable and bundled native libs.
+          local machos=()
+          while IFS= read -r f; do
+            if file "$f" | grep -q 'Mach-O'; then machos+=("$f"); fi
+          done < <(find "$dir" -type f)
+
+          # Sort so .dylib/.so come before extension-less executables; sign each.
+          local libs=() exes=()
+          for f in "${machos[@]}"; do
+            case "$f" in
+              *.dylib|*.so) libs+=("$f") ;;
+              *) exes+=("$f") ;;
+            esac
+          done
+          for f in "${libs[@]}" "${exes[@]}"; do
+            codesign --force --options runtime --timestamp \
+              --keychain "$KEYCHAIN" --sign "$IDENTITY" "$f"
+          done
+        }
+
+        notarize_dir() {
+          local dir="$1" name="$2"
+          local zip="$RUNNER_TEMP/${name}.zip"
+          /usr/bin/ditto -c -k --keepParent "$dir" "$zip"
+          xcrun notarytool submit "$zip" \
+            --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_PASSWORD" \
+            --wait
+          # Staple ONLY a real .app bundle (a raw dir / CLI binary cannot be
+          # stapled; it relies on Apple's online ticket instead).
+          local app
+          app="$(find "$dir" -maxdepth 2 -name '*.app' -type d | head -n 1 || true)"
+          if [ -n "$app" ]; then
+            xcrun stapler staple "$app" || echo "stapler: nothing to staple in $app (continuing)"
+          else
+            echo "No .app bundle in $dir — notarized via online ticket (no local staple)."
+          fi
+        }
+
+        for target in cli avalonia; do
+          sign_dir "publish/${target}-${{ matrix.rid }}"
+          notarize_dir "publish/${target}-${{ matrix.rid }}" "${target}-${{ matrix.rid }}"
+        done
+
+        # Remove the throwaway keychain.
+        security delete-keychain "$KEYCHAIN" || true
+        echo "macOS bundles codesigned + notarized."
+
+    # ------------------------------------------------------------------------
+    # Conditional Authenticode signing of the published Windows CLI/Avalonia
+    # exes (#1634). Same WINDOWS_CERT_* secret set as msbuild.yml; runs only on
+    # win-x64 when both secrets are present. No-secret path uploads unchanged.
+    - name: Detect Windows signing secret
+      id: winsign
+      if: matrix.rid == 'win-x64'
+      shell: pwsh
+      env:
+        WINDOWS_CERT_BASE64: ${{ secrets.WINDOWS_CERT_BASE64 }}
+        WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+      run: |
+        $set = 0
+        $missing = @()
+        foreach ($name in 'WINDOWS_CERT_BASE64','WINDOWS_CERT_PASSWORD') {
+          $val = [Environment]::GetEnvironmentVariable($name)
+          if (-not [string]::IsNullOrEmpty($val)) { $set++ } else { $missing += $name }
+        }
+        if ($set -eq 2) {
+          "present=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          Write-Host "Windows signing secrets detected — Authenticode-signing the Windows bundles."
+        } elseif ($set -eq 0) {
+          "present=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          Write-Host "No Windows signing secrets — uploading the unsigned Windows bundles (unchanged)."
+        } else {
+          Write-Host "::error::Partial Windows signing secrets configured. Set BOTH WINDOWS_CERT_BASE64 and WINDOWS_CERT_PASSWORD (or neither). Missing: $($missing -join ', ')"
+          exit 1
+        }
+
+    - name: Sign Windows CLI/Avalonia exes (Authenticode)
+      # Imports the PFX into the CurrentUser store, signs the published *.exe by
+      # thumbprint with signtool (password never on a command line), removes the
+      # cert. Same deterministic approach as msbuild.yml.
+      if: matrix.rid == 'win-x64' && steps.winsign.outputs.present == 'true'
+      shell: pwsh
+      env:
+        WINDOWS_CERT_BASE64: ${{ secrets.WINDOWS_CERT_BASE64 }}
+        WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $signtool = Get-ChildItem -Path "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Recurse -Filter signtool.exe -ErrorAction SilentlyContinue |
+          Where-Object { $_.FullName -match '\\x64\\' } |
+          Sort-Object FullName -Descending | Select-Object -First 1
+        if (-not $signtool) {
+          Write-Host "::error::signtool.exe not found under the Windows SDK. Cannot Authenticode-sign."
+          exit 1
+        }
+        $pfx = Join-Path $env:RUNNER_TEMP "codesign.pfx"
+        [IO.File]::WriteAllBytes($pfx, [Convert]::FromBase64String($env:WINDOWS_CERT_BASE64))
+        $sec = ConvertTo-SecureString -String $env:WINDOWS_CERT_PASSWORD -AsPlainText -Force
+        $cert = Import-PfxCertificate -FilePath $pfx -CertStoreLocation Cert:\CurrentUser\My -Password $sec
+        try {
+          # Sign the managed entry-point exes for both bundles (the self-contained
+          # apphost is the SmartScreen-relevant binary).
+          $exes = @(
+            "publish/cli-${{ matrix.rid }}/FEBuilderGBA.CLI.exe",
+            "publish/avalonia-${{ matrix.rid }}/FEBuilderGBA.Avalonia.exe"
+          ) | Where-Object { Test-Path $_ }
+          if ($exes.Count -eq 0) { Write-Host "::error::No Windows exes found to sign."; exit 1 }
+          foreach ($exe in $exes) {
+            & $signtool.FullName sign /sha1 $cert.Thumbprint /fd sha256 /tr http://timestamp.digicert.com /td sha256 $exe
+            if ($LASTEXITCODE -ne 0) { Write-Host "::error::signtool failed for $exe (exit $LASTEXITCODE)."; exit 1 }
+            & $signtool.FullName verify /pa $exe
+            if ($LASTEXITCODE -ne 0) { Write-Host "::error::verification failed for $exe."; exit 1 }
+          }
+        } finally {
+          Remove-Item -Path ("Cert:\CurrentUser\My\" + $cert.Thumbprint) -Force -ErrorAction SilentlyContinue
+          Remove-Item -Path $pfx -Force -ErrorAction SilentlyContinue
+        }
+        Write-Host "Windows bundles Authenticode-signed."
+
     - name: Upload CLI artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -60,6 +60,94 @@ jobs:
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
       run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} /t:build /restore ${{env.SOLUTION_FILE_PATH}}
 
+    # ------------------------------------------------------------------------
+    # Conditional Authenticode signing of the WinForms FEBuilderGBA.exe (#1634).
+    #
+    # Mirrors the conditional-signing pattern from #1654 (Android release
+    # signing): the signing step activates ONLY when the maintainer adds a
+    # code-signing certificate to GitHub Actions secrets. With the secrets ABSENT
+    # — the state of this fork's CI — the unsigned exe is packaged exactly as
+    # before, so no existing CI breaks. Documented in docs/RELEASE.md.
+    #
+    # `secrets.*` cannot be referenced in a step-level `if:` (GitHub Actions
+    # forbids it), so presence is classified once into a step output
+    # (winsign.outputs.present) and the signing step gates on that output. Both
+    # WINDOWS_CERT_BASE64 and WINDOWS_CERT_PASSWORD must be set together: both
+    # empty => unsigned fallback (the fork's current CI); both set => Authenticode
+    # signing; a PARTIAL set fails fast so a half-configured maintainer gets a
+    # clear error instead of a silent unsigned build.
+    - name: Detect Windows signing secret
+      id: winsign
+      shell: pwsh
+      env:
+        WINDOWS_CERT_BASE64: ${{ secrets.WINDOWS_CERT_BASE64 }}
+        WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+      run: |
+        # Read from env: (NOT inline ${{ secrets.* }}) to stay aligned with the
+        # GitHub limitation and avoid embedding secret values in the script body.
+        $set = 0
+        $missing = @()
+        foreach ($name in 'WINDOWS_CERT_BASE64','WINDOWS_CERT_PASSWORD') {
+          $val = [Environment]::GetEnvironmentVariable($name)
+          if (-not [string]::IsNullOrEmpty($val)) { $set++ } else { $missing += $name }
+        }
+        if ($set -eq 2) {
+          "present=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          Write-Host "Windows signing secrets detected — Authenticode-signing FEBuilderGBA.exe."
+        } elseif ($set -eq 0) {
+          "present=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          Write-Host "No Windows signing secrets — packaging the unsigned exe (unchanged)."
+        } else {
+          Write-Host "::error::Partial Windows signing secrets configured. Set BOTH WINDOWS_CERT_BASE64 and WINDOWS_CERT_PASSWORD (or neither). Missing: $($missing -join ', ')"
+          exit 1
+        }
+
+    - name: Sign Windows WinForms exe (Authenticode)
+      # Runs ONLY when both signing secrets are present. Imports the base64 PFX
+      # into the CurrentUser cert store (password as a SecureString from env: —
+      # never on a command line), signs FEBuilderGBA.exe by SHA-1 thumbprint with
+      # signtool (located from the Windows SDK; hard error if not found), then
+      # removes the cert from the store. SHA-256 file digest + RFC-3161 timestamp
+      # so the signature stays valid after the cert expires.
+      if: steps.winsign.outputs.present == 'true'
+      shell: pwsh
+      env:
+        WINDOWS_CERT_BASE64: ${{ secrets.WINDOWS_CERT_BASE64 }}
+        WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $exe = "FEBuilderGBA/bin/Release/FEBuilderGBA.exe"
+        if (-not (Test-Path $exe)) { Write-Host "::error::$exe not found — cannot sign."; exit 1 }
+
+        # Locate signtool.exe from the installed Windows SDK(s). windows-latest
+        # ships the SDK; pick the newest x64 signtool. Fail clearly if absent.
+        $signtool = Get-ChildItem -Path "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Recurse -Filter signtool.exe -ErrorAction SilentlyContinue |
+          Where-Object { $_.FullName -match '\\x64\\' } |
+          Sort-Object FullName -Descending | Select-Object -First 1
+        if (-not $signtool) {
+          Write-Host "::error::signtool.exe not found under the Windows SDK. Cannot Authenticode-sign."
+          exit 1
+        }
+
+        # Decode the PFX to a runner-temp file (auto-cleaned at job end).
+        $pfx = Join-Path $env:RUNNER_TEMP "codesign.pfx"
+        [IO.File]::WriteAllBytes($pfx, [Convert]::FromBase64String($env:WINDOWS_CERT_BASE64))
+
+        # Import into CurrentUser\My, sign by thumbprint, then remove the cert —
+        # so the PFX password is never passed to signtool as an argument.
+        $sec = ConvertTo-SecureString -String $env:WINDOWS_CERT_PASSWORD -AsPlainText -Force
+        $cert = Import-PfxCertificate -FilePath $pfx -CertStoreLocation Cert:\CurrentUser\My -Password $sec
+        try {
+          & $signtool.FullName sign /sha1 $cert.Thumbprint /fd sha256 /tr http://timestamp.digicert.com /td sha256 $exe
+          if ($LASTEXITCODE -ne 0) { Write-Host "::error::signtool failed (exit $LASTEXITCODE)."; exit 1 }
+          & $signtool.FullName verify /pa $exe
+          if ($LASTEXITCODE -ne 0) { Write-Host "::error::signature verification failed."; exit 1 }
+        } finally {
+          Remove-Item -Path ("Cert:\CurrentUser\My\" + $cert.Thumbprint) -Force -ErrorAction SilentlyContinue
+          Remove-Item -Path $pfx -Force -ErrorAction SilentlyContinue
+        }
+        Write-Host "FEBuilderGBA.exe Authenticode-signed."
+
     - name: Run Tests
       run: dotnet test --configuration ${{env.BUILD_CONFIGURATION}} --no-build --verbosity normal --logger "trx;LogFileName=test-results.trx" --collect:"XPlat Code Coverage" --settings coverlet.runsettings
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -2,6 +2,8 @@
 
 > **For the full-suite release flow** (WinForms + CLI + Avalonia + Android + Gitee sync), see **[RELEASE.md](RELEASE.md)** — that runbook is the entry point for cutting a release. This guide covers only the WinForms split-package (FULL/CORE/PATCH2) update system.
 >
+> **Code-signing / notarization** of the Windows exe and macOS bundles is conditional and secret-gated — see **[RELEASE.md → §7.1 Code-signing & notarization](RELEASE.md#71-code-signing--notarization-1634)** for the required GitHub Actions secrets and the unsigned-artifact SmartScreen/Gatekeeper workaround.
+>
 > **⚠️ Design / historical reference — not currently runnable as written.** The split-package `.7z` generator (`scripts/create-split-packages.ps1`) and the `split-packages_{buildTime}` CI artifact described throughout this page are **not present in the current tree**; `msbuild.yml` uploads only the single `FEBuilderGBA_{build_time}` artifact. Read the rest of this document as the design of the in-app split-package updater, **not** a sequence you can run today. For the **live** artifact set and the steps that actually work, follow [RELEASE.md → CI artifact inventory](RELEASE.md#2-ci-artifact-inventory-what-each-workflow-produces) and [RELEASE.md → Manual release](RELEASE.md#4-manual-release-the-live-path).
 
 This guide explains how to create GitHub releases with the split package update system.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -177,7 +177,77 @@ These do **not** block a manual WinForms release, but flag them in release notes
 | patch2 not bundled into CLI/Avalonia artifacts | [#1630](https://github.com/laqieer/FEBuilderGBA/issues/1630) |
 | Release-signed (non-debug) Android APK/AAB | [#1631](https://github.com/laqieer/FEBuilderGBA/issues/1631) |
 | Changelog / release-notes generation | [#1632](https://github.com/laqieer/FEBuilderGBA/issues/1632) |
-| Code-sign / notarize Windows + macOS artifacts | [#1634](https://github.com/laqieer/FEBuilderGBA/issues/1634) |
+| Code-sign / notarize Windows + macOS artifacts — **conditional, secret-gated** ([§7.1](#71-code-signing--notarization-1634)): the CI wiring is in place, but artifacts stay **unsigned until the maintainer adds the certificate secrets** | [#1634](https://github.com/laqieer/FEBuilderGBA/issues/1634) |
+
+---
+
+## 7.1. Code-signing & notarization (#1634)
+
+Code-signing (Windows Authenticode) and macOS codesign + notarization are wired
+into the build workflows but are **conditional**: they activate **only when the
+maintainer adds the relevant certificate secrets** to **Settings → Secrets and
+variables → Actions**. This mirrors the conditional Android release signing
+([#1654](https://github.com/laqieer/FEBuilderGBA/pull/1654)).
+
+> **Default (no-secret) behaviour — the fork's current state:** with the secrets
+> absent, **every signing step is skipped** and the workflows produce the same
+> **unsigned** artifacts as before, so CI stays green. Unsigned artifacts still
+> trigger **SmartScreen "unknown publisher"** (Windows) and **Gatekeeper
+> "unidentified developer"** (macOS) — see the workaround below. This row stays a
+> caveat in the gaps table until the secrets are configured and a download is
+> verified to open without a hard block.
+
+### Required secrets (set ALL of a platform's secrets, or NONE)
+
+A **partial** set **fails the workflow fast** (clear `::error::`), so a
+half-configured maintainer never gets a silent unsigned build or a confusing
+publish failure.
+
+**Windows — Authenticode** (signs `FEBuilderGBA.exe` in `msbuild.yml`, and the
+`win-x64` CLI/Avalonia `.exe` in `crossplatform.yml`):
+
+| Secret | Meaning / how to produce |
+| --- | --- |
+| `WINDOWS_CERT_BASE64` | base64 of the code-signing certificate `.pfx`/`.p12` — `base64 -w0 cert.pfx` (or `certutil -encode` on Windows, stripped of header/footer) |
+| `WINDOWS_CERT_PASSWORD` | the `.pfx` export password |
+
+The exe is signed with **SHA-256** + an **RFC-3161 timestamp**
+(`http://timestamp.digicert.com`) so the signature outlives the certificate. The
+PFX is imported into the runner's `CurrentUser\My` store and signed **by
+thumbprint** with `signtool` (located from the Windows SDK), so the password is
+never passed on a command line; the cert is removed afterwards.
+
+**macOS — Developer ID codesign + notarization** (signs the `osx-arm64`
+CLI/Avalonia bundles in `crossplatform.yml`):
+
+| Secret | Meaning / how to produce |
+| --- | --- |
+| `APPLE_CERT_BASE64` | base64 of the **Developer ID Application** certificate `.p12` — `base64 -i cert.p12 -o -` |
+| `APPLE_CERT_PASSWORD` | the `.p12` export password |
+| `APPLE_ID` | the Apple ID (email) used for notarization |
+| `APPLE_TEAM_ID` | the 10-character Apple Developer Team ID |
+| `APPLE_APP_PASSWORD` | an **app-specific password** for that Apple ID (appleid.apple.com → Sign-In and Security) |
+| `APPLE_SIGN_IDENTITY` *(optional)* | explicit signing-identity string; auto-detected from the imported cert when omitted |
+
+The `.p12` is imported into a throwaway keychain; **every Mach-O payload** is
+codesigned with the hardened runtime (**libraries first, the executable last**),
+then a `ditto` zip of each bundle is submitted to `notarytool submit --wait`.
+
+> **Stapling note (honest framing):** the artifacts are raw `dotnet publish`
+> **directories**, not `.app`/`.pkg`/`.dmg` bundles, so a directory/CLI binary
+> **cannot be stapled**. Notarization still attaches the ticket to Apple's online
+> service, so a notarized binary passes Gatekeeper via **online validation**. The
+> workflow staples only if a real `.app` bundle is present in the output.
+> Shipping a stapled `.dmg`/`.pkg` installer is a possible future enhancement.
+
+### Workaround for the unsigned (no-secret) artifacts
+
+- **Windows:** on the SmartScreen prompt choose **More info → Run anyway**.
+- **macOS:** clear the quarantine attribute after download —
+  ```bash
+  xattr -dr com.apple.quarantine /path/to/FEBuilderGBA-avalonia-osx-arm64
+  ```
+  (or right-click → Open once to add a Gatekeeper exception).
 
 ---
 


### PR DESCRIPTION
## Summary

`Closes #1634`. Part of the release-readiness umbrella #1628.

No release artifact was code-signed or notarized: the Windows `FEBuilderGBA.exe` triggers SmartScreen "unknown publisher", and the unsigned macOS `osx-arm64` Avalonia/CLI bundles are blocked by Gatekeeper. This PR adds **conditional code-signing/notarization** to the release-artifact workflows that activates **only when the maintainer adds the certificate secrets** to GitHub Actions — mirroring the conditional Android release signing from **#1654** (`if:` step guards, `secrets.*` classified once into a per-OS step output, all-or-none-per-platform with a partial fail-fast).

With the secrets **absent — the fork's current CI** — every signing step is skipped and the workflows produce the same **unsigned** artifacts as before, so **no existing CI breaks**.

**Scope:** workflows + docs only. Does **not** touch `FEBuilderGBA.CLI.csproj` / `FEBuilderGBA.Avalonia.csproj` (owned by a sibling PR). No build run (shared disk) — YAML validated with `python -c "import yaml;yaml.safe_load(...)"` and both detector scripts dry-run across empty/partial/full secret sets.

## What changed

- **`.github/workflows/msbuild.yml`** — detect `WINDOWS_CERT_BASE64`/`WINDOWS_CERT_PASSWORD`; Authenticode-sign `FEBuilderGBA.exe` by SHA-1 **thumbprint** with `signtool` (located from the Windows SDK), SHA-256 file digest + RFC-3161 timestamp. PFX imported into `CurrentUser\My` and removed after — the password is **never** passed on a command line.
- **`.github/workflows/crossplatform.yml`** —
  - **macOS (`osx-arm64`):** import the `.p12` into a throwaway keychain, **recursively codesign every Mach-O** (libraries first, executable last) with the hardened runtime, then notarize a `ditto` zip via `xcrun notarytool submit --wait`. Staples only a real `.app` if present (raw publish dirs/CLI binaries can't be stapled — they pass Gatekeeper via Apple's **online** ticket; documented honestly).
  - **Windows (`win-x64`):** sign the published CLI/Avalonia `.exe` the same deterministic way as `msbuild.yml`.
- **`docs/RELEASE.md` §7.1 + `docs/DEPLOYMENT.md`** — document every required secret, the no-secret SmartScreen/Gatekeeper warnings, and the `xattr -dr com.apple.quarantine` workaround. The #1634 gaps row stays a **caveat** ("conditional, secret-gated; unsigned until certs added").

## Required GitHub Actions secrets

Set **ALL** of a platform's secrets, or **NONE** (a partial set fails fast).

**Windows — Authenticode:**

| Secret | Meaning |
| --- | --- |
| `WINDOWS_CERT_BASE64` | base64 of the code-signing `.pfx`/`.p12` (`base64 -w0 cert.pfx`) |
| `WINDOWS_CERT_PASSWORD` | the `.pfx` export password |

**macOS — Developer ID codesign + notarization:**

| Secret | Meaning |
| --- | --- |
| `APPLE_CERT_BASE64` | base64 of the Developer ID Application `.p12` |
| `APPLE_CERT_PASSWORD` | the `.p12` export password |
| `APPLE_ID` | Apple ID (email) for notarization |
| `APPLE_TEAM_ID` | 10-char Apple Developer Team ID |
| `APPLE_APP_PASSWORD` | app-specific password for that Apple ID |
| `APPLE_SIGN_IDENTITY` *(optional)* | explicit signing identity; auto-detected when omitted |

Add at **Settings → Secrets and variables → Actions → New repository secret**.

## Behaviour by secret state

- **All set** → decode cert → sign (Win) / codesign + notarize (mac) → upload signed artifacts.
- **None set** (the fork's CI today) → all signing steps `if:`-skip → upload the current **unsigned** artifacts, unchanged.
- **Partial set** → detect step **fails fast** with `::error::Partial … signing secrets configured …`.

`secrets.*` cannot appear in a step-level `if:` (GitHub forbids it), so presence is classified once per OS into a step output (`winsign`/`macsign`.`outputs.present`) that the signing steps gate on — exactly the #1654 idiom.

## Plan & review

Plan posted on #1634 and reviewed by Copilot CLI (GPT-5.5). All five findings adopted:
1. ✅ macOS stapling honesty — codesign-all-Mach-O + notarize a `ditto` zip; staple only a real `.app`; document online-ticket validation + quarantine workaround for the dir artifact.
2. ✅ Sign **all** Mach-O payloads (libs first, exe last), not just the top-level exe.
3. ✅ Deterministic Windows tool — `signtool` from the SDK (clear error if absent), sign **by thumbprint** so the password is never a tool arg.
4. ✅ #1634 stays a caveat; docs state rationale + warnings + workaround.
5. ✅ Validation beyond YAML — detector dry-runs across empty/partial/full env sets + docs secret-coverage check.

## Test plan

- [x] `python -c "import yaml;yaml.safe_load(open('.github/workflows/msbuild.yml'))"` → parses OK.
- [x] `python -c "import yaml;yaml.safe_load(open('.github/workflows/crossplatform.yml'))"` → parses OK.
- [x] macOS detector (bash) dry-run: empty → `present=false` exit 0; full (5 vars) → `present=true` exit 0; partial (4 vars) → `::error::` exit 1.
- [x] Windows detector (pwsh) dry-run: empty → `present=false` exit 0; full → `present=true` exit 0; partial → `::error::` exit 1.
- [x] Docs cover **all 8** secret names + the `com.apple.quarantine` workaround (grep-verified).
- [x] No-secret path leaves artifacts byte-identical: every signing step gated on `…outputs.present == 'true'`; the fork has no secrets so live CI is unchanged (confirmed by reading the `if:` conditions).
- [x] Scope check — only `msbuild.yml`, `crossplatform.yml`, `docs/RELEASE.md`, `docs/DEPLOYMENT.md` changed (`git diff --stat`); no `.csproj` touched.
- [ ] `actionlint` — not installed in this environment; YAML validated via `yaml.safe_load` + manual review of `if:`/step-output expressions instead.

This is a CI/docs-only change (no GUI, no Core/CLI code), so the proof is the YAML parse + detector dry-run output above.

## Screenshots / proof

```
$ python -c "import yaml; yaml.safe_load(open('.github/workflows/msbuild.yml')); print('OK')"      # OK
$ python -c "import yaml; yaml.safe_load(open('.github/workflows/crossplatform.yml')); print('OK')" # OK
mac detector  empty→present=false(0)  full→present=true(0)  partial→::error::(1)
win detector  empty→present=false(0)  full→present=true(0)  partial→::error::(1)
docs: 8/8 secrets documented; com.apple.quarantine workaround present
```

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.8, 1M context)
