### PR TITLE
fix(l10n): translate Map Setting / Summon Unit / Status Options strings shown in English mode

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/JapaneseExpandButtonL10nRegressionTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/JapaneseExpandButtonL10nRegressionTests.cs
@@ -1,0 +1,119 @@
+using System;
+using System.IO;
+using FEBuilderGBA.Avalonia.GapSweep;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    /// <summary>
+    /// Regression tests for issue #1691: six Avalonia views shipped the Expand List
+    /// button label as the raw Japanese literal <c>Content="リストの拡張"</c> rather
+    /// than the English source literal <c>Content="Data Expansion"</c>.  Because
+    /// <see cref="ViewTranslationHelper.IsTranslatable"/> only translates text that
+    /// contains at least one ASCII letter, the raw Japanese literal was skipped and
+    /// rendered unchanged in English mode.
+    ///
+    /// The fix changes the six attribute values to <c>"Data Expansion"</c>, which
+    /// already has ja/zh entries in config/translate/ (リストの拡張 / 扩展列表).
+    /// These tests pin that fix: if any of the six files regresses back to the raw
+    /// Japanese literal, or if the translation entries are removed, these tests fail.
+    /// </summary>
+    public class JapaneseExpandButtonL10nRegressionTests
+    {
+        /// <summary>
+        /// Relative paths (forward-slash) of the six views that were fixed.
+        /// Used by both tests in this class.
+        /// </summary>
+        static readonly string[] FixedViewRelPaths = new[]
+        {
+            "FEBuilderGBA.Avalonia/Views/MapSettingView.axaml",
+            "FEBuilderGBA.Avalonia/Views/MapSettingFE6View.axaml",
+            "FEBuilderGBA.Avalonia/Views/MapSettingFE7View.axaml",
+            "FEBuilderGBA.Avalonia/Views/MapSettingFE7UView.axaml",
+            "FEBuilderGBA.Avalonia/Views/SummonUnitViewerView.axaml",
+            "FEBuilderGBA.Avalonia/Views/StatusOptionView.axaml",
+        };
+
+        /// <summary>
+        /// Assert that none of the six fixed view files still contains the raw
+        /// Japanese literal as a Content attribute value.  The check is scoped to
+        /// <c>Content="リストの拡張"</c> so unrelated Japanese labels in (e.g.)
+        /// MapSettingFE6View that are out of scope for this fix do NOT trip it.
+        /// </summary>
+        [Fact]
+        public void ExpandListButton_NoRawJapaneseLiteral()
+        {
+            string repoRoot = FindRepoRoot();
+            foreach (string relPath in FixedViewRelPaths)
+            {
+                string fullPath = Path.Combine(repoRoot, relPath.Replace('/', Path.DirectorySeparatorChar));
+                string text = File.ReadAllText(fullPath);
+                Assert.False(
+                    text.Contains("Content=\"リストの拡張\"", StringComparison.Ordinal),
+                    $"File '{relPath}' still contains raw Japanese Content attribute " +
+                    $"'Content=\"リストの拡張\"'. Change it to Content=\"Data Expansion\" " +
+                    $"so the Avalonia localizer can translate it via the existing " +
+                    $"config/translate/ entries (fix for issue #1691).");
+            }
+        }
+
+        /// <summary>
+        /// Assert that the English literal "Data Expansion" resolves to non-empty
+        /// translations in both Japanese and Chinese via the translate-file pipeline:
+        ///   en.txt reverse map: "Data Expansion" → "リストの拡張"
+        ///   ja.txt forward map: "リストの拡張" → non-empty
+        ///   zh.txt forward map: "リストの拡張" → "扩展列表" (non-empty)
+        /// This guards against accidental removal of the entries from the translate
+        /// files, which would silently break the runtime translation even after the
+        /// AXAML fix.
+        /// </summary>
+        [Fact]
+        public void DataExpansionLiteral_HasJaAndZhTranslation()
+        {
+            string repoRoot = FindRepoRoot();
+            string translateDir = Path.Combine(repoRoot, "config", "translate");
+
+            var reverseEnMap = L10nScanner.LoadReverseEnglishMap(Path.Combine(translateDir, "en.txt"));
+            var jaMap = L10nScanner.LoadForwardMap(Path.Combine(translateDir, "ja.txt"));
+            var zhMap = L10nScanner.LoadForwardMap(Path.Combine(translateDir, "zh.txt"));
+
+            const string literal = "Data Expansion";
+
+            // Step 1: reverse-map English literal → Japanese key.
+            Assert.True(
+                reverseEnMap.TryGetValue(literal, out string? jaKey) && !string.IsNullOrEmpty(jaKey),
+                $"config/translate/en.txt does not map '{literal}' to any Japanese key. " +
+                $"Expected entry ':リストの拡張' / 'Data Expansion' in en.txt.");
+
+            // Step 2: forward-map Japanese key in ja.txt → non-empty.
+            Assert.True(
+                jaMap.TryGetValue(jaKey!, out string? jaTranslation) && !string.IsNullOrEmpty(jaTranslation),
+                $"config/translate/ja.txt does not have a non-empty entry for key '{jaKey}'. " +
+                $"The Japanese translation of 'Data Expansion' is missing.");
+
+            // Step 3: forward-map Japanese key in zh.txt → "扩展列表" (non-empty).
+            Assert.True(
+                zhMap.TryGetValue(jaKey!, out string? zhTranslation) && !string.IsNullOrEmpty(zhTranslation),
+                $"config/translate/zh.txt does not have a non-empty entry for key '{jaKey}'. " +
+                $"Expected Chinese translation '扩展列表' (fix for issue #1691).");
+
+            // Sanity: confirm the Chinese value matches the expected string.
+            Assert.Equal("扩展列表", zhTranslation);
+        }
+
+        /// <summary>
+        /// Walk up the directory tree from the test assembly until FEBuilderGBA.sln
+        /// is found.  Mirrors the pattern in <see cref="L10nCoverageTest.FindRepoRoot"/>.
+        /// </summary>
+        static string FindRepoRoot()
+        {
+            string start = AppDomain.CurrentDomain.BaseDirectory;
+            for (var dir = new DirectoryInfo(start); dir != null; dir = dir.Parent)
+            {
+                if (File.Exists(Path.Combine(dir.FullName, "FEBuilderGBA.sln")))
+                    return dir.FullName;
+            }
+            throw new InvalidOperationException(
+                $"Could not locate FEBuilderGBA.sln starting from {start}");
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/MapSettingExpandWiringTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/MapSettingExpandWiringTests.cs
@@ -8,7 +8,7 @@
 //
 // Three layers of proof:
 //   1. AXAML source scan — each view's .axaml carries the per-view
-//      *_ExpandList_Button AutomationId AND the literal リストの拡張.
+//      *_ExpandList_Button AutomationId AND the English Content literal "Data Expansion".
 //   2. Code-behind source scan — each .axaml.cs wires the Click handler and
 //      routes through MapSettingCore.ExpandMapSettingTable under one
 //      UndoService scope (Begin + Rollback present). FE7/FE7U use _vm.LoadList()
@@ -54,17 +54,21 @@ namespace FEBuilderGBA.Avalonia.Tests
         private static string ReadCode(string file)
             => File.ReadAllText(Path.Combine(ViewsDir(), file));
 
-        // ---- Layer 1: AXAML carries the button id + Japanese literal ----
+        // ---- Layer 1: AXAML carries the button id + English Content literal ----
 
         [Theory]
         [InlineData("MapSettingFE7View.axaml", "MapSettingFE7_ExpandList_Button")]
         [InlineData("MapSettingFE7UView.axaml", "MapSettingFE7U_ExpandList_Button")]
         [InlineData("MapSettingView.axaml", "MapSetting_ExpandList_Button")]
-        public void Axaml_HasExpandButton_AndJapaneseLiteral(string axamlFile, string buttonId)
+        public void Axaml_HasExpandButton_AndDataExpansionLiteral(string axamlFile, string buttonId)
         {
             string xaml = ReadAxaml(axamlFile);
             Assert.Contains(buttonId, xaml);
-            Assert.Contains("リストの拡張", xaml);
+            // #1691: Content literal must be the English source "Data Expansion"
+            // (routed through R._ + config/translate), NOT raw Japanese リストの拡張
+            // which ViewTranslationHelper.IsTranslatable skips (no ASCII letters).
+            Assert.Contains("Content=\"Data Expansion\"", xaml);
+            Assert.DoesNotContain("Content=\"リストの拡張\"", xaml);
             // The button must be named so the code-behind can wire it.
             Assert.Contains("Name=\"ExpandListButton\"", xaml);
         }

--- a/FEBuilderGBA.Avalonia.Tests/StatusOptionExpandTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/StatusOptionExpandTests.cs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // #1607 — wiring tests for the Status Screen Option (Game Option) editor's new
-// List Expand affordance (リストの拡張): a warning-gated table expand that grows
+// List Expand affordance (Data Expansion): a warning-gated table expand that grows
 // the 44-byte status_game_option table and repoints all references
 // (StatusGameOptionCore.ExpandGameOptionTable).
 //
@@ -32,7 +32,10 @@ namespace FEBuilderGBA.Avalonia.Tests
             var expand = view.FindControl<Button>("ExpandListButton");
             Assert.NotNull(expand);
             Assert.True(expand!.IsEnabled, "ExpandListButton must be enabled (wired in #1607).");
-            Assert.Equal("リストの拡張", expand!.Content);
+            // #1691: AvaloniaFact constructs the view WITHOUT .Show(), so the Opened
+            // handler (ViewTranslationHelper.TranslateAll) never fires; Content stays
+            // the raw AXAML literal, which is now the English source "Data Expansion".
+            Assert.Equal("Data Expansion", expand!.Content);
         }
 
         // ---- Layer 2: source-text wiring scan (CI-safe, no runtime) ----

--- a/FEBuilderGBA.Avalonia.Tests/SummonUnitExpandWiringTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/SummonUnitExpandWiringTests.cs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // #1605 — wiring tests for the Summon Unit (FE8) editor's new List Expand
-// affordance (リストの拡張): an FE8-only table expand that grows the 2-byte
+// affordance (Data Expansion): an FE8-only table expand that grows the 2-byte
 // summon_unit_pointer table and repoints all references + the SPECIFIC
 // hardcoded engine sites (SummonUnitExpandCore.ExpandSummonUnitTable).
 //
@@ -45,7 +45,10 @@ namespace FEBuilderGBA.Avalonia.Tests
 
             var expand = view.FindControl<Button>("ExpandListButton");
             Assert.NotNull(expand);
-            Assert.Equal("リストの拡張", expand!.Content);
+            // #1691: AvaloniaFact constructs the view WITHOUT .Show(), so the Opened
+            // handler (ViewTranslationHelper.TranslateAll) never fires; Content stays
+            // the raw AXAML literal, which is now the English source "Data Expansion".
+            Assert.Equal("Data Expansion", expand!.Content);
         }
 
         // ---- Layer 2: ROM-backed enabled-state + list parity -----------------
