### PR TITLE
ci(release): bound Gitee mirror curl calls with timeouts (fix upload hang)

### DIFF
--- a/.github/workflows/mirror-winforms-to-gitee.yml
+++ b/.github/workflows/mirror-winforms-to-gitee.yml
@@ -91,8 +91,8 @@ jobs:
             # --connect-timeout/--max-time bound each call so a stalled Gitee
             # connection (US runner -> Gitee) fails fast instead of hanging the
             # job (the upload once stalled ~22 min with no progress). Re-running
-            # is safe: this workflow is idempotent (the GET-then-create + asset
-            # presence check below prevent duplicates).
+            # is safe: this workflow is idempotent (its GET-then-create and
+            # asset-presence checks below prevent duplicates).
             http="$(curl -sS --connect-timeout 30 --max-time 900 -w '%{http_code}' -o "$out" -X "$method" "$@" "$url")" || {
               echo "::error::curl transport error calling ${method} ${safe_url}" >&2
               cat "$out" >&2 || true

--- a/.github/workflows/mirror-winforms-to-gitee.yml
+++ b/.github/workflows/mirror-winforms-to-gitee.yml
@@ -88,7 +88,12 @@ jobs:
             local out http
             out="$(mktemp)"
             local safe_url="${url%%\?*}"
-            http="$(curl -sS -w '%{http_code}' -o "$out" -X "$method" "$@" "$url")" || {
+            # --connect-timeout/--max-time bound each call so a stalled Gitee
+            # connection (US runner -> Gitee) fails fast instead of hanging the
+            # job (the upload once stalled ~22 min with no progress). Re-running
+            # is safe: this workflow is idempotent (the GET-then-create + asset
+            # presence check below prevent duplicates).
+            http="$(curl -sS --connect-timeout 30 --max-time 900 -w '%{http_code}' -o "$out" -X "$method" "$@" "$url")" || {
               echo "::error::curl transport error calling ${method} ${safe_url}" >&2
               cat "$out" >&2 || true
               rm -f "$out"
@@ -115,7 +120,7 @@ jobs:
             local out http safe_url
             out="$(mktemp)"
             safe_url="${url%%\?*}"
-            http="$(curl -sS -w '%{http_code}' -o "$out" -X GET "$url")" || {
+            http="$(curl -sS --connect-timeout 30 --max-time 900 -w '%{http_code}' -o "$out" -X GET "$url")" || {
               echo "::error::curl transport error calling GET ${safe_url}" >&2
               cat "$out" >&2 || true
               rm -f "$out"


### PR DESCRIPTION
## Problem
The first real run of `mirror-winforms-to-gitee.yml` (mirroring `ver_20260628.21`) **hung**: the `attach_files` upload step ran **~22 minutes with zero progress** and had to be cancelled. The `curl` calls in the two Gitee helpers had **no timeout**, so a stalled US-runner → Gitee connection waits indefinitely (up to the 6-hour job cap). The Gitee release got created (with the auto-generated source archives) but the 36 MB WinForms zip never attached.

## Fix
Add `--connect-timeout 30 --max-time 900` to both `curl` invocations (`gitee_call` and `gitee_get_release_or_empty`) so a stalled connection **fails fast and loudly** instead of hanging. No `--retry` — an interrupted `attach_files` POST could create a duplicate asset (Gitee doesn't de-dup by filename); the safe retry path is re-running the workflow, which is idempotent (GET-then-create + asset-presence check prevent duplicates).

## Testing
Workflow-YAML-only change: `yaml.safe_load` parses clean. The real proof is re-running the mirror after merge (`gh workflow run mirror-winforms-to-gitee.yml -f tag=ver_20260628.21`), which I'll do and verify via the Gitee API.

Original request: /batch create new release
🤖 Generated with Claude Code (Opus 4.8, 1M context)
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>