### PR TITLE
fix(avalonia): Class/Item editor description overflow & overlap

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/ClassEditorDescOverflowLayoutTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ClassEditorDescOverflowLayoutTests.cs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Layout regression tests for ClassEditorView (#1682).
+//
+// Two AXAML-only fixes are guarded here:
+//   1. The content ScrollViewer (Grid.Column=1) must allow horizontal
+//      scrolling (HorizontalScrollBarVisibility=Auto) so the wider
+//      Pointers / Movement / Terrain rows (P60 Rain / P64 Snow etc.) can
+//      always be reached even when the editor is narrower than the content.
+//   2. The Identity / Misc grid's Desc-hosting column (Col 4) was 170px,
+//      too narrow for NumericUpDown(100) + DescTextLabel(MaxWidth=200) +
+//      "Desc" button + theme padding, so the Desc block overflowed and the
+//      far-right pointer fields became unreachable. The column was widened
+//      to 360px. This test proves the Desc block (DescTextLabel + the
+//      JumpToDesc "Desc" button) fits inside that column once arranged, and
+//      that the Movement/Terrain pointer inputs (Ptr60Box / Ptr64Box) exist.
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
+using Avalonia.VisualTree;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    /// <summary>
+    /// Regression for #1682: Class Editor description overflow / unreachable
+    /// pointer fields. Layout-only AXAML fix (ScrollViewer horizontal scroll +
+    /// widened Identity/Misc Desc column).
+    /// </summary>
+    public class ClassEditorDescOverflowLayoutTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public ClassEditorDescOverflowLayoutTests(ITestOutputHelper output) => _output = output;
+
+        /// <summary>
+        /// The content ScrollViewer (the one in Grid.Column=1 hosting the
+        /// editor body) must enable horizontal scrolling so widened pointer
+        /// rows remain reachable.
+        /// </summary>
+        [AvaloniaFact]
+        public void ContentScrollViewer_AllowsHorizontalScroll()
+        {
+            var view = new ClassEditorView();
+            var scroller = FindContentScrollViewer(view);
+            Assert.NotNull(scroller);
+            Assert.Equal(ScrollBarVisibility.Auto, scroller!.HorizontalScrollBarVisibility);
+        }
+
+        /// <summary>
+        /// The Movement / Terrain pointer inputs that were previously pushed
+        /// off-screen must exist (Ptr60 Rain / Ptr64 Snow are the fields
+        /// called out in #1682).
+        /// </summary>
+        [AvaloniaTheory]
+        [InlineData("Ptr60Box")]
+        [InlineData("Ptr64Box")]
+        public void MovementTerrain_PointerInputs_Exist(string controlName)
+        {
+            var view = new ClassEditorView();
+            var box = view.FindControl<TextBox>(controlName);
+            Assert.NotNull(box);
+        }
+
+        /// <summary>
+        /// After Measure + Arrange at a realistic editor size, the Identity /
+        /// Misc Desc block (DescTextLabel + the "Desc" jump button) must fit
+        /// horizontally inside the grid column it lives in — i.e. it must not
+        /// overflow past the column's right edge. We assert the Desc button's
+        /// right edge stays within the arranged width of the parent Grid that
+        /// hosts the Identity / Misc fields. Assertions stay tolerant of
+        /// sub-pixel layout rounding rather than over-fitting exact values.
+        /// </summary>
+        [AvaloniaFact]
+        public void IdentityMisc_DescBlock_DoesNotOverflowColumn()
+        {
+            var view = new ClassEditorView();
+            view.Show();
+            try
+            {
+                view.UpdateLayout();
+                view.Measure(new Size(1200, 900));
+                view.Arrange(new Rect(0, 0, 1200, 900));
+                view.UpdateLayout();
+
+                var descLabel = view.FindControl<TextBlock>("DescTextLabel");
+                var descButton = FindByContent<Button>(view, "Desc");
+                Assert.NotNull(descLabel);
+                Assert.NotNull(descButton);
+
+                // The Identity/Misc grid is the Grid ancestor of DescTextLabel
+                // that defines 5 columns (the widened one). Walk up to it.
+                var grid = descLabel!.GetVisualAncestors().OfType<Grid>()
+                    .FirstOrDefault(g => g.ColumnDefinitions.Count == 5);
+                Assert.NotNull(grid);
+
+                // Translate the Desc button's right edge into the grid's
+                // coordinate space; it must not exceed the grid's width.
+                var rightEdge = descButton!.TranslatePoint(
+                    new Point(descButton.Bounds.Width, 0), grid!);
+                Assert.NotNull(rightEdge);
+
+                double gridWidth = grid!.Bounds.Width;
+                _output.WriteLine(
+                    $"Desc button right edge X = {rightEdge!.Value.X:F1}, grid width = {gridWidth:F1}");
+
+                // Allow 1px tolerance for layout rounding.
+                Assert.True(rightEdge.Value.X <= gridWidth + 1.0,
+                    $"Desc block right edge ({rightEdge.Value.X:F1}) overflows the " +
+                    $"Identity/Misc grid width ({gridWidth:F1}). The Desc column is too narrow.");
+            }
+            finally
+            {
+                view.Close();
+            }
+        }
+
+        // ---------------------------------------------------------------
+        // Helpers
+        // ---------------------------------------------------------------
+
+        /// <summary>
+        /// The content ScrollViewer is the one placed in Grid.Column=1 of the
+        /// root grid (the editor body host). Pick the ScrollViewer whose
+        /// Grid.Column attached value is 1. Uses the logical tree so the
+        /// control resolves even before the view is shown/realized.
+        /// </summary>
+        private static ScrollViewer? FindContentScrollViewer(Control root)
+        {
+            return root.GetLogicalDescendants()
+                .OfType<ScrollViewer>()
+                .FirstOrDefault(sv => Grid.GetColumn(sv) == 1)
+                ?? root.GetLogicalDescendants().OfType<ScrollViewer>().FirstOrDefault();
+        }
+
+        private static T? FindByContent<T>(Control root, string content) where T : ContentControl
+        {
+            return root.GetVisualDescendants()
+                .OfType<T>()
+                .FirstOrDefault(c => c.Content as string == content);
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/ItemEditorDescOverflowLayoutTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ItemEditorDescOverflowLayoutTests.cs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Layout regression tests for ItemEditorView (#1683).
+//
+// Two AXAML-only fixes are guarded here:
+//   1. The content ScrollViewer (Grid.Column=1) must allow horizontal
+//      scrolling (HorizontalScrollBarVisibility=Auto) so widened Basic Info
+//      rows remain reachable when the editor is narrower than its content.
+//   2. The Basic Info grid's two value columns (Col 1 and Col 4) were 200px,
+//      too narrow for NumericUpDown(100) + DescTextLabel(MaxWidth=160) +
+//      "Desc" button + padding, so the Desc / mini-desc block overflowed and
+//      overlapped the adjacent "Use Desc (W4):" label. Both columns were
+//      widened to 320px. This test proves the DescId block no longer
+//      horizontally overlaps the UseDescId_Link label after arrange.
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
+using Avalonia.VisualTree;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    /// <summary>
+    /// Regression for #1683: Item Editor Basic Info description block overflow
+    /// overlapping the "Use Desc (W4):" label. Layout-only AXAML fix
+    /// (ScrollViewer horizontal scroll + widened Basic Info value columns).
+    /// </summary>
+    public class ItemEditorDescOverflowLayoutTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public ItemEditorDescOverflowLayoutTests(ITestOutputHelper output) => _output = output;
+
+        /// <summary>
+        /// The content ScrollViewer (the one in Grid.Column=1 hosting the
+        /// editor body) must enable horizontal scrolling.
+        /// </summary>
+        [AvaloniaFact]
+        public void ContentScrollViewer_AllowsHorizontalScroll()
+        {
+            var view = new ItemEditorView();
+            var scroller = FindContentScrollViewer(view);
+            Assert.NotNull(scroller);
+            Assert.Equal(ScrollBarVisibility.Auto, scroller!.HorizontalScrollBarVisibility);
+        }
+
+        /// <summary>
+        /// After Measure + Arrange at a realistic editor size, the DescId
+        /// block (the StackPanel hosting DescIdBox + DescTextLabel + "Desc"
+        /// button) must not horizontally overlap the "Use Desc (W4):" label
+        /// (UseDescId_Link) that sits in the next column pair. We translate
+        /// both into the shared Basic Info grid coordinate space and assert
+        /// the DescId block's right edge stays left of the UseDescId_Link
+        /// label's left edge. Assertions tolerate sub-pixel layout rounding.
+        /// </summary>
+        [AvaloniaFact]
+        public void BasicInfo_DescBlock_DoesNotOverlapUseDescLabel()
+        {
+            var view = new ItemEditorView();
+            view.Show();
+            try
+            {
+                view.UpdateLayout();
+                view.Measure(new Size(1408, 856));
+                view.Arrange(new Rect(0, 0, 1408, 856));
+                view.UpdateLayout();
+
+                var descBox = view.FindControl<NumericUpDown>("DescIdBox");
+                var useDescLabel = view.FindControl<TextBlock>("UseDescId_Link");
+                Assert.NotNull(descBox);
+                Assert.NotNull(useDescLabel);
+
+                // The DescId value block is the StackPanel hosting DescIdBox.
+                var descBlock = descBox!.GetVisualAncestors().OfType<StackPanel>().FirstOrDefault();
+                Assert.NotNull(descBlock);
+
+                // Shared ancestor: the Basic Info grid (5 columns).
+                var grid = descBox.GetVisualAncestors().OfType<Grid>()
+                    .FirstOrDefault(g => g.ColumnDefinitions.Count == 5);
+                Assert.NotNull(grid);
+
+                var descRight = descBlock!.TranslatePoint(
+                    new Point(descBlock.Bounds.Width, 0), grid!);
+                var useDescLeft = useDescLabel!.TranslatePoint(new Point(0, 0), grid!);
+                Assert.NotNull(descRight);
+                Assert.NotNull(useDescLeft);
+
+                _output.WriteLine(
+                    $"DescId block right edge X = {descRight!.Value.X:F1}, " +
+                    $"UseDesc label left edge X = {useDescLeft!.Value.X:F1}");
+
+                // Allow 1px tolerance for layout rounding.
+                Assert.True(descRight.Value.X <= useDescLeft.Value.X + 1.0,
+                    $"DescId block right edge ({descRight.Value.X:F1}) overlaps the " +
+                    $"'Use Desc (W4):' label left edge ({useDescLeft.Value.X:F1}). " +
+                    "The Basic Info Desc column is too narrow.");
+            }
+            finally
+            {
+                view.Close();
+            }
+        }
+
+        // ---------------------------------------------------------------
+        // Helpers
+        // ---------------------------------------------------------------
+
+        /// <summary>
+        /// The content ScrollViewer is the one placed in Grid.Column=1 of the
+        /// root grid (the editor body host). Uses the logical tree so the
+        /// control resolves even before the view is shown/realized.
+        /// </summary>
+        private static ScrollViewer? FindContentScrollViewer(Control root)
+        {
+            return root.GetLogicalDescendants()
+                .OfType<ScrollViewer>()
+                .FirstOrDefault(sv => Grid.GetColumn(sv) == 1)
+                ?? root.GetLogicalDescendants().OfType<ScrollViewer>().FirstOrDefault();
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/Views/ClassEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ClassEditorView.axaml
@@ -21,7 +21,7 @@
       </Border>
     </Grid>
 
-    <ScrollViewer Grid.Column="1" Margin="4">
+    <ScrollViewer Grid.Column="1" Margin="4" HorizontalScrollBarVisibility="Auto">
       <StackPanel Spacing="4" Margin="8">
         <TextBlock Text="Class Editor" FontSize="18" FontWeight="Bold" />
 
@@ -92,7 +92,7 @@
         <!-- Identity / Misc -->
         <Expander AutomationProperties.AutomationId="ClassEditor_IdentityMisc_Expander" Header="Identity / Misc" IsExpanded="True" Margin="0,4,0,2">
         <Border BorderBrush="Gray" BorderThickness="1" Padding="8" CornerRadius="4">
-          <Grid ColumnDefinitions="130,170,20,130,170" RowDefinitions="Auto,Auto,Auto,Auto">
+          <Grid ColumnDefinitions="130,170,20,130,360" RowDefinitions="Auto,Auto,Auto,Auto">
             <TextBlock Grid.Row="0" Grid.Column="0" Text="Name ID (W0):" VerticalAlignment="Center"
                        AutomationProperties.AutomationId="ClassEditor_NameId_Link"
                        Classes="Hyperlink" Name="NameId_Link" PointerPressed="OnNameIdLinkClick"

--- a/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml
@@ -21,7 +21,7 @@
       </Border>
     </Grid>
 
-    <ScrollViewer Grid.Column="1" Margin="4">
+    <ScrollViewer Grid.Column="1" Margin="4" HorizontalScrollBarVisibility="Auto">
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="Item Editor" FontSize="18" FontWeight="Bold" />
 
@@ -49,7 +49,7 @@
         <!-- Basic Info -->
         <Expander AutomationProperties.AutomationId="ItemEditor_BasicInfo_Expander" Header="Basic Info" IsExpanded="True" Margin="0,4,0,2">
         <Border BorderBrush="Gray" BorderThickness="1" Padding="8" CornerRadius="4">
-        <Grid ColumnDefinitions="140,200,20,140,200" RowDefinitions="Auto,Auto,Auto">
+        <Grid ColumnDefinitions="140,320,20,140,320" RowDefinitions="Auto,Auto,Auto">
           <TextBlock Grid.Row="0" Grid.Column="0" Text="Name ID (W0):" VerticalAlignment="Center"
                      AutomationProperties.AutomationId="ItemEditor_NameId_Link"
                      Classes="Hyperlink" Name="NameId_Link" PointerPressed="OnNameIdLinkClick"


### PR DESCRIPTION
## Summary

Two layout-only AXAML fixes for the Avalonia editors. No code-behind, Core, or behavior changes — purely grid/scroll geometry.

### Fix A — Class Editor (#1682)
Before: the content `ScrollViewer` had no horizontal scroll, and the Identity / Misc grid's Desc-hosting column (Col 4) was only 170px — too narrow for `NumericUpDown(Width=100)` + `DescTextLabel(MaxWidth=200)` + the "Desc" button + theme padding. The Desc block overflowed its column, and the Pointers / Movement / Terrain fields (notably **P60 Move Cost Rain** and **P64 Move Cost Snow**) became unreachable.

After: `HorizontalScrollBarVisibility="Auto"` was added to the content `ScrollViewer`, and the Identity / Misc grid's last column was widened `170 -> 360px` (only that grid's `ColumnDefinitions` changed). The Desc block now fits, and the pointer rows stay reachable.

### Fix B — Item Editor (#1683)
Before: in the Basic Info grid the Desc / mini-desc block overflowed its 200px value column and overlapped the **"Use Desc (W4):"** label in the next column pair.

After: `HorizontalScrollBarVisibility="Auto"` was added to the content `ScrollViewer`, and the Basic Info grid's **both** value columns (Col 1 and Col 4 — they host the same Desc/UseDesc block layout) were widened symmetrically `200 -> 320px` (only that grid's `ColumnDefinitions` changed). The Desc block no longer overlaps the UseDesc label.

Both fixes are minimal: exactly one `ScrollViewer` attribute and one grid's `ColumnDefinitions` per file.

> No hosted screenshot is included: the title is `fix(...)`-scoped and the coordinator runs a **consolidated visual screenshot pass after merge** (per the task instructions). The AvaloniaFact bounds assertions below provide the functional proof that the overflow/overlap is resolved.

## Docs
No docs change. `CHANGELOG.md` is **auto-generated from Conventional-Commit subjects** (its `[Unreleased]` section is regenerated by `scripts/generate-changelog.sh`), so this `fix(avalonia):` commit is picked up automatically; a hand-typed entry would conflict with the generator. The other `docs/avalonia-*` files are gap-analysis/audit artifacts, not a per-fix changelog. Nothing else fit cleanly.

Closes #1682
Closes #1683

## Test plan
- [x] Added `FEBuilderGBA.Avalonia.Tests/ClassEditorDescOverflowLayoutTests.cs` (4 cases) and `FEBuilderGBA.Avalonia.Tests/ItemEditorDescOverflowLayoutTests.cs` (2 cases) — headless `AvaloniaFact` tests.
- [x] Built `FEBuilderGBA.Avalonia.Tests` locally (`dotnet build -c Debug`): 0 errors (pre-existing warnings only).
- [x] Ran the 6 new tests locally with `--filter` on the two new classes: **6 passed, 0 failed, 0 skipped** (Duration ~1 s).
- [x] `ClassEditor` — content `ScrollViewer` (Grid.Column=1) asserts `HorizontalScrollBarVisibility == ScrollBarVisibility.Auto`.
- [x] `ClassEditor` — `Ptr60Box` and `Ptr64Box` (the P60 Rain / P64 Snow pointer inputs called out in #1682) resolve via `FindControl`.
- [x] `ClassEditor` — after `Measure(1200x900)` + `Arrange`, the Identity/Misc Desc "Desc" button's right edge stays within the 5-column grid's arranged width (no column overflow; 1px rounding tolerance).
- [x] `ItemEditor` — content `ScrollViewer` (Grid.Column=1) asserts `HorizontalScrollBarVisibility == ScrollBarVisibility.Auto`.
- [x] `ItemEditor` — after `Measure(1408x856)` + `Arrange`, the DescId block's right edge stays left of the `UseDescId_Link` ("Use Desc (W4):") label's left edge (no horizontal overlap; 1px rounding tolerance).

## GUI Test Report

These are headless Avalonia GUI tests (`[AvaloniaFact]`) that instantiate the real Views, realize layout with `Show()` + `Measure`/`Arrange`, and assert geometry. Run locally with `dotnet test --no-build --filter`.

| # | Test | Asserts | Result |
|---|------|---------|--------|
| 1 | `ClassEditorDescOverflowLayoutTests.ContentScrollViewer_AllowsHorizontalScroll` | Class content ScrollViewer `HorizontalScrollBarVisibility == Auto` | PASS |
| 2 | `ClassEditorDescOverflowLayoutTests.MovementTerrain_PointerInputs_Exist(Ptr60Box)` | P60 Rain pointer input resolves | PASS |
| 3 | `ClassEditorDescOverflowLayoutTests.MovementTerrain_PointerInputs_Exist(Ptr64Box)` | P64 Snow pointer input resolves | PASS |
| 4 | `ClassEditorDescOverflowLayoutTests.IdentityMisc_DescBlock_DoesNotOverflowColumn` | Desc button right edge within Identity/Misc grid width after Arrange | PASS |
| 5 | `ItemEditorDescOverflowLayoutTests.ContentScrollViewer_AllowsHorizontalScroll` | Item content ScrollViewer `HorizontalScrollBarVisibility == Auto` | PASS |
| 6 | `ItemEditorDescOverflowLayoutTests.BasicInfo_DescBlock_DoesNotOverlapUseDescLabel` | DescId block right edge left of UseDesc label left edge after Arrange | PASS |

Total: **6 passed / 0 failed / 0 skipped.** The consolidated visual screenshot pass is run by the coordinator post-merge per the task instructions.

Original request: review and reply discussions, create issues for reported bugs, resolve them via dev-flow
🤖 Generated with Claude Code (Opus 4.8, 1M context)
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