@@ -116,7 +119,8 @@ namespace FEBuilderGBA.Avalonia.Tests
             string xaml = File.ReadAllText(Repo("FEBuilderGBA.Avalonia", "Views", "SummonUnitViewerView.axaml"));
             Assert.Contains("Name=\"ExpandListButton\"", xaml);
             Assert.Contains("SummonUnitViewer_Expand_Button", xaml);
-            Assert.Contains("リストの拡張", xaml);
+            // #1691: Content literal is now the English source "Data Expansion".
+            Assert.Contains("Content=\"Data Expansion\"", xaml);
         }
 
         [Fact]

--- a/FEBuilderGBA.Avalonia/Views/MapSettingFE6View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MapSettingFE6View.axaml
@@ -9,7 +9,7 @@
     <DockPanel Grid.Column="0" Margin="4">
       <TextBlock DockPanel.Dock="Top" Text="先頭アドレス" Margin="2,0,2,2" FontWeight="Bold" />
       <TextBlock DockPanel.Dock="Top" Text="読込数" Margin="2,0,2,2" Foreground="Gray" FontSize="11" />
-      <Button AutomationProperties.AutomationId="MapSettingFE6_ExpandList_Button" DockPanel.Dock="Top" Name="ExpandListButton" Content="リストの拡張" Margin="2" />
+      <Button AutomationProperties.AutomationId="MapSettingFE6_ExpandList_Button" DockPanel.Dock="Top" Name="ExpandListButton" Content="Data Expansion" Margin="2" />
       <Button AutomationProperties.AutomationId="MapSettingFE6_Refetch_Button" DockPanel.Dock="Top" Name="RefetchButton" Content="再取得" Margin="2" />
       <controls:AddressListControl AutomationProperties.AutomationId="MapSettingFE6_Entry_List" Name="EntryList" />
     </DockPanel>

