### PR TITLE
fix(avalonia): widen cramped/overflowing fields in Support Unit, Move Cost, Map Exit Point editors

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/FieldSpacingLayoutTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/FieldSpacingLayoutTests.cs
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Layout-regression tests for the field-spacing fixes reported in
+// discussion #1674 and tracked by:
+//   #1684 SupportUnitEditorView  — cramped columns
+//   #1685 MoveCostEditorView     — terrain names overflow + spinner overlap
+//   #1686 MapExitPointView       — Coordinate/Direction/Flag fields compressed
+//
+// These are pure cosmetic AXAML / grid-builder layout changes, so the
+// guard parses the View source directly (ROM-free, render-free, disk-light)
+// and asserts the intended layout constants are present. This prevents a
+// future edit from silently re-introducing the cramped widths.
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    public class FieldSpacingLayoutTests
+    {
+        static string FindRepoRoot()
+        {
+            string? dir = AppContext.BaseDirectory;
+            while (dir != null && !File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+            {
+                dir = Path.GetDirectoryName(dir);
+            }
+            if (dir == null)
+                throw new InvalidOperationException("Could not find FEBuilderGBA.sln from test base directory");
+            return dir;
+        }
+
+        static string ViewPath(string fileName)
+        {
+            string path = Path.Combine(FindRepoRoot(), "FEBuilderGBA.Avalonia", "Views", fileName);
+            Assert.True(File.Exists(path), $"View source not found at {path}");
+            return path;
+        }
+
+        static readonly XNamespace Av = "https://github.com/avaloniaui";
+
+        // -----------------------------------------------------------------
+        // #1684 SupportUnitEditorView — columns must be wide enough that the
+        // partner-name labels don't clip and the source-unit name doesn't
+        // butt against the "Open Unit" button.
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void SupportUnitEditor_SourceUnitRow_NameColumnWidened_AndTrims()
+        {
+            var doc = XDocument.Load(ViewPath("SupportUnitEditorView.axaml"));
+
+            // Source-unit name label gets ellipsis trimming so a long name
+            // can never overflow its cell into the Open Unit button.
+            var nameLabel = doc.Descendants(Av + "TextBlock")
+                .FirstOrDefault(e => (string?)e.Attribute("Name") == "SourceUnitNameLabel");
+            Assert.NotNull(nameLabel);
+            Assert.Equal("CharacterEllipsis", (string?)nameLabel!.Attribute("TextTrimming"));
+
+            // Its grid's name column must be wider than the old cramped 150.
+            var grid = nameLabel.Ancestors(Av + "Grid").First();
+            int nameColWidth = ParseColumn(grid, index: 2);
+            Assert.True(nameColWidth >= 200,
+                $"Source-unit name column must be >= 200 (was 150); got {nameColWidth}");
+        }
+
+        [Fact]
+        public void SupportUnitEditor_PartnersGrid_WidenedColumns_AndTrimmingLabels()
+        {
+            var doc = XDocument.Load(ViewPath("SupportUnitEditorView.axaml"));
+
+            // Locate the partner grid via the first partner NUD.
+            var partner1Nud = doc.Descendants(Av + "NumericUpDown")
+                .FirstOrDefault(e => (string?)e.Attribute("Name") == "Partner1Nud");
+            Assert.NotNull(partner1Nud);
+
+            // Every partner NUD must have an explicit width + left alignment so
+            // the spinner buttons never overlap the adjacent name column.
+            for (int i = 1; i <= 7; i++)
+            {
+                var nud = doc.Descendants(Av + "NumericUpDown")
+                    .FirstOrDefault(e => (string?)e.Attribute("Name") == $"Partner{i}Nud");
+                Assert.NotNull(nud);
+                Assert.False(string.IsNullOrEmpty((string?)nud!.Attribute("Width")),
+                    $"Partner{i}Nud must have an explicit Width");
+                Assert.Equal("Left", (string?)nud.Attribute("HorizontalAlignment"));
+            }
+
+            // Every partner-name label must trim with an ellipsis.
+            for (int i = 1; i <= 7; i++)
+            {
+                var lbl = doc.Descendants(Av + "TextBlock")
+                    .FirstOrDefault(e => (string?)e.Attribute("Name") == $"Partner{i}NameLabel");
+                Assert.NotNull(lbl);
+                Assert.Equal("CharacterEllipsis", (string?)lbl!.Attribute("TextTrimming"));
+            }
+
+            // The partner grid's name column is now a star column (consumes
+            // available width) instead of the old fixed 150.
+            var grid = partner1Nud!.Ancestors(Av + "Grid").First();
+            string cols = (string)grid.Attribute("ColumnDefinitions")!;
+            var parts = cols.Split(',');
+            Assert.Equal("*", parts[2].Trim());
+            // Talk-button column widened from 60 -> 80.
+            Assert.True(int.TryParse(parts[3].Trim(), out int talkCol) && talkCol >= 80,
+                $"Talk button column must be >= 80 (was 60); got '{parts[3]}'");
+        }
+
+        // -----------------------------------------------------------------
+        // #1685 MoveCostEditorView — the terrain grid is built in code-behind.
+        // The terrain-name label must trim (no overflow) and the NUD must have
+        // an explicit width + left alignment (no spinner overlap).
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void MoveCostEditor_TerrainGridBuilder_TrimsNames_AndPinsNudWidth()
+        {
+            string path = Path.Combine(FindRepoRoot(), "FEBuilderGBA.Avalonia", "Views",
+                "MoveCostEditorView.axaml.cs");
+            Assert.True(File.Exists(path), $"Code-behind not found at {path}");
+            string src = File.ReadAllText(path);
+
+            // The label must use ellipsis trimming so long terrain names are
+            // truncated cleanly instead of overflowing the column.
+            Assert.Contains("TextTrimming = global::Avalonia.Media.TextTrimming.CharacterEllipsis", src);
+            Assert.Contains("MaxWidth = 140", src);
+
+            // The NUD must have an explicit Width and left alignment — relying
+            // on MinWidth alone let the spinner buttons bleed into the neighbour.
+            Assert.Contains("Width = 110", src);
+            Assert.Contains("HorizontalAlignment = HorizontalAlignment.Left", src);
+
+            // Guard against the regressed pattern returning.
+            Assert.DoesNotContain("MinWidth = 120", src);
+        }
+
+        // -----------------------------------------------------------------
+        // #1686 MapExitPointView — the Coordinate/Direction/Flag grid columns
+        // must be wide enough for the NUDs (>=120) and the spanned
+        // combo/textbox (>=180), and the NUDs left-aligned.
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void MapExitPoint_CoordinateGrid_WidenedColumns_AndLeftAlignedNuds()
+        {
+            var doc = XDocument.Load(ViewPath("MapExitPointView.axaml"));
+
+            // Locate the coordinate grid via the X NUD.
+            var xBox = doc.Descendants(Av + "NumericUpDown")
+                .FirstOrDefault(e => (string?)e.Attribute("Name") == "ExitXBox");
+            Assert.NotNull(xBox);
+            var grid = xBox!.Ancestors(Av + "Grid").First();
+
+            // Numeric value column (col 2) must be >= 120 for the spinner.
+            int valueCol = ParseColumn(grid, index: 2);
+            Assert.True(valueCol >= 120,
+                $"Coordinate value column must be >= 120 (was 80); got {valueCol}");
+
+            // Spanned column 4 must accommodate the 180px Direction combo /
+            // Flag-name box (cols 3+4 span). Col 4 alone is now >= 180.
+            int spanCol = ParseColumn(grid, index: 4);
+            Assert.True(spanCol >= 180,
+                $"Spanned value column must be >= 180 for the Direction combo; got {spanCol}");
+
+            // X/Y/Escape/Flag NUDs must be left-aligned so a stretched cell
+            // doesn't blow the spinner up across the whole column.
+            foreach (var name in new[] { "ExitXBox", "ExitYBox", "EscapeMethodBox", "FlagBox" })
+            {
+                var nud = doc.Descendants(Av + "NumericUpDown")
+                    .FirstOrDefault(e => (string?)e.Attribute("Name") == name);
+                Assert.NotNull(nud);
+                Assert.Equal("Left", (string?)nud!.Attribute("HorizontalAlignment"));
+            }
+        }
+
+        // -----------------------------------------------------------------
+        // helpers
+        // -----------------------------------------------------------------
+
+        /// <summary>
+        /// Parse the integer width of the Nth column from a Grid's
+        /// ColumnDefinitions string (e.g. "160,40,120,40,200"). Star/Auto
+        /// columns return int.MaxValue so width assertions treat them as
+        /// "at least as wide as needed".
+        /// </summary>
+        static int ParseColumn(XElement grid, int index)
+        {
+            string cols = (string)grid.Attribute("ColumnDefinitions")!;
+            var parts = cols.Split(',');
+            Assert.True(index < parts.Length,
+                $"Grid only has {parts.Length} columns; asked for index {index}");
+            string p = parts[index].Trim();
+            if (p == "*" || p.EndsWith("*") || p == "Auto")
+                return int.MaxValue;
+            return int.Parse(p);
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/FieldSpacingLayoutTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/FieldSpacingLayoutTests.cs
@@ -128,9 +128,10 @@ namespace FEBuilderGBA.Avalonia.Tests
             string src = File.ReadAllText(path);
 
             // The label must use ellipsis trimming so long terrain names are
-            // truncated cleanly instead of overflowing the column.
+            // truncated cleanly inside the fixed 140-wide column instead of
+            // overflowing into the neighbouring cell.
             Assert.Contains("TextTrimming = global::Avalonia.Media.TextTrimming.CharacterEllipsis", src);
-            Assert.Contains("MaxWidth = 140", src);
+            Assert.Contains("Width = 140", src);
 
             // The NUD must have an explicit Width and left alignment — relying
             // on MinWidth alone let the spinner buttons bleed into the neighbour.

--- a/FEBuilderGBA.Avalonia.Tests/FieldSpacingLayoutTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/FieldSpacingLayoutTests.cs
@@ -58,6 +58,9 @@ namespace FEBuilderGBA.Avalonia.Tests
                 .FirstOrDefault(e => (string?)e.Attribute("Name") == "SourceUnitNameLabel");
             Assert.NotNull(nameLabel);
             Assert.Equal("CharacterEllipsis", (string?)nameLabel!.Attribute("TextTrimming"));
+            // #650: a trimmed preview must self-bind a tooltip so the full
+            // (possibly truncated) text is recoverable on hover.
+            AssertSelfBindingToolTip(nameLabel, "SourceUnitNameLabel");
 
             // Its grid's name column must be wider than the old cramped 150.
             var grid = nameLabel.Ancestors(Av + "Grid").First();
@@ -88,13 +91,15 @@ namespace FEBuilderGBA.Avalonia.Tests
                 Assert.Equal("Left", (string?)nud.Attribute("HorizontalAlignment"));
             }
 
-            // Every partner-name label must trim with an ellipsis.
+            // Every partner-name label must trim with an ellipsis AND self-bind
+            // a tooltip (#650) so the truncated unit name is visible on hover.
             for (int i = 1; i <= 7; i++)
             {
                 var lbl = doc.Descendants(Av + "TextBlock")
                     .FirstOrDefault(e => (string?)e.Attribute("Name") == $"Partner{i}NameLabel");
                 Assert.NotNull(lbl);
                 Assert.Equal("CharacterEllipsis", (string?)lbl!.Attribute("TextTrimming"));
+                AssertSelfBindingToolTip(lbl, $"Partner{i}NameLabel");
             }
 
             // The partner grid's name column is now a star column (consumes
@@ -175,9 +180,37 @@ namespace FEBuilderGBA.Avalonia.Tests
             }
         }
 
