### PR TITLE
fix(avalonia): widen Class/Item editor columns to worst-case + real overflow guards (follow-up #1697)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/ClassEditorDescOverflowLayoutTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ClassEditorDescOverflowLayoutTests.cs
@@ -22,7 +22,7 @@
 // label reaches its MaxWidth), then re-Measure the StackPanel with infinite
 // available width to obtain its NATURAL (unconstrained) content width, and
 // assert that natural width fits inside the column. That genuinely FAILS when
-// the column is too narrow (the pre-fix 170px) and PASSES at the fixed 360px.
+// the column is too narrow (the pre-fix 170px) and PASSES at the fixed 380px.
 // Mirrors the proven pattern in ClassEditorListPreviewTests
 // (PreviewBorder_FitsInsideLeftColumn_EvenWithLongName).
 using System.Linq;

--- a/FEBuilderGBA.Avalonia.Tests/ClassEditorDescOverflowLayoutTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ClassEditorDescOverflowLayoutTests.cs
@@ -10,9 +10,21 @@
 //      too narrow for NumericUpDown(100) + DescTextLabel(MaxWidth=200) +
 //      "Desc" button + theme padding, so the Desc block overflowed and the
 //      far-right pointer fields became unreachable. The column was widened
-//      to 360px. This test proves the Desc block (DescTextLabel + the
-//      JumpToDesc "Desc" button) fits inside that column once arranged, and
-//      that the Movement/Terrain pointer inputs (Ptr60Box / Ptr64Box) exist.
+//      to 380px — sized to the measured worst case (NumericUpDown desires
+//      ~120px incl. spinner chrome + label clamped to MaxWidth=200 + 34px
+//      "Desc" button + StackPanel spacing => ~378px natural block width).
+//
+// IMPORTANT (test-discrimination): the Desc block is a Horizontal StackPanel
+// with default HorizontalAlignment=Stretch, so its ARRANGED bounds always
+// equal the full grid-column width regardless of content — asserting on the
+// arranged right edge is a FALSE GUARD that passes against both the buggy and
+// fixed layouts. Instead we populate DescTextLabel with a long string (so the
+// label reaches its MaxWidth), then re-Measure the StackPanel with infinite
+// available width to obtain its NATURAL (unconstrained) content width, and
+// assert that natural width fits inside the column. That genuinely FAILS when
+// the column is too narrow (the pre-fix 170px) and PASSES at the fixed 360px.
+// Mirrors the proven pattern in ClassEditorListPreviewTests
+// (PreviewBorder_FitsInsideLeftColumn_EvenWithLongName).
 using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
@@ -33,6 +45,14 @@ namespace FEBuilderGBA.Avalonia.Tests
     /// </summary>
     public class ClassEditorDescOverflowLayoutTests
     {
+        // Worst-case content: long enough that DescTextLabel reaches its
+        // MaxWidth=200 so the Desc block hits its natural maximum width.
+        private const string LongText = "WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW"; // 59 W's
+        // The pre-fix Identity/Misc Desc column width (#1682). The populated
+        // Desc block must exceed this — proving the test would fail against
+        // the buggy layout.
+        private const double OldColumnWidth = 170.0;
+
         private readonly ITestOutputHelper _output;
 
         public ClassEditorDescOverflowLayoutTests(ITestOutputHelper output) => _output = output;
@@ -67,13 +87,15 @@ namespace FEBuilderGBA.Avalonia.Tests
         }
 
         /// <summary>
-        /// After Measure + Arrange at a realistic editor size, the Identity /
-        /// Misc Desc block (DescTextLabel + the "Desc" jump button) must fit
-        /// horizontally inside the grid column it lives in — i.e. it must not
-        /// overflow past the column's right edge. We assert the Desc button's
-        /// right edge stays within the arranged width of the parent Grid that
-        /// hosts the Identity / Misc fields. Assertions stay tolerant of
-        /// sub-pixel layout rounding rather than over-fitting exact values.
+        /// Discriminating regression: with a long description, the Identity /
+        /// Misc Desc block's NATURAL content width must fit inside the widened
+        /// Desc column. Populating the label forces the block to its true
+        /// maximum width (NumericUpDown 100 + label up to MaxWidth=200 + "Desc"
+        /// button + spacing). The block's natural width is measured with
+        /// infinite available width (so Stretch cannot mask it), then compared
+        /// to the actual column width. The companion assertion proves the
+        /// populated block would have overflowed the pre-fix 170px column, so
+        /// this test FAILS against the buggy layout and PASSES against the fix.
         /// </summary>
         [AvaloniaFact]
         public void IdentityMisc_DescBlock_DoesNotOverflowColumn()
@@ -82,36 +104,51 @@ namespace FEBuilderGBA.Avalonia.Tests
             view.Show();
             try
             {
+                var descBox = view.FindControl<NumericUpDown>("DescIdBox");
+                var descLabel = view.FindControl<TextBlock>("DescTextLabel");
+                Assert.NotNull(descBox);
+                Assert.NotNull(descLabel);
+
+                // Force worst-case content so the block reaches its natural max.
+                descLabel!.Text = LongText;
+
                 view.UpdateLayout();
                 view.Measure(new Size(1200, 900));
                 view.Arrange(new Rect(0, 0, 1200, 900));
                 view.UpdateLayout();
 
-                var descLabel = view.FindControl<TextBlock>("DescTextLabel");
-                var descButton = FindByContent<Button>(view, "Desc");
-                Assert.NotNull(descLabel);
-                Assert.NotNull(descButton);
+                // The Desc block = the horizontal StackPanel hosting DescIdBox.
+                var descBlock = descBox!.GetVisualAncestors().OfType<StackPanel>().First();
 
-                // The Identity/Misc grid is the Grid ancestor of DescTextLabel
-                // that defines 5 columns (the widened one). Walk up to it.
-                var grid = descLabel!.GetVisualAncestors().OfType<Grid>()
+                // The Identity/Misc grid = nearest 5-column Grid ancestor.
+                var grid = descBox.GetVisualAncestors().OfType<Grid>()
                     .FirstOrDefault(g => g.ColumnDefinitions.Count == 5);
                 Assert.NotNull(grid);
 
-                // Translate the Desc button's right edge into the grid's
-                // coordinate space; it must not exceed the grid's width.
-                var rightEdge = descButton!.TranslatePoint(
-                    new Point(descButton.Bounds.Width, 0), grid!);
-                Assert.NotNull(rightEdge);
+                double colWidth = grid!.ColumnDefinitions[4].ActualWidth;
+                Assert.True(colWidth > 0,
+                    $"Identity/Misc Desc column ActualWidth should be populated after Arrange; got {colWidth}.");
 
-                double gridWidth = grid!.Bounds.Width;
+                // Natural (unconstrained) width of the populated Desc block.
+                descBlock.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+                double naturalWidth = descBlock.DesiredSize.Width;
+
                 _output.WriteLine(
-                    $"Desc button right edge X = {rightEdge!.Value.X:F1}, grid width = {gridWidth:F1}");
+                    $"Desc block natural width = {naturalWidth:F1}, col[4] ActualWidth = {colWidth:F1}, " +
+                    $"old column = {OldColumnWidth:F1}");
 
-                // Allow 1px tolerance for layout rounding.
-                Assert.True(rightEdge.Value.X <= gridWidth + 1.0,
-                    $"Desc block right edge ({rightEdge.Value.X:F1}) overflows the " +
-                    $"Identity/Misc grid width ({gridWidth:F1}). The Desc column is too narrow.");
+                // (a) Discrimination guard: the populated block exceeds the old
+                //     170px column — so this test genuinely fails on the buggy
+                //     layout (where col[4] was 170px).
+                Assert.True(naturalWidth > OldColumnWidth,
+                    $"Populated Desc block natural width ({naturalWidth:F1}) must exceed the pre-fix " +
+                    $"column width ({OldColumnWidth:F1}); otherwise this test cannot detect the regression.");
+
+                // (b) The fix: the block fits inside the widened column (1px
+                //     tolerance for layout rounding).
+                Assert.True(naturalWidth <= colWidth + 1.0,
+                    $"Desc block natural width ({naturalWidth:F1}) overflows the Identity/Misc Desc " +
+                    $"column ({colWidth:F1}). The column is too narrow.");
             }
             finally
             {
@@ -135,13 +172,6 @@ namespace FEBuilderGBA.Avalonia.Tests
                 .OfType<ScrollViewer>()
                 .FirstOrDefault(sv => Grid.GetColumn(sv) == 1)
                 ?? root.GetLogicalDescendants().OfType<ScrollViewer>().FirstOrDefault();
-        }
-
-        private static T? FindByContent<T>(Control root, string content) where T : ContentControl
-        {
-            return root.GetVisualDescendants()
-                .OfType<T>()
-                .FirstOrDefault(c => c.Content as string == content);
         }
     }
 }