--- a/FEBuilderGBA.Avalonia/Views/MapSettingFE7UView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MapSettingFE7UView.axaml
@@ -6,7 +6,7 @@
         SizeToContent="WidthAndHeight">
   <Grid ColumnDefinitions="250,*">
     <DockPanel Grid.Column="0" Margin="4">
-      <Button AutomationProperties.AutomationId="MapSettingFE7U_ExpandList_Button" DockPanel.Dock="Top" Name="ExpandListButton" Content="リストの拡張" Margin="2" />
+      <Button AutomationProperties.AutomationId="MapSettingFE7U_ExpandList_Button" DockPanel.Dock="Top" Name="ExpandListButton" Content="Data Expansion" Margin="2" />
       <controls:AddressListControl AutomationProperties.AutomationId="MapSettingFE7U_Entry_List" Name="EntryList" />
     </DockPanel>
 

--- a/FEBuilderGBA.Avalonia/Views/MapSettingFE7View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MapSettingFE7View.axaml
@@ -6,7 +6,7 @@
         SizeToContent="WidthAndHeight">
   <Grid ColumnDefinitions="250,*">
     <DockPanel Grid.Column="0" Margin="4">
-      <Button AutomationProperties.AutomationId="MapSettingFE7_ExpandList_Button" DockPanel.Dock="Top" Name="ExpandListButton" Content="リストの拡張" Margin="2" />
+      <Button AutomationProperties.AutomationId="MapSettingFE7_ExpandList_Button" DockPanel.Dock="Top" Name="ExpandListButton" Content="Data Expansion" Margin="2" />
       <controls:AddressListControl AutomationProperties.AutomationId="MapSettingFE7_Entry_List" Name="EntryList" />
     </DockPanel>
 