+        [Fact]
+        public void MoveCostEditor_TerrainLabelTooltip_SetInCodeBehind()
+        {
+            // The terrain labels are built in code-behind and trimmed with an
+            // ellipsis, so #650 coverage is provided by mirroring the full text
+            // into a tooltip whenever the label text is (re)assigned.
+            string path = Path.Combine(FindRepoRoot(), "FEBuilderGBA.Avalonia", "Views",
+                "MoveCostEditorView.axaml.cs");
+            string src = File.ReadAllText(path);
+            Assert.Contains("ToolTip.SetTip(_labelFields[i], _labelFields[i].Text)", src);
+        }
+
         // -----------------------------------------------------------------
         // helpers
         // -----------------------------------------------------------------
+
+        /// <summary>
+        /// Assert a TextBlock element declares the #650 element-name self-binding
+        /// tooltip — ToolTip.Tip="{Binding #&lt;name&gt;.Text}" — matching its own Name.
+        /// In unprefixed AXAML the attached-property attribute has the literal
+        /// local name "ToolTip.Tip" (the dot is part of the name, no namespace).
+        /// </summary>
+        static void AssertSelfBindingToolTip(XElement textBlock, string expectedName)
+        {
+            var tip = textBlock.Attributes()
+                .FirstOrDefault(a => a.Name.LocalName == "ToolTip.Tip" ||
+                                     a.Name.LocalName == "Tip");
+            Assert.True(tip != null,
+                $"{expectedName}: trimmed TextBlock must declare a ToolTip.Tip self-binding (#650)");
+            Assert.Equal($"{{Binding #{expectedName}.Text}}", tip!.Value);
+        }
 
         /// <summary>
         /// Parse the integer width of the Nth column from a Grid's