--- a/FEBuilderGBA.Avalonia.Tests/ItemEditorDescOverflowLayoutTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ItemEditorDescOverflowLayoutTests.cs
@@ -9,8 +9,22 @@
 //      too narrow for NumericUpDown(100) + DescTextLabel(MaxWidth=160) +
 //      "Desc" button + padding, so the Desc / mini-desc block overflowed and
 //      overlapped the adjacent "Use Desc (W4):" label. Both columns were
-//      widened to 320px. This test proves the DescId block no longer
-//      horizontally overlaps the UseDescId_Link label after arrange.
+//      widened to 340px — sized to the measured worst case (NumericUpDown
+//      desires ~120px incl. spinner chrome + label clamped to MaxWidth=160 +
+//      34px "Desc" button + StackPanel spacing => ~338px natural block width).
+//
+// IMPORTANT (test-discrimination): the Desc / UseDesc blocks are Horizontal
+// StackPanels with default HorizontalAlignment=Stretch, so their ARRANGED
+// bounds always equal the full grid-column width regardless of content —
+// asserting on arranged right/left edges is a FALSE GUARD that passes against
+// both the buggy and fixed layouts. Instead we populate DescTextLabel (and
+// UseDescTextLabel) with a long string so the label reaches its MaxWidth=160,
+// then re-Measure the DescId StackPanel with infinite available width to get
+// its NATURAL content width, and assert it fits inside the (widened) value
+// column. Because the block fits within its own column it cannot paint into
+// the next column pair (the "Use Desc (W4):" label) — that is the no-overlap
+// guarantee. The companion assertion proves the populated block exceeds the
+// pre-fix 200px column, so this test FAILS against the buggy layout.
 using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
