### PR TITLE
ci(release): re-pack WinForms package to .7z before Gitee upload (fix 36MB stall)

### DIFF
--- a/.github/workflows/mirror-winforms-to-gitee.yml
+++ b/.github/workflows/mirror-winforms-to-gitee.yml
@@ -56,6 +56,18 @@ jobs:
           fi
           echo "GITEE_TOKEN is present."
 
+      - name: Validate the tag input
+        # TAG comes from workflow_dispatch and is interpolated into filenames and
+        # `rm -rf` below, so restrict it to the strict ver_YYYYMMDD.NN release-tag
+        # shape — this rules out path separators and `..` (no path traversal).
+        run: |
+          set -euo pipefail
+          if ! printf '%s' "${TAG}" | grep -qE '^ver_[0-9]{8}\.[0-9]+$'; then
+            echo "::error::Tag '${TAG}' is not a valid ver_YYYYMMDD.NN release tag; refusing to proceed."
+            exit 1
+          fi
+          echo "Tag '${TAG}' is valid."
+
       - name: Download ONLY the WinForms zip from the GitHub release
         run: |
           set -euo pipefail
@@ -95,6 +107,13 @@ jobs:
           base="FEBuilderGBA_${TAG}"
           rm -rf _winforms_stage "${base}.7z"
           mkdir _winforms_stage
+          # Zip Slip guard: refuse any entry with an absolute path or a `..`
+          # segment so extraction cannot escape _winforms_stage (defence in depth;
+          # the asset is self-produced by release.yml).
+          if unzip -Z1 "${ASSET}" | grep -qE '(^/|(^|/)\.\.(/|$))'; then
+            echo "::error::Refusing to extract '${ASSET}': a zip entry has an absolute or parent-traversal path (Zip Slip)."
+            exit 1
+          fi
           unzip -q "${ASSET}" -d _winforms_stage
           ( cd _winforms_stage && "${SEVENZ}" a -t7z -mx=9 "${GITHUB_WORKSPACE}/${base}.7z" . >/dev/null )
           echo "Recompressed $(du -h "${ASSET}" | cut -f1) zip -> $(du -h "${base}.7z" | cut -f1) 7z"

--- a/.github/workflows/mirror-winforms-to-gitee.yml
+++ b/.github/workflows/mirror-winforms-to-gitee.yml
@@ -1,7 +1,8 @@
 name: Mirror WinForms package to Gitee
 
-# Mirrors ONLY the WinForms desktop zip (FEBuilderGBA_<tag>.zip, ~36 MB) of a
-# given GitHub release to the Gitee mirror, and FAILS LOUDLY on any Gitee API
+# Mirrors ONLY the WinForms desktop package of a given GitHub release to the
+# Gitee mirror, re-packed from the ~36 MB .zip to a ~6 MB .7z (Gitee's release
+# upload can't reliably take the 36 MB .zip), and FAILS LOUDLY on any Gitee API
 # error. Manual-only: GitHub releases here are created by the default
 # GITHUB_TOKEN, whose `release: published` events GitHub deliberately suppresses,
 # so an `on: release` trigger would never auto-fire (see release.yml).
@@ -76,7 +77,33 @@ jobs:
           echo "Selected WinForms asset:"
           ls -la "${zips[0]}"
 
-      - name: Find or create the Gitee release, then upload the WinForms zip (idempotent)
+      - name: Recompress the WinForms package to .7z (Gitee size-friendly)
+        # Gitee has only ever hosted ~6 MB WinForms assets, because the older
+        # releases shipped a LZMA `.7z`. release.yml ships a ~36 MB `.zip`, which
+        # is too big for Gitee's release-attachment upload on the US-runner ->
+        # Gitee path (it stalls/times out). Re-pack the SAME content as `.7z`
+        # (~6 MB) so the Gitee upload is small and reliable, matching the
+        # historical FEBuilderGBA_*.7z asset format. (The GitHub release keeps
+        # the .zip; only the Gitee mirror gets the .7z.)
+        run: |
+          set -euo pipefail
+          SEVENZ="$(command -v 7z || command -v 7za || true)"
+          if [ -z "${SEVENZ}" ]; then
+            echo "::error::Neither 7z nor 7za is available on the runner."
+            exit 1
+          fi
+          base="FEBuilderGBA_${TAG}"
+          rm -rf _winforms_stage "${base}.7z"
+          mkdir _winforms_stage
+          unzip -q "${ASSET}" -d _winforms_stage
+          ( cd _winforms_stage && "${SEVENZ}" a -t7z -mx=9 "${GITHUB_WORKSPACE}/${base}.7z" . >/dev/null )
+          echo "Recompressed $(du -h "${ASSET}" | cut -f1) zip -> $(du -h "${base}.7z" | cut -f1) 7z"
+          ls -la "${base}.7z"
+          # Override ASSET/ASSET_NAME so the upload step ships the .7z, not the zip.
+          echo "ASSET=${base}.7z" >> "$GITHUB_ENV"
+          echo "ASSET_NAME=${base}.7z" >> "$GITHUB_ENV"
+
+      - name: Find or create the Gitee release, then upload the WinForms package (idempotent)
         run: |
           set -euo pipefail
           api="https://gitee.com/api/v5/repos/${GITEE_OWNER}/${GITEE_REPO}"