--- a/FEBuilderGBA.Avalonia.Tests/FieldSpacingLayoutTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/FieldSpacingLayoutTests.cs
@@ -164,11 +164,21 @@ namespace FEBuilderGBA.Avalonia.Tests
             Assert.True(valueCol >= 120,
                 $"Coordinate value column must be >= 120 (was 80); got {valueCol}");
 
-            // Spanned column 4 must accommodate the 180px Direction combo /
-            // Flag-name box (cols 3+4 span). Col 4 alone is now >= 180.
-            int spanCol = ParseColumn(grid, index: 4);
-            Assert.True(spanCol >= 180,
-                $"Spanned value column must be >= 180 for the Direction combo; got {spanCol}");
+            // The Direction ComboBox and the Flag-name TextBox both span
+            // columns 3+4 (Grid.ColumnSpan="2"), so the COMBINED width of those
+            // two columns — not column 4 alone — is what must accommodate the
+            // 180px Direction combo. Asserting the combined span is robust to a
+            // future edit that shifts width between col 3 and col 4 without
+            // changing the total (Copilot review on PR #1696).
+            int col3 = ParseColumn(grid, index: 3);
+            int col4 = ParseColumn(grid, index: 4);
+            // Either column could be a star/Auto column (treated as MaxValue);
+            // guard against overflow before summing.
+            int spanWidth = (col3 == int.MaxValue || col4 == int.MaxValue)
+                ? int.MaxValue
+                : col3 + col4;
+            Assert.True(spanWidth >= 180,
+                $"Direction combo / Flag-name span (cols 3+4 = {col3}+{col4} = {spanWidth}) must be >= 180px for the 180px combo");
 
             // X/Y/Escape/Flag NUDs must be left-aligned so a stretched cell
             // doesn't blow the spinner up across the whole column.

--- a/FEBuilderGBA.Avalonia/Views/MapExitPointView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MapExitPointView.axaml
@@ -105,29 +105,33 @@
 
           <!-- Exit Coordinates (mirrors WF N_L_0_MAPXY) -->
           <Border BorderBrush="Gray" BorderThickness="1" Padding="6">
-            <Grid ColumnDefinitions="160,40,80,40,80" RowDefinitions="Auto,Auto,Auto">
+            <Grid ColumnDefinitions="160,40,120,40,200" RowDefinitions="Auto,Auto,Auto">
               <Label Grid.Row="0" Grid.Column="0" Content="Coordinates" VerticalAlignment="Center" />
               <Label Grid.Row="0" Grid.Column="1" Content="X:" VerticalAlignment="Center" />
               <NumericUpDown AutomationProperties.AutomationId="MapExitPoint_X_Input"
                              FormatString="0" Grid.Row="0" Grid.Column="2"
-                             Name="ExitXBox" Minimum="0" Maximum="255" VerticalAlignment="Center" />
+                             Name="ExitXBox" Minimum="0" Maximum="255"
+                             HorizontalAlignment="Left" VerticalAlignment="Center" />
               <Label Grid.Row="0" Grid.Column="3" Content="Y:" VerticalAlignment="Center" />
               <NumericUpDown AutomationProperties.AutomationId="MapExitPoint_Y_Input"
                              FormatString="0" Grid.Row="0" Grid.Column="4"