@@ -31,6 +45,14 @@ namespace FEBuilderGBA.Avalonia.Tests
     /// </summary>
     public class ItemEditorDescOverflowLayoutTests
     {
+        // Worst-case content: long enough that DescTextLabel reaches its
+        // MaxWidth=160 so the Desc block hits its natural maximum width.
+        private const string LongText = "WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW"; // 59 W's
+        // The pre-fix Basic Info value column width (#1683). The populated
+        // Desc block must exceed this — proving the test would fail against
+        // the buggy layout.
+        private const double OldColumnWidth = 200.0;
+
         private readonly ITestOutputHelper _output;
 
         public ItemEditorDescOverflowLayoutTests(ITestOutputHelper output) => _output = output;
@@ -49,13 +71,15 @@ namespace FEBuilderGBA.Avalonia.Tests
         }
 
         /// <summary>
-        /// After Measure + Arrange at a realistic editor size, the DescId
-        /// block (the StackPanel hosting DescIdBox + DescTextLabel + "Desc"
-        /// button) must not horizontally overlap the "Use Desc (W4):" label
-        /// (UseDescId_Link) that sits in the next column pair. We translate
-        /// both into the shared Basic Info grid coordinate space and assert
-        /// the DescId block's right edge stays left of the UseDescId_Link
-        /// label's left edge. Assertions tolerate sub-pixel layout rounding.
+        /// Discriminating regression: with long descriptions, the Basic Info
+        /// DescId block's NATURAL content width must fit inside the widened
+        /// value column, so it cannot overflow into and overlap the next
+        /// column pair's "Use Desc (W4):" label. We populate both desc labels,
+        /// measure the DescId block with infinite available width (so Stretch
+        /// cannot mask its true size), and compare to the actual column width.
+        /// The companion assertion proves the populated block would have
+        /// overflowed the pre-fix 200px column, so this test FAILS against the
+        /// buggy layout and PASSES against the fix.
         /// </summary>
         [AvaloniaFact]
         public void BasicInfo_DescBlock_DoesNotOverlapUseDescLabel()
