### PR TITLE
docs(cross-platform): document local test ROMs in roms/ (gitignored)

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -201,7 +201,8 @@ own legally-obtained ROMs in a **git-ignored `roms/`** folder at the repo root:
 `FE6.gba`, `FE7J.gba`, `FE7U.gba`, `FE8J.gba`, `FE8U.gba`.
 
 - They drive local GUI reproduction and the headless Avalonia screenshot recipe, e.g.
-  `FEBuilderGBA.Avalonia --rom roms/FE8U.gba --screenshot-all --screenshot-dir shots --screenshot-tab`.
+  `FEBuilderGBA.Avalonia --rom roms/FE8U.gba --screenshot-all --screenshot-dir shots`
+  (optionally add `--screenshot-tab=<AutomationId>` to activate a specific tab before capture).
 - `roms/` lives only in the **main working copy** — it is **not** copied into `git worktree`
   checkouts, so build/screenshot from the main repo (or pass an absolute ROM path) when
   reproducing GUI issues.

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -193,6 +193,21 @@ dotnet test FEBuilderGBA.Avalonia.Tests/FEBuilderGBA.Avalonia.Tests.csproj
 msbuild /m /p:Configuration=Release /p:Platform=x86 /t:build /restore FEBuilderGBA.sln
 ```
 
+## Local Test ROMs (GUI / E2E reproduction)
+
+Running the GUI/CLI against real game data needs Fire Emblem GBA ROMs, which are
+copyrighted and therefore **never committed or shipped**. For local testing, place your
+own legally-obtained ROMs in a **git-ignored `roms/`** folder at the repo root:
+`FE6.gba`, `FE7J.gba`, `FE7U.gba`, `FE8J.gba`, `FE8U.gba`.
+
+- They drive local GUI reproduction and the headless Avalonia screenshot recipe, e.g.
+  `FEBuilderGBA.Avalonia --rom roms/FE8U.gba --screenshot-all --screenshot-dir shots --screenshot-tab`.
+- `roms/` lives only in the **main working copy** — it is **not** copied into `git worktree`
+  checkouts, so build/screenshot from the main repo (or pass an absolute ROM path) when
+  reproducing GUI issues.
+- CI / E2E does **not** use these local files; it fetches ROMs from the `ROMS_URL` repository
+  secret instead.
+
 ## External Tools (Per-Platform)
 
 | Tool | Windows | Linux | macOS |


### PR DESCRIPTION
Records where local GBA test ROMs live for GUI / E2E reproduction — a **git-ignored `roms/`** folder at the repo root (`FE6/FE7J/FE7U/FE8J/FE8U.gba`), used by the headless Avalonia screenshot recipe.

Key gotcha documented: `roms/` exists only in the **main working copy** and is **not** copied into `git worktree` checkouts (so reproduce GUI issues from the main repo, or pass an absolute ROM path); CI/E2E fetches ROMs via the `ROMS_URL` secret instead. ROMs are copyrighted → never committed or shipped.

Docs-only. Added under `docs/CROSS_PLATFORM.md` → new "Local Test ROMs" section, after "Building Cross-Platform".

Original request: remember it in docs/ and memories
🤖 Generated with Claude Code (Opus 4.8, 1M context)
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>