--- a/FEBuilderGBA.Avalonia/Views/MapSettingView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MapSettingView.axaml
@@ -6,7 +6,7 @@
         SizeToContent="WidthAndHeight">
   <Grid ColumnDefinitions="250,*">
     <DockPanel Grid.Column="0" Margin="4">
-      <Button AutomationProperties.AutomationId="MapSetting_ExpandList_Button" DockPanel.Dock="Top" Name="ExpandListButton" Content="リストの拡張" Margin="2" />
+      <Button AutomationProperties.AutomationId="MapSetting_ExpandList_Button" DockPanel.Dock="Top" Name="ExpandListButton" Content="Data Expansion" Margin="2" />
       <controls:AddressListControl AutomationProperties.AutomationId="MapSetting_Map_List" Name="MapList" />
     </DockPanel>
 

--- a/FEBuilderGBA.Avalonia/Views/StatusOptionView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/StatusOptionView.axaml
@@ -6,7 +6,7 @@
         SizeToContent="WidthAndHeight">
   <Grid ColumnDefinitions="250,*">
     <DockPanel Grid.Column="0" Margin="4">
-      <Button AutomationProperties.AutomationId="StatusOption_ExpandList_Button" DockPanel.Dock="Top" Name="ExpandListButton" Content="リストの拡張" Margin="0,0,0,4" />
+      <Button AutomationProperties.AutomationId="StatusOption_ExpandList_Button" DockPanel.Dock="Top" Name="ExpandListButton" Content="Data Expansion" Margin="0,0,0,4" />
       <controls:AddressListControl AutomationProperties.AutomationId="StatusOption_Entry_List" Name="EntryList" />
     </DockPanel>
 

--- a/FEBuilderGBA.Avalonia/Views/SummonUnitViewerView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SummonUnitViewerView.axaml
@@ -45,7 +45,7 @@
 
         <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,16,0,0">
           <Button AutomationProperties.AutomationId="SummonUnitViewer_Write_Button" Content="Write" Click="Write_Click" />
-          <Button AutomationProperties.AutomationId="SummonUnitViewer_Expand_Button" Name="ExpandListButton" Content="リストの拡張" Click="OnExpandListClick" />
+          <Button AutomationProperties.AutomationId="SummonUnitViewer_Expand_Button" Name="ExpandListButton" Content="Data Expansion" Click="OnExpandListClick" />
         </StackPanel>
       </StackPanel>
     </ScrollViewer>


### PR DESCRIPTION
## Summary

In Avalonia English mode, raw Japanese text `リストの拡張` ("Expand List") was shown for the **Expand button** in the Map Setting, Summon Unit, and Status Screen Options editors — exactly as reported by @OrionNebula12 in discussion #1674 (FE8U, English UI).