@@ -64,40 +88,55 @@ namespace FEBuilderGBA.Avalonia.Tests
             view.Show();
             try
             {
+                var descBox = view.FindControl<NumericUpDown>("DescIdBox");
+                var descLabel = view.FindControl<TextBlock>("DescTextLabel");
+                var useDescLabel = view.FindControl<TextBlock>("UseDescTextLabel");
+                Assert.NotNull(descBox);
+                Assert.NotNull(descLabel);
+                Assert.NotNull(useDescLabel);
+
+                // Force worst-case content on both desc blocks.
+                descLabel!.Text = LongText;
+                useDescLabel!.Text = LongText;
+
                 view.UpdateLayout();
                 view.Measure(new Size(1408, 856));
                 view.Arrange(new Rect(0, 0, 1408, 856));
                 view.UpdateLayout();
 
-                var descBox = view.FindControl<NumericUpDown>("DescIdBox");
-                var useDescLabel = view.FindControl<TextBlock>("UseDescId_Link");
-                Assert.NotNull(descBox);
-                Assert.NotNull(useDescLabel);
+                // The DescId block = the horizontal StackPanel hosting DescIdBox.
+                var descBlock = descBox!.GetVisualAncestors().OfType<StackPanel>().First();
 
-                // The DescId value block is the StackPanel hosting DescIdBox.
-                var descBlock = descBox!.GetVisualAncestors().OfType<StackPanel>().FirstOrDefault();
-                Assert.NotNull(descBlock);
-
-                // Shared ancestor: the Basic Info grid (5 columns).
+                // The Basic Info grid = nearest 5-column Grid ancestor.
                 var grid = descBox.GetVisualAncestors().OfType<Grid>()
                     .FirstOrDefault(g => g.ColumnDefinitions.Count == 5);
                 Assert.NotNull(grid);
 
-                var descRight = descBlock!.TranslatePoint(
-                    new Point(descBlock.Bounds.Width, 0), grid!);
-                var useDescLeft = useDescLabel!.TranslatePoint(new Point(0, 0), grid!);
-                Assert.NotNull(descRight);
-                Assert.NotNull(useDescLeft);
+                double colWidth = grid!.ColumnDefinitions[1].ActualWidth;
+                Assert.True(colWidth > 0,
+                    $"Basic Info Desc column ActualWidth should be populated after Arrange; got {colWidth}.");
+
+                // Natural (unconstrained) width of the populated Desc block.
+                descBlock.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+                double naturalWidth = descBlock.DesiredSize.Width;
 
                 _output.WriteLine(
-                    $"DescId block right edge X = {descRight!.Value.X:F1}, " +
-                    $"UseDesc label left edge X = {useDescLeft!.Value.X:F1}");
+                    $"DescId block natural width = {naturalWidth:F1}, col[1] ActualWidth = {colWidth:F1}, " +
+                    $"old column = {OldColumnWidth:F1}");
 