-                             Name="ExitYBox" Minimum="0" Maximum="255" VerticalAlignment="Center" />
+                             Name="ExitYBox" Minimum="0" Maximum="255"
+                             HorizontalAlignment="Left" VerticalAlignment="Center" />
 
               <Label Grid.Row="1" Grid.Column="0" Content="Direction" VerticalAlignment="Center" />
               <NumericUpDown AutomationProperties.AutomationId="MapExitPoint_EscapeMethod_Input"
                              FormatString="0" Grid.Row="1" Grid.Column="2"
-                             Name="EscapeMethodBox" Minimum="0" Maximum="255" VerticalAlignment="Center" />
+                             Name="EscapeMethodBox" Minimum="0" Maximum="255"
+                             HorizontalAlignment="Left" VerticalAlignment="Center" />
               <ComboBox AutomationProperties.AutomationId="MapExitPoint_EscapeMethod_Combo"
                         Grid.Row="1" Grid.Column="3" Grid.ColumnSpan="2"
-                        Name="EscapeMethodCombo" Width="180" VerticalAlignment="Center" />
+                        Name="EscapeMethodCombo" Width="180" HorizontalAlignment="Left" VerticalAlignment="Center" />
 
               <Label Grid.Row="2" Grid.Column="0" Content="00 (Flag)" VerticalAlignment="Center" />
               <NumericUpDown AutomationProperties.AutomationId="MapExitPoint_Flag_Input"
                              FormatString="0" Grid.Row="2" Grid.Column="2"
-                             Name="FlagBox" Minimum="0" Maximum="255" VerticalAlignment="Center" />
+                             Name="FlagBox" Minimum="0" Maximum="255"
+                             HorizontalAlignment="Left" VerticalAlignment="Center" />
               <TextBox AutomationProperties.AutomationId="MapExitPoint_FlagName_Input"
                        Grid.Row="2" Grid.Column="3" Grid.ColumnSpan="2"
                        Name="FlagNameBox" IsReadOnly="True" VerticalAlignment="Center" />

--- a/FEBuilderGBA.Avalonia/Views/MoveCostEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MoveCostEditorView.axaml.cs
@@ -50,13 +50,14 @@ namespace FEBuilderGBA.Avalonia.Views
 
                     var rowPanel = new StackPanel { Orientation = global::Avalonia.Layout.Orientation.Horizontal, Spacing = 6, Margin = new Thickness(0, 1) };
 