### Root cause
The runtime AXAML localizer `FEBuilderGBA.Avalonia/Services/ViewTranslationHelper.cs` only rewrites a control's `Content`/`Text` when `IsTranslatable(text)` returns true, and that helper **requires the literal to contain at least one ASCII letter**. Six views shipped the button label as the *raw Japanese* literal `Content="リストの拡張"`, which has zero ASCII letters → the localizer skipped it → the Japanese stayed on screen in every locale.

The established repo convention (already used by 5 other views: `MapExitPointView`, `ImageMagicCSACreatorView`, `MapTileAnimation2View`, `OPClassDemoViewerView`) is the **English source literal** `Content="Data Expansion"`, which flows through `R._()` → `en.txt` reverse-map → Japanese key `リストの拡張` → `ja.txt`/`zh.txt` forward map.

### Fix
Change `Content="リストの拡張"` → `Content="Data Expansion"` in the six views. No other attribute was touched (Name / AutomationId / Click / Margin preserved).

**No translate-file edits were needed** — the entries already exist:
| Key | en.txt | ja.txt | zh.txt |
|---|---|---|---|
| `リストの拡張` | `Data Expansion` | `リストの拡張` | `扩展列表` |

### Strings fixed (the same label across 6 files)
| File | Editor (issue mapping) | Translate key added/used |
|---|---|---|
| `Views/MapSettingView.axaml` | **Map Setting** (FE8 — reporter's ROM) | `Data Expansion` → `リストの拡張` (existing) |
| `Views/MapSettingFE6View.axaml` | Map Setting (FE6 sibling) | same |
| `Views/MapSettingFE7View.axaml` | Map Setting (FE7 sibling) | same |
| `Views/MapSettingFE7UView.axaml` | Map Setting (FE7U sibling) | same |
| `Views/SummonUnitViewerView.axaml` | **Summon Unit** ("one field") | same |
| `Views/StatusOptionView.axaml` | **Status Screen Options** ("a button label") | same |

### Out of scope (verified — NOT the reported bug, left untouched)
- `StatusOptionView.axaml.cs` `R._("ゲームオプションの拡張…")` confirm dialog — Japanese-*keyed* `R._()`, **already fully localized** (en.txt:11446 + zh.txt:11431 have real translations). This is the standard WinForms-parity pattern, not a UI bug.
- The many fully-Japanese labels in `MapSettingFE6View.axaml` (先頭アドレス, 読込数, …), `SongInstrumentView.axaml`, and the intentional `日本語`/`中文` picker buttons in `ToolInitWizardView.axaml` — different editors, not named in #1674, out of scope.

## Scope
Closes #1691.

## Test plan
- [x] `JapaneseExpandButtonL10nRegressionTests.ExpandListButton_NoRawJapaneseLiteral` — asserts zero `Content="リストの拡張"` occurrences across the six fixed files (scoped to that exact attribute so unrelated FE6 Japanese labels are not flagged) — **PASS**
- [x] `JapaneseExpandButtonL10nRegressionTests.DataExpansionLiteral_HasJaAndZhTranslation` — walks the real translate pipeline (`LoadReverseEnglishMap` + `LoadForwardMap`) to prove `"Data Expansion"` resolves to non-empty ja AND zh (`扩展列表`) — **PASS**
- [x] Existing global gate `L10nCoverageTest.AvaloniaViews_HaveJaAndZhTranslations` — **PASS** (the six buttons are now classified `Translated`, not `NonEnglish`; gate stays green)
- [x] `CodeLiteralL10nCoverageTest.AvaloniaCodeLiterals_HaveJaAndZhTranslations` — **PASS**
- [x] `CodeLiteralL10nCoverageTest.Gate_WouldHaveCaught_Issue1635_Examples` — **PASS**
- [x] `grep -rnP 'Content="リストの拡張"' FEBuilderGBA.Avalonia/Views/` → zero matches (exit 1)

Totals: **5 passed, 0 failed, 0 skipped** (targeted `--filter` run; no full Avalonia app build — disk-constrained).

## Screenshots
N/A — this is a translation-data change with no single editor screenshot (scoped `fix(l10n)` title; the screenshot CI gate is skipped for scoped titles). Proof is the regression test output above.

Original request: review and reply discussions, create issues for reported bugs, resolve them via dev-flow
🤖 Generated with Claude Code (Opus 4.8, 1M context)
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