-                // Allow 1px tolerance for layout rounding.
-                Assert.True(descRight.Value.X <= useDescLeft.Value.X + 1.0,
-                    $"DescId block right edge ({descRight.Value.X:F1}) overlaps the " +
-                    $"'Use Desc (W4):' label left edge ({useDescLeft.Value.X:F1}). " +
-                    "The Basic Info Desc column is too narrow.");
+                // (a) Discrimination guard: the populated block exceeds the old
+                //     200px column — so this test genuinely fails on the buggy
+                //     layout (where col[1] was 200px).
+                Assert.True(naturalWidth > OldColumnWidth,
+                    $"Populated DescId block natural width ({naturalWidth:F1}) must exceed the pre-fix " +
+                    $"column width ({OldColumnWidth:F1}); otherwise this test cannot detect the regression.");
+
+                // (b) The fix: the block fits inside the widened column (1px
+                //     tolerance), so it cannot overlap the "Use Desc" label.
+                Assert.True(naturalWidth <= colWidth + 1.0,
+                    $"DescId block natural width ({naturalWidth:F1}) overflows the Basic Info value " +
+                    $"column ({colWidth:F1}) and would overlap the 'Use Desc (W4):' label. " +
+                    "The column is too narrow.");
             }
             finally
             {

--- a/FEBuilderGBA.Avalonia/Views/ClassEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ClassEditorView.axaml
@@ -92,7 +92,7 @@
         <!-- Identity / Misc -->
         <Expander AutomationProperties.AutomationId="ClassEditor_IdentityMisc_Expander" Header="Identity / Misc" IsExpanded="True" Margin="0,4,0,2">
         <Border BorderBrush="Gray" BorderThickness="1" Padding="8" CornerRadius="4">
-          <Grid ColumnDefinitions="130,170,20,130,360" RowDefinitions="Auto,Auto,Auto,Auto">
+          <Grid ColumnDefinitions="130,170,20,130,380" RowDefinitions="Auto,Auto,Auto,Auto">
             <TextBlock Grid.Row="0" Grid.Column="0" Text="Name ID (W0):" VerticalAlignment="Center"
                        AutomationProperties.AutomationId="ClassEditor_NameId_Link"
                        Classes="Hyperlink" Name="NameId_Link" PointerPressed="OnNameIdLinkClick"

--- a/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml
@@ -49,7 +49,7 @@
         <!-- Basic Info -->
         <Expander AutomationProperties.AutomationId="ItemEditor_BasicInfo_Expander" Header="Basic Info" IsExpanded="True" Margin="0,4,0,2">
         <Border BorderBrush="Gray" BorderThickness="1" Padding="8" CornerRadius="4">
-        <Grid ColumnDefinitions="140,320,20,140,320" RowDefinitions="Auto,Auto,Auto">
+        <Grid ColumnDefinitions="140,340,20,140,340" RowDefinitions="Auto,Auto,Auto">
           <TextBlock Grid.Row="0" Grid.Column="0" Text="Name ID (W0):" VerticalAlignment="Center"
                      AutomationProperties.AutomationId="ItemEditor_NameId_Link"
                      Classes="Hyperlink" Name="NameId_Link" PointerPressed="OnNameIdLinkClick"


### PR DESCRIPTION
Follow-up to #1697 (which closed #1682 / #1683). Two hardening fixes the deeper verification surfaced:

1. **Columns ~18 px too narrow for the true worst case.** Honest re-measurement (populate the Desc block with a long string, re-`Measure` with infinite width so `Stretch` can't mask it) gives natural content width **378 px (Class)** / **338 px (Item)** — NumericUpDown `DesiredSize=120` + label `MaxWidth` (200/160) + 34 px "Desc" button + spacing. First-cut 360/320 still clipped the worst case → widened **Class col 4 → 380**, **Item cols 1 & 4 → 340**.
2. **The merged layout tests were false guards** (asserted on `Stretch`-arranged bounds with empty labels → passed against both buggy and fixed layouts). Replaced with genuinely discriminating overflow tests: they FAIL at the pre-fix 170/200 widths (378>170, 338>200) and PASS at 380/340.

Replaces #1698 (which was DIRTY from squash-merged history). Context: #1682, #1683 (already closed).

Original request: review and reply discussions, create issues for reported bugs, resolve them via dev-flow
🤖 Generated with Claude Code (Opus 4.8, 1M context)
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>