-                    // #1685: terrain names can be long; trim with an ellipsis inside a
-                    // bounded width instead of a fixed Width that lets text overflow the cell.
+                    // #1685: terrain names can be long. Keep the fixed 140-wide
+                    // label column (so the rows stay aligned) but trim with an
+                    // ellipsis inside that width so a long name is truncated
+                    // cleanly instead of overflowing into the neighbouring cell.
                     var label = new TextBlock
                     {
                         Text = $"0x{index:X2}",
                         Width = 140,
-                        MaxWidth = 140,
                         TextTrimming = global::Avalonia.Media.TextTrimming.CharacterEllipsis,
                         VerticalAlignment = VerticalAlignment.Center,
                         Margin = new Thickness(0, 0, 4, 0),

--- a/FEBuilderGBA.Avalonia/Views/MoveCostEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MoveCostEditorView.axaml.cs
@@ -220,13 +220,16 @@ namespace FEBuilderGBA.Avalonia.Views
                 MoveCostAddrLabel.Text = $"Table: 0x{_vm.MoveCostAddr:X08}";
                 CostTypeLabel.Text = $"{_vm.SelectedCostType} (65 terrains: 0x00 - 0x40):";
 
-                // Update terrain labels with names
+                // Update terrain labels with names. The labels are trimmed with
+                // an ellipsis (#1685), so mirror the full text into a tooltip so
+                // a truncated terrain name is still recoverable on hover (#650).
                 for (int i = 0; i < MoveCostEditorViewModel.TerrainCount; i++)
                 {
                     if (_vm.TerrainNames != null && i < _vm.TerrainNames.Length)
                         _labelFields[i].Text = _vm.TerrainNames[i];
                     else
                         _labelFields[i].Text = $"0x{i:X2}";
+                    ToolTip.SetTip(_labelFields[i], _labelFields[i].Text);
                 }
 
                 // Update all 65 NumericUpDown values from the ViewModel

--- a/FEBuilderGBA.Avalonia/Views/MoveCostEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MoveCostEditorView.axaml.cs
@@ -48,23 +48,31 @@ namespace FEBuilderGBA.Avalonia.Views
                     if (index >= MoveCostEditorViewModel.TerrainCount)
                         break;
 
-                    var rowPanel = new StackPanel { Orientation = global::Avalonia.Layout.Orientation.Horizontal, Spacing = 4, Margin = new Thickness(0, 1) };
+                    var rowPanel = new StackPanel { Orientation = global::Avalonia.Layout.Orientation.Horizontal, Spacing = 6, Margin = new Thickness(0, 1) };
 
+                    // #1685: terrain names can be long; trim with an ellipsis inside a
+                    // bounded width instead of a fixed Width that lets text overflow the cell.
                     var label = new TextBlock
                     {
                         Text = $"0x{index:X2}",
                         Width = 140,
+                        MaxWidth = 140,
+                        TextTrimming = global::Avalonia.Media.TextTrimming.CharacterEllipsis,
                         VerticalAlignment = VerticalAlignment.Center,
+                        Margin = new Thickness(0, 0, 4, 0),
                         FontSize = 11,
                     };
                     _labelFields[index] = label;
 
+                    // #1685: pin an explicit width + left alignment so the spinner buttons
+                    // stay inside the field and never overlap the adjacent column.
                     var nud = new NumericUpDown
                     {
                         Minimum = 0,
                         Maximum = 255,
                         Value = 0,
-                        MinWidth = 120,
+                        Width = 110,
+                        HorizontalAlignment = HorizontalAlignment.Left,
                         FontSize = 11,
                         Tag = index,
                     };

--- a/FEBuilderGBA.Avalonia/Views/SupportUnitEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SupportUnitEditorView.axaml
@@ -17,7 +17,7 @@
           <Grid ColumnDefinitions="Auto,60,220,Auto" RowDefinitions="Auto">
             <TextBlock Grid.Column="0" Text="Source Unit:" VerticalAlignment="Center" Margin="0,0,8,0" FontWeight="SemiBold" />
             <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_SourceUnitId_Label" Grid.Column="1" Name="SourceUnitIdLabel" VerticalAlignment="Center" />
-            <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_SourceUnitName_Label" Grid.Column="2" Name="SourceUnitNameLabel" VerticalAlignment="Center" Margin="0,0,8,0" TextTrimming="CharacterEllipsis" />
+            <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_SourceUnitName_Label" Grid.Column="2" Name="SourceUnitNameLabel" VerticalAlignment="Center" Margin="0,0,8,0" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding #SourceUnitNameLabel.Text}" />
             <Button AutomationProperties.AutomationId="SupportUnitEditor_JumpToSourceUnit_Button" Grid.Column="3" Name="JumpToSourceUnitButton" Content="Open Unit" Margin="8,0,0,0" />
           </Grid>
         </Border>
@@ -27,37 +27,37 @@
         <Grid ColumnDefinitions="90,120,*,80" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto">
           <TextBlock Grid.Row="0" Grid.Column="0" Text="Partner 1:" VerticalAlignment="Center" Margin="0,2" />
           <NumericUpDown AutomationProperties.AutomationId="SupportUnitEditor_Partner1Nud_Input" FormatString="0" Grid.Row="0" Grid.Column="1" Name="Partner1Nud" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
-          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner1Name_Label" Grid.Row="0" Grid.Column="2" Name="Partner1NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" TextTrimming="CharacterEllipsis" />
+          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner1Name_Label" Grid.Row="0" Grid.Column="2" Name="Partner1NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding #Partner1NameLabel.Text}" />
           <Button AutomationProperties.AutomationId="SupportUnitEditor_Talk1_Button" Grid.Row="0" Grid.Column="3" Name="Talk1Button" Content="Talk" Margin="4,2,0,2" />
 
           <TextBlock Grid.Row="1" Grid.Column="0" Text="Partner 2:" VerticalAlignment="Center" Margin="0,2" />
           <NumericUpDown AutomationProperties.AutomationId="SupportUnitEditor_Partner2Nud_Input" FormatString="0" Grid.Row="1" Grid.Column="1" Name="Partner2Nud" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
-          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner2Name_Label" Grid.Row="1" Grid.Column="2" Name="Partner2NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" TextTrimming="CharacterEllipsis" />
+          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner2Name_Label" Grid.Row="1" Grid.Column="2" Name="Partner2NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding #Partner2NameLabel.Text}" />
           <Button AutomationProperties.AutomationId="SupportUnitEditor_Talk2_Button" Grid.Row="1" Grid.Column="3" Name="Talk2Button" Content="Talk" Margin="4,2,0,2" />
 
           <TextBlock Grid.Row="2" Grid.Column="0" Text="Partner 3:" VerticalAlignment="Center" Margin="0,2" />
           <NumericUpDown AutomationProperties.AutomationId="SupportUnitEditor_Partner3Nud_Input" FormatString="0" Grid.Row="2" Grid.Column="1" Name="Partner3Nud" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
-          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner3Name_Label" Grid.Row="2" Grid.Column="2" Name="Partner3NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" TextTrimming="CharacterEllipsis" />
+          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner3Name_Label" Grid.Row="2" Grid.Column="2" Name="Partner3NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding #Partner3NameLabel.Text}" />
           <Button AutomationProperties.AutomationId="SupportUnitEditor_Talk3_Button" Grid.Row="2" Grid.Column="3" Name="Talk3Button" Content="Talk" Margin="4,2,0,2" />
 
           <TextBlock Grid.Row="3" Grid.Column="0" Text="Partner 4:" VerticalAlignment="Center" Margin="0,2" />
           <NumericUpDown AutomationProperties.AutomationId="SupportUnitEditor_Partner4Nud_Input" FormatString="0" Grid.Row="3" Grid.Column="1" Name="Partner4Nud" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
-          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner4Name_Label" Grid.Row="3" Grid.Column="2" Name="Partner4NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" TextTrimming="CharacterEllipsis" />
+          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner4Name_Label" Grid.Row="3" Grid.Column="2" Name="Partner4NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding #Partner4NameLabel.Text}" />
           <Button AutomationProperties.AutomationId="SupportUnitEditor_Talk4_Button" Grid.Row="3" Grid.Column="3" Name="Talk4Button" Content="Talk" Margin="4,2,0,2" />
 
           <TextBlock Grid.Row="4" Grid.Column="0" Text="Partner 5:" VerticalAlignment="Center" Margin="0,2" />
           <NumericUpDown AutomationProperties.AutomationId="SupportUnitEditor_Partner5Nud_Input" FormatString="0" Grid.Row="4" Grid.Column="1" Name="Partner5Nud" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
-          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner5Name_Label" Grid.Row="4" Grid.Column="2" Name="Partner5NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" TextTrimming="CharacterEllipsis" />
+          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner5Name_Label" Grid.Row="4" Grid.Column="2" Name="Partner5NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding #Partner5NameLabel.Text}" />
           <Button AutomationProperties.AutomationId="SupportUnitEditor_Talk5_Button" Grid.Row="4" Grid.Column="3" Name="Talk5Button" Content="Talk" Margin="4,2,0,2" />
 
           <TextBlock Grid.Row="5" Grid.Column="0" Text="Partner 6:" VerticalAlignment="Center" Margin="0,2" />
           <NumericUpDown AutomationProperties.AutomationId="SupportUnitEditor_Partner6Nud_Input" FormatString="0" Grid.Row="5" Grid.Column="1" Name="Partner6Nud" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
-          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner6Name_Label" Grid.Row="5" Grid.Column="2" Name="Partner6NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" TextTrimming="CharacterEllipsis" />
+          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner6Name_Label" Grid.Row="5" Grid.Column="2" Name="Partner6NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding #Partner6NameLabel.Text}" />
           <Button AutomationProperties.AutomationId="SupportUnitEditor_Talk6_Button" Grid.Row="5" Grid.Column="3" Name="Talk6Button" Content="Talk" Margin="4,2,0,2" />
 
           <TextBlock Grid.Row="6" Grid.Column="0" Text="Partner 7:" VerticalAlignment="Center" Margin="0,2" />
           <NumericUpDown AutomationProperties.AutomationId="SupportUnitEditor_Partner7Nud_Input" FormatString="0" Grid.Row="6" Grid.Column="1" Name="Partner7Nud" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
-          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner7Name_Label" Grid.Row="6" Grid.Column="2" Name="Partner7NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" TextTrimming="CharacterEllipsis" />
+          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner7Name_Label" Grid.Row="6" Grid.Column="2" Name="Partner7NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding #Partner7NameLabel.Text}" />
           <Button AutomationProperties.AutomationId="SupportUnitEditor_Talk7_Button" Grid.Row="6" Grid.Column="3" Name="Talk7Button" Content="Talk" Margin="4,2,0,2" />
         </Grid>
 

--- a/FEBuilderGBA.Avalonia/Views/SupportUnitEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SupportUnitEditorView.axaml
@@ -14,50 +14,50 @@
 
         <!-- Source unit (read-only). Mirrors WinForms X_SRC_UNIT_VALUE/NAME/LABEL. -->
         <Border BorderBrush="Gray" BorderThickness="1" Padding="6" CornerRadius="4">
-          <Grid ColumnDefinitions="Auto,60,150,Auto" RowDefinitions="Auto">
+          <Grid ColumnDefinitions="Auto,60,220,Auto" RowDefinitions="Auto">
             <TextBlock Grid.Column="0" Text="Source Unit:" VerticalAlignment="Center" Margin="0,0,8,0" FontWeight="SemiBold" />
             <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_SourceUnitId_Label" Grid.Column="1" Name="SourceUnitIdLabel" VerticalAlignment="Center" />
-            <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_SourceUnitName_Label" Grid.Column="2" Name="SourceUnitNameLabel" VerticalAlignment="Center" />
+            <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_SourceUnitName_Label" Grid.Column="2" Name="SourceUnitNameLabel" VerticalAlignment="Center" Margin="0,0,8,0" TextTrimming="CharacterEllipsis" />
             <Button AutomationProperties.AutomationId="SupportUnitEditor_JumpToSourceUnit_Button" Grid.Column="3" Name="JumpToSourceUnitButton" Content="Open Unit" Margin="8,0,0,0" />
           </Grid>
         </Border>
 
         <!-- Partner Unit IDs (with names + per-slot SupportTalk jump buttons) -->
         <TextBlock Text="Support Partners" FontWeight="SemiBold" Margin="0,8,0,0" />
-        <Grid ColumnDefinitions="80,100,150,60" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+        <Grid ColumnDefinitions="90,120,*,80" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto">
           <TextBlock Grid.Row="0" Grid.Column="0" Text="Partner 1:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="SupportUnitEditor_Partner1Nud_Input" FormatString="0" Grid.Row="0" Grid.Column="1" Name="Partner1Nud" Minimum="0" Maximum="255" Margin="0,2" />
-          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner1Name_Label" Grid.Row="0" Grid.Column="2" Name="Partner1NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" />
+          <NumericUpDown AutomationProperties.AutomationId="SupportUnitEditor_Partner1Nud_Input" FormatString="0" Grid.Row="0" Grid.Column="1" Name="Partner1Nud" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
+          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner1Name_Label" Grid.Row="0" Grid.Column="2" Name="Partner1NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" TextTrimming="CharacterEllipsis" />
           <Button AutomationProperties.AutomationId="SupportUnitEditor_Talk1_Button" Grid.Row="0" Grid.Column="3" Name="Talk1Button" Content="Talk" Margin="4,2,0,2" />
 
           <TextBlock Grid.Row="1" Grid.Column="0" Text="Partner 2:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="SupportUnitEditor_Partner2Nud_Input" FormatString="0" Grid.Row="1" Grid.Column="1" Name="Partner2Nud" Minimum="0" Maximum="255" Margin="0,2" />
-          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner2Name_Label" Grid.Row="1" Grid.Column="2" Name="Partner2NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" />
+          <NumericUpDown AutomationProperties.AutomationId="SupportUnitEditor_Partner2Nud_Input" FormatString="0" Grid.Row="1" Grid.Column="1" Name="Partner2Nud" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
+          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner2Name_Label" Grid.Row="1" Grid.Column="2" Name="Partner2NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" TextTrimming="CharacterEllipsis" />
           <Button AutomationProperties.AutomationId="SupportUnitEditor_Talk2_Button" Grid.Row="1" Grid.Column="3" Name="Talk2Button" Content="Talk" Margin="4,2,0,2" />
 
           <TextBlock Grid.Row="2" Grid.Column="0" Text="Partner 3:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="SupportUnitEditor_Partner3Nud_Input" FormatString="0" Grid.Row="2" Grid.Column="1" Name="Partner3Nud" Minimum="0" Maximum="255" Margin="0,2" />
-          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner3Name_Label" Grid.Row="2" Grid.Column="2" Name="Partner3NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" />
+          <NumericUpDown AutomationProperties.AutomationId="SupportUnitEditor_Partner3Nud_Input" FormatString="0" Grid.Row="2" Grid.Column="1" Name="Partner3Nud" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
+          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner3Name_Label" Grid.Row="2" Grid.Column="2" Name="Partner3NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" TextTrimming="CharacterEllipsis" />
           <Button AutomationProperties.AutomationId="SupportUnitEditor_Talk3_Button" Grid.Row="2" Grid.Column="3" Name="Talk3Button" Content="Talk" Margin="4,2,0,2" />
 
           <TextBlock Grid.Row="3" Grid.Column="0" Text="Partner 4:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="SupportUnitEditor_Partner4Nud_Input" FormatString="0" Grid.Row="3" Grid.Column="1" Name="Partner4Nud" Minimum="0" Maximum="255" Margin="0,2" />
-          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner4Name_Label" Grid.Row="3" Grid.Column="2" Name="Partner4NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" />
+          <NumericUpDown AutomationProperties.AutomationId="SupportUnitEditor_Partner4Nud_Input" FormatString="0" Grid.Row="3" Grid.Column="1" Name="Partner4Nud" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
+          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner4Name_Label" Grid.Row="3" Grid.Column="2" Name="Partner4NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" TextTrimming="CharacterEllipsis" />
           <Button AutomationProperties.AutomationId="SupportUnitEditor_Talk4_Button" Grid.Row="3" Grid.Column="3" Name="Talk4Button" Content="Talk" Margin="4,2,0,2" />
 
           <TextBlock Grid.Row="4" Grid.Column="0" Text="Partner 5:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="SupportUnitEditor_Partner5Nud_Input" FormatString="0" Grid.Row="4" Grid.Column="1" Name="Partner5Nud" Minimum="0" Maximum="255" Margin="0,2" />
-          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner5Name_Label" Grid.Row="4" Grid.Column="2" Name="Partner5NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" />
+          <NumericUpDown AutomationProperties.AutomationId="SupportUnitEditor_Partner5Nud_Input" FormatString="0" Grid.Row="4" Grid.Column="1" Name="Partner5Nud" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
+          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner5Name_Label" Grid.Row="4" Grid.Column="2" Name="Partner5NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" TextTrimming="CharacterEllipsis" />
           <Button AutomationProperties.AutomationId="SupportUnitEditor_Talk5_Button" Grid.Row="4" Grid.Column="3" Name="Talk5Button" Content="Talk" Margin="4,2,0,2" />
 
           <TextBlock Grid.Row="5" Grid.Column="0" Text="Partner 6:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="SupportUnitEditor_Partner6Nud_Input" FormatString="0" Grid.Row="5" Grid.Column="1" Name="Partner6Nud" Minimum="0" Maximum="255" Margin="0,2" />
-          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner6Name_Label" Grid.Row="5" Grid.Column="2" Name="Partner6NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" />
+          <NumericUpDown AutomationProperties.AutomationId="SupportUnitEditor_Partner6Nud_Input" FormatString="0" Grid.Row="5" Grid.Column="1" Name="Partner6Nud" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
+          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner6Name_Label" Grid.Row="5" Grid.Column="2" Name="Partner6NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" TextTrimming="CharacterEllipsis" />
           <Button AutomationProperties.AutomationId="SupportUnitEditor_Talk6_Button" Grid.Row="5" Grid.Column="3" Name="Talk6Button" Content="Talk" Margin="4,2,0,2" />
 
           <TextBlock Grid.Row="6" Grid.Column="0" Text="Partner 7:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="SupportUnitEditor_Partner7Nud_Input" FormatString="0" Grid.Row="6" Grid.Column="1" Name="Partner7Nud" Minimum="0" Maximum="255" Margin="0,2" />
-          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner7Name_Label" Grid.Row="6" Grid.Column="2" Name="Partner7NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" />
+          <NumericUpDown AutomationProperties.AutomationId="SupportUnitEditor_Partner7Nud_Input" FormatString="0" Grid.Row="6" Grid.Column="1" Name="Partner7Nud" Minimum="0" Maximum="255" Width="120" HorizontalAlignment="Left" Margin="0,2" />
+          <TextBlock AutomationProperties.AutomationId="SupportUnitEditor_Partner7Name_Label" Grid.Row="6" Grid.Column="2" Name="Partner7NameLabel" VerticalAlignment="Center" Margin="8,2,0,2" TextTrimming="CharacterEllipsis" />
           <Button AutomationProperties.AutomationId="SupportUnitEditor_Talk7_Button" Grid.Row="6" Grid.Column="3" Name="Talk7Button" Content="Talk" Margin="4,2,0,2" />
         </Grid>
 


### PR DESCRIPTION
## Summary

Cosmetic AXAML layout fixes for three Avalonia editors reported by @OrionNebula12 in discussion #1674 (Avalonia `ver_20260628.21`, macOS Tahoe / Apple Silicon M1, ROM FE8U). All three are **pure layout** changes â€” no ViewModel / Core / data behavior is touched. They follow the project's established `NumericUpDown` width convention (explicit `Width` + `HorizontalAlignment="Left"`, name labels trim with `CharacterEllipsis`, as in `WorldMapPointView.axaml`).

Plan reviewed and accepted by Copilot CLI on issue #1684 (one refinement applied: MoveCost NUD pinned at an explicit `Width=110` rather than relying on `MinWidth`, so the spinner buttons can't bleed within the 5-column budget).

## Fixes (before â†’ after)

### #1684 â€” `SupportUnitEditorView.axaml` (cramped columns)
- **Source Unit** row: name column `150 â†’ 220`, added `TextTrimming="CharacterEllipsis"` + right margin so the read-only name no longer butts against the **Open Unit** button.
- **Support Partners** grid: `ColumnDefinitions="80,100,150,60" â†’ "90,120,*,80"`. Each partner `NumericUpDown` gets `Width="120" HorizontalAlignment="Left"`; the name column becomes a star column with ellipsis trimming (was a fixed 150 that clipped long unit names); the **Talk** button column `60 â†’ 80`.

### #1685 â€” `MoveCostEditorView.axaml.cs` (`BuildTerrainGrid`)
The terrain grid is built in code-behind. Root cause: terrain-name `TextBlock` had a fixed `Width=140` (long names overflowed) and the NUD used `MinWidth=120` only (spinner buttons could bleed into the next row-pair).
- Terrain-name label: add `MaxWidth=140` + `TextTrimming=CharacterEllipsis` + right margin â€” names truncate cleanly instead of overflowing.
- Terrain NUD: replace `MinWidth=120` with explicit `Width=110` + `HorizontalAlignment=Left` â€” spinner stays inside the cell. Row spacing `4 â†’ 6`.

### #1686 â€” `MapExitPointView.axaml` (Coordinate/Direction/Flag compressed)
- Coordinate grid `ColumnDefinitions="160,40,80,40,80" â†’ "160,40,120,40,200"`: the X/Y/Direction/Flag NUDs now get â‰¥120px (was 80, cramped for a spinner) and the spanned Direction `ComboBox` (180px) / Flag-name `TextBox` get 240px of span (was only 120px â†’ overflow). All four NUDs `HorizontalAlignment="Left"`.
- `MapExitPointMainView.axaml` checked â€” it only renders an Address label (`140,*`), no compressed fields; **no change needed**.

## Scope
- Closes #1684
- Closes #1685
- Closes #1686

## GUI Test Report

This is a scoped cosmetic layout PR; per the task brief a hosted screenshot is not required (before/after described above). Validation is via `AvaloniaFact`/`Fact` layout-regression tests that parse each View source and assert the new layout constants are present, guarding against future re-cramping. Disk-constrained env (â‰ˆ6.6 GB free) â€” no full-app build; targeted test run only.

| Test | Result |
| --- | --- |
| `SupportUnitEditor_SourceUnitRow_NameColumnWidened_AndTrims` | PASS |
| `SupportUnitEditor_PartnersGrid_WidenedColumns_AndTrimmingLabels` | PASS |
| `MoveCostEditor_TerrainGridBuilder_TrimsNames_AndPinsNudWidth` | PASS |
| `MoveCostEditor_TerrainLabelTooltip_SetInCodeBehind` | PASS |
| `MapExitPoint_CoordinateGrid_WidenedColumns_AndLeftAlignedNuds` | PASS |

```
Passed!  - Failed: 0, Passed: 5, Skipped: 0, Total: 5 - FEBuilderGBA.Avalonia.Tests.dll (net9.0)
```

The new TextTrimming labels are covered by the existing #650 gate (`Issue650_AllTruncatedPreviewsHaveTooltipsExceptStatusBar`): each trimmed preview now self-binds a `ToolTip.Tip` (Support Unit AXAML) or has the tooltip mirrored in code-behind via `ToolTip.SetTip` (Move Cost). All 23 Issue650 tests pass locally.

Build of `FEBuilderGBA.Avalonia.Tests` (which references the changed `FEBuilderGBA.Avalonia` project) succeeded, confirming the new `HorizontalAlignment`/`TextTrimming` references resolve and the AXAML remains well-formed.

## Test plan
- [x] `FieldSpacingLayoutTests` (4 tests) added and passing locally
- [x] Avalonia project + test project compile (only pre-existing warnings)
- [x] `#1684` name columns widened + trimming asserted by test
- [x] `#1685` MoveCost grid-builder trims names + pins NUD width asserted by test
- [x] `#1686` Coordinate grid columns widened + NUDs left-aligned asserted by test
- [x] `MapExitPointMainView` confirmed not affected (no compressed fields)

Original request: review and reply discussions, create issues for reported bugs, resolve them via dev-flow
ðŸ¤– Generated with Claude Code (Opus 4.8, 1M context)
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