@@ -153,7 +180,7 @@ jobs:
               --data-urlencode "access_token=${GITEE_TOKEN}" \
               --data-urlencode "tag_name=${TAG}" \
               --data-urlencode "name=${TAG}" \
-              --data-urlencode "body=WinForms desktop package (FEBuilderGBA_${TAG}.zip) mirrored from the GitHub release ${TAG}. The cross-platform CLI/Avalonia bundles exceed Gitee's per-asset size limit and remain GitHub-only." \
+              --data-urlencode "body=WinForms desktop package (FEBuilderGBA_${TAG}.7z) mirrored from the GitHub release ${TAG}. The cross-platform CLI/Avalonia bundles exceed Gitee's per-asset size limit and remain GitHub-only." \
               --data-urlencode "target_commitish=master" \
               --data-urlencode "prerelease=false")"
             rel_id="$(printf '%s' "$rel" | jq -r '.id // empty')"

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -185,17 +185,19 @@ If a sync fails (e.g. transient upload error), re-run it the same way (`workflow
 > **Oversized-asset caveat (full-suite releases).** A full-suite release also ships the
 > cross-platform CLI/Avalonia bundles, which are **96–114 MB each and exceed Gitee's per-asset
 > size limit**. `H-TWINKLE/sync-action` reports success but **silently skips** the oversized
-> release, so nothing lands on Gitee. To mirror the small (~36 MB) WinForms package for such a
-> release, run the dedicated [`mirror-winforms-to-gitee.yml`](../.github/workflows/mirror-winforms-to-gitee.yml)
+> release, so nothing lands on Gitee. To mirror the WinForms package for such a release, run the
+> dedicated [`mirror-winforms-to-gitee.yml`](../.github/workflows/mirror-winforms-to-gitee.yml)
 > workflow manually:
 >
 > ```bash
 > gh workflow run mirror-winforms-to-gitee.yml -R laqieer/FEBuilderGBA -f tag=<tag>
 > ```
 >
-> It uploads only `FEBuilderGBA_<tag>.zip` (the CLI/Avalonia bundles never touch the runner), is
-> idempotent (skips re-upload if the asset is already attached), and **fails loudly** on any Gitee
-> API error.
+> It downloads only the WinForms `FEBuilderGBA_<tag>.zip` and **re-packs it to a ~6 MB `.7z`**
+> before upload — the ~36 MB `.zip` is too big for Gitee's release-attachment upload (it stalls),
+> whereas the LZMA `.7z` matches the size Gitee has always hosted. The CLI/Avalonia bundles never
+> touch the runner. The workflow is idempotent (skips re-upload if the asset is already attached)
+> and **fails loudly** on any Gitee API error.
 
 ---
 


### PR DESCRIPTION
## Root cause (diagnosed)
The Gitee mirror upload of `ver_20260628.21` stalled/timed out **twice**. Comparing asset sizes was decisive:

| | Asset | Size |
|---|---|---|
| Historical Gitee releases | `FEBuilderGBA_*.7z` (LZMA) | **5.6–6.5 MB** |
| New pipeline (release.yml) | `FEBuilderGBA_<tag>.zip` | **34.8 MB** |

Gitee has only ever hosted ~6 MB WinForms assets. The new `.zip` is ~6× larger than anything Gitee has accepted, and Gitee's release-attachment upload can't take 36 MB over the GitHub-US-runner → Gitee path (it stalls; the previous `--max-time 900` fix correctly made it fail-fast instead of hang, but couldn't make 36 MB go through).

## Fix
Re-pack the **same** WinForms content from the ~36 MB `.zip` to a **~6 MB `.7z`** (7z LZMA `-mx=9`) before uploading, matching the historical `FEBuilderGBA_*.7z` format/size that uploads reliably. The GitHub release keeps its `.zip`; only the Gitee mirror gets the `.7z`. `ASSET`/`ASSET_NAME` are overridden so the upload + idempotency check use the `.7z`. Comments + `docs/RELEASE.md` §6 updated.

## Testing
`yaml.safe_load` parses clean. The real proof is re-running the mirror after merge (`gh workflow run mirror-winforms-to-gitee.yml -f tag=ver_20260628.21`) and confirming `FEBuilderGBA_ver_20260628.21.7z` attaches on Gitee via the API — which I'll do and report.

Original request: /batch create new release
🤖 Generated with Claude Code (Opus 4.8, 1M context)
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>