### PR TITLE
ci(release): zip CLI/Avalonia bundles without `zip` on windows-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,10 +190,23 @@ jobs:
           fi
 
       - name: Zip CLI + Avalonia bundles
+        # windows-latest has no `zip` on PATH (the previous bash `zip` here failed
+        # the win-x64 leg with "zip: command not found", exit 127). Prefer Info-ZIP
+        # `zip` where it exists (linux/macOS) because it preserves the executable
+        # bit on the self-contained app hosts; fall back to PowerShell
+        # Compress-Archive only where `zip` is unavailable (Windows, where unix
+        # file permissions are irrelevant to the .exe bundle).
         shell: bash
         run: |
-          ( cd publish/cli-${{ matrix.rid }}      && zip -r "$GITHUB_WORKSPACE/FEBuilderGBA-cli-${{ matrix.rid }}.zip" . )
-          ( cd publish/avalonia-${{ matrix.rid }} && zip -r "$GITHUB_WORKSPACE/FEBuilderGBA-avalonia-${{ matrix.rid }}.zip" . )
+          for target in cli avalonia; do
+            src="publish/${target}-${{ matrix.rid }}"
+            out="$GITHUB_WORKSPACE/FEBuilderGBA-${target}-${{ matrix.rid }}.zip"
+            if command -v zip >/dev/null 2>&1; then
+              ( cd "$src" && zip -r "$out" . )
+            else
+              pwsh -NoProfile -Command "Compress-Archive -Path '$src/*' -DestinationPath '$out' -Force"
+            fi
+          done
 
       - name: Upload CLI + Avalonia artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Problem
The first real run of `release.yml` (tag `ver_20260628.21`) **failed**: the **CLI + Avalonia (win-x64)** job died at the *Zip CLI + Avalonia bundles* step with `zip: command not found` (exit 127). `windows-latest` has no Info-ZIP `zip` on PATH, while the linux/macOS legs passed because `zip` exists there. Because that build job failed, the `Create GitHub Release` job was correctly **skipped** — no partial release was published.

This is a pre-existing latent bug in the crossplatform job (unrelated to the RELEASE_TOKEN gate change in #1672); it only surfaced now that the workflow ran end-to-end for the first time.

## Fix
Make the zip step portable. Prefer Info-ZIP `zip` where it exists (linux/macOS) — it **preserves the executable bit** on the self-contained app hosts — and fall back to PowerShell `Compress-Archive` **only** where `zip` is unavailable (Windows, where unix file permissions are irrelevant to the `.exe` bundle). Detection is via `command -v zip`, so the already-passing linux-x64 / osx-arm64 legs are byte-for-byte unchanged; only the win-x64 path changes.

## Testing
Workflow-YAML-only change (no C# logic): `yaml.safe_load` parses clean. The real proof is the re-run of `release.yml` after this merges, which I'll trigger by re-pushing the `ver_20260628.21` tag at the fixed commit. Screenshots N/A for a CI-config change.

Original request: /batch create new release
🤖 Generated with Claude Code (Opus 4.8, 1M context)
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>