### PR TITLE
fix(avalonia): size AI Script Address button & fix Palette number cropping

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/PaletteAndAIScriptLayoutTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/PaletteAndAIScriptLayoutTests.cs
@@ -28,26 +28,25 @@ namespace FEBuilderGBA.Avalonia.Tests
     /// </summary>
     public class PaletteAndAIScriptLayoutTests
     {
-        private static string FindProjectRoot()
+        // Walk parents of a starting directory looking for the solution file.
+        // Copilot review (#1700): replaces the earlier fixed-depth(12) double
+        // loop with an unbounded DirectoryInfo parent-walk, keeping the same
+        // BaseDirectory -> CWD fallback order.
+        private static string? WalkForSln(string? start)
         {
-            string dir = AppDomain.CurrentDomain.BaseDirectory;
-            for (int i = 0; i < 12; i++)
+            for (DirectoryInfo? d = start == null ? null : new DirectoryInfo(start);
+                 d != null; d = d.Parent)
             {
-                if (File.Exists(Path.Combine(dir, "FEBuilderGBA.sln"))) return dir;
-                string? parent = Path.GetDirectoryName(dir);
-                if (parent == null || parent == dir) break;
-                dir = parent;
+                if (File.Exists(Path.Combine(d.FullName, "FEBuilderGBA.sln")))
+                    return d.FullName;
             }
-            string cwd = Directory.GetCurrentDirectory();
-            for (int i = 0; i < 12; i++)
-            {
-                if (File.Exists(Path.Combine(cwd, "FEBuilderGBA.sln"))) return cwd;
-                string? parent = Path.GetDirectoryName(cwd);
-                if (parent == null || parent == cwd) break;
-                cwd = parent;
-            }
-            throw new InvalidOperationException("Could not find project root (FEBuilderGBA.sln)");
+            return null;
         }
+
+        private static string FindProjectRoot()
+            => WalkForSln(AppDomain.CurrentDomain.BaseDirectory)
+               ?? WalkForSln(Directory.GetCurrentDirectory())
+               ?? throw new InvalidOperationException("Could not find project root (FEBuilderGBA.sln)");
 
         private static string ViewsDir()
             => Path.Combine(FindProjectRoot(), "FEBuilderGBA.Avalonia", "Views");

--- a/FEBuilderGBA.Avalonia.Tests/PaletteAndAIScriptLayoutTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/PaletteAndAIScriptLayoutTests.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    /// <summary>
+    /// Pure-XML layout structure tests guarding two cosmetic regressions:
+    ///
+    /// #1689 — AIScriptView's clickable "Detail Address" link
+    /// (<c>AutomationId="AIScript_DetailAddress_Label"</c>) had a fixed
+    /// <c>Width="140"</c> that clipped the formatted <c>0x00000000</c> address
+    /// under wider macOS fonts. The fix swaps <c>Width</c> → <c>MinWidth</c> so
+    /// the link auto-grows and never clips.
+    ///
+    /// #1690 — ImagePalletView's 16 index labels
+    /// (<c>AutomationId="ImagePallet_IndexN_Label"</c>, N = 1..16) had a fixed
+    /// <c>Width="20"</c> that cropped the 2-digit indices 10..16 under macOS
+    /// fonts, made worse by the adjacent black swatch <c>Image</c>. The fix
+    /// widens each to <c>Width="30"</c> (matching the sibling
+    /// ImageUnitPaletteView index column).
+    ///
+    /// No ROM, no Avalonia runtime — fast and deterministic.
+    /// </summary>
+    public class PaletteAndAIScriptLayoutTests
+    {
+        private static string FindProjectRoot()
+        {
+            string dir = AppDomain.CurrentDomain.BaseDirectory;
+            for (int i = 0; i < 12; i++)
+            {
+                if (File.Exists(Path.Combine(dir, "FEBuilderGBA.sln"))) return dir;
+                string? parent = Path.GetDirectoryName(dir);
+                if (parent == null || parent == dir) break;
+                dir = parent;
+            }
+            string cwd = Directory.GetCurrentDirectory();
+            for (int i = 0; i < 12; i++)
+            {
+                if (File.Exists(Path.Combine(cwd, "FEBuilderGBA.sln"))) return cwd;
+                string? parent = Path.GetDirectoryName(cwd);
+                if (parent == null || parent == cwd) break;
+                cwd = parent;
+            }
+            throw new InvalidOperationException("Could not find project root (FEBuilderGBA.sln)");
+        }
+
+        private static string ViewsDir()
+            => Path.Combine(FindProjectRoot(), "FEBuilderGBA.Avalonia", "Views");
+
+        // The AutomationId attribute appears in XML as the attached-property
+        // attribute "AutomationProperties.AutomationId". In .NET LINQ-to-XML this
+        // dotted, unprefixed name is a single LocalName (NOT namespace-split), so
+        // we match the FULL "AutomationProperties.AutomationId" string — mirroring
+        // the existing GapSweep/ToolTranslateROMParityTests helper.
+        private static string? GetAutomationId(XElement e)
+            => e.Attributes()
+                .FirstOrDefault(a => a.Name.LocalName == "AutomationProperties.AutomationId")?.Value;
+
+        private static string? GetAttr(XElement e, string localName)
+            => e.Attributes().FirstOrDefault(a => a.Name.LocalName == localName)?.Value;
+
+        [Fact]
+        public void AIScript_DetailAddressLabel_UsesMinWidthNotFixedWidth()
+        {
+            string path = Path.Combine(ViewsDir(), "AIScriptView.axaml");
+            Assert.True(File.Exists(path), $"AIScriptView.axaml not found: {path}");
+
+            XDocument doc = XDocument.Load(path);
+
+            XElement? label = doc.Descendants()
+                .FirstOrDefault(e => GetAutomationId(e) == "AIScript_DetailAddress_Label");
+            Assert.True(label != null,
+                "Element with AutomationId 'AIScript_DetailAddress_Label' not found in AIScriptView.axaml.");
+
+            // #1689: the clickable address link must NOT have a fixed Width
+            // (that clips the formatted address on macOS) ...
+            string? width = GetAttr(label!, "Width");
+            Assert.True(string.IsNullOrEmpty(width),
+                $"AIScript_DetailAddress_Label must NOT declare a fixed Width (found Width=\"{width}\"). " +
+                "Use MinWidth so the link auto-grows and never clips (#1689).");
+
+            // ... and MUST have a MinWidth >= 140 so it stays at least as wide as before.
+            string? minWidth = GetAttr(label!, "MinWidth");
+            Assert.False(string.IsNullOrEmpty(minWidth),
+                "AIScript_DetailAddress_Label must declare a MinWidth (>= 140) so it auto-grows (#1689).");
+            Assert.True(double.TryParse(minWidth, out double mw),
+                $"AIScript_DetailAddress_Label MinWidth must be numeric (found \"{minWidth}\").");
+            Assert.True(mw >= 140,
+                $"AIScript_DetailAddress_Label MinWidth must be >= 140 (found {mw}).");
+        }
+
+        [Fact]
+        public void ImagePallet_IndexLabels_AreWideEnoughForTwoDigits()
+        {
+            string path = Path.Combine(ViewsDir(), "ImagePalletView.axaml");
+            Assert.True(File.Exists(path), $"ImagePalletView.axaml not found: {path}");
+
+            XDocument doc = XDocument.Load(path);
+
+            var indexLabelRe = new Regex(@"^ImagePallet_Index(\d+)_Label$");
+            var indexLabels = doc.Descendants()
+                .Where(e =>
+                {
+                    string? id = GetAutomationId(e);
+                    return id != null && indexLabelRe.IsMatch(id);
+                })
+                .ToList();
+
+            // #1690: all 16 palette index labels must be present.
+            Assert.Equal(16, indexLabels.Count);
+
+            var offenders = new List<string>();
+            foreach (var label in indexLabels)
+            {
+                string id = GetAutomationId(label)!;
+                string? width = GetAttr(label, "Width");
+                string? minWidth = GetAttr(label, "MinWidth");
+
+                // The old clipping value Width="20" must be gone.
+                if (width == "20")
+                {
+                    offenders.Add($"{id}: still has the clipping Width=\"20\".");
+                    continue;
+                }
+
+                // Robust per Copilot review: accept either a Width >= 30 OR a MinWidth >= 30.
+                bool wideEnough = false;
+                if (!string.IsNullOrEmpty(width) && double.TryParse(width, out double w) && w >= 30)
+                    wideEnough = true;
+                if (!string.IsNullOrEmpty(minWidth) && double.TryParse(minWidth, out double mw) && mw >= 30)
+                    wideEnough = true;
+
+                if (!wideEnough)
+                    offenders.Add($"{id}: Width=\"{width ?? "(none)"}\" MinWidth=\"{minWidth ?? "(none)"}\" " +
+                                  "— needs Width >= 30 OR MinWidth >= 30 so 2-digit indices (10..16) are not cropped.");
+            }
+
+            Assert.True(offenders.Count == 0,
+                "Palette index labels too narrow (2-digit indices 10..16 will be cropped by the adjacent swatch) " +
+                "— give each Width >= 30 or MinWidth >= 30 (#1690):\n" + string.Join("\n", offenders));
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/App.axaml.cs
+++ b/FEBuilderGBA.Avalonia/App.axaml.cs
@@ -377,6 +377,12 @@ namespace FEBuilderGBA.Avalonia
                 global::Avalonia.Controls.Window window = viewName switch
                 {
                     "LogViewerView" => new Views.LogViewerView(),
+                    // #1700 PR proof: render the two cosmetic-fix editors with the
+                    // real desktop Skia rasterizer (the empty editor already lays
+                    // out the geometry under test — AIScript's MinWidth address
+                    // link and the palette index columns + swatches; no ROM needed).
+                    "AIScriptView" => new Views.AIScriptView(),
+                    "ImagePalletView" => new Views.ImagePalletView(),
                     _ => throw new ArgumentException($"Unsupported --screenshot-window view: {viewName}"),
                 };
 

--- a/FEBuilderGBA.Avalonia/Views/AIScriptView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/AIScriptView.axaml
@@ -87,7 +87,7 @@
             <TextBlock Text="Detail Address" VerticalAlignment="Center" Width="120" />
             <TextBlock AutomationProperties.AutomationId="AIScript_DetailAddress_Label"
                        Name="DetailAddressLabel" Text="0x00000000"
-                       Width="140" VerticalAlignment="Center"
+                       MinWidth="140" VerticalAlignment="Center"
                        PointerPressed="DetailAddress_Click"
                        Foreground="Blue" TextDecorations="Underline" Cursor="Hand" />
             <TextBlock Text="Script Bytes:" VerticalAlignment="Center" Width="100" />

--- a/FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml
@@ -72,7 +72,7 @@
           <Border Grid.Row="0" Grid.Column="0" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
             <StackPanel Spacing="2">
               <StackPanel Orientation="Horizontal" Spacing="4">
-                <Label AutomationProperties.AutomationId="ImagePallet_Index1_Label" Content="1" Width="20" />
+                <Label AutomationProperties.AutomationId="ImagePallet_Index1_Label" Content="1" Width="30" />
                 <Image AutomationProperties.AutomationId="ImagePallet_P1_Image" Name="P1Swatch" Width="40" Height="20" />
               </StackPanel>
               <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R1_Input" Name="R1Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
@@ -84,7 +84,7 @@
           <Border Grid.Row="0" Grid.Column="1" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
             <StackPanel Spacing="2">
               <StackPanel Orientation="Horizontal" Spacing="4">
-                <Label AutomationProperties.AutomationId="ImagePallet_Index2_Label" Content="2" Width="20" />
+                <Label AutomationProperties.AutomationId="ImagePallet_Index2_Label" Content="2" Width="30" />
                 <Image AutomationProperties.AutomationId="ImagePallet_P2_Image" Name="P2Swatch" Width="40" Height="20" />
               </StackPanel>
               <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R2_Input" Name="R2Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
@@ -96,7 +96,7 @@
           <Border Grid.Row="0" Grid.Column="2" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
             <StackPanel Spacing="2">
               <StackPanel Orientation="Horizontal" Spacing="4">
-                <Label AutomationProperties.AutomationId="ImagePallet_Index3_Label" Content="3" Width="20" />
+                <Label AutomationProperties.AutomationId="ImagePallet_Index3_Label" Content="3" Width="30" />
                 <Image AutomationProperties.AutomationId="ImagePallet_P3_Image" Name="P3Swatch" Width="40" Height="20" />
               </StackPanel>
               <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R3_Input" Name="R3Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
@@ -108,7 +108,7 @@
           <Border Grid.Row="0" Grid.Column="3" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
             <StackPanel Spacing="2">
               <StackPanel Orientation="Horizontal" Spacing="4">
-                <Label AutomationProperties.AutomationId="ImagePallet_Index4_Label" Content="4" Width="20" />
+                <Label AutomationProperties.AutomationId="ImagePallet_Index4_Label" Content="4" Width="30" />
                 <Image AutomationProperties.AutomationId="ImagePallet_P4_Image" Name="P4Swatch" Width="40" Height="20" />
               </StackPanel>
               <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R4_Input" Name="R4Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
@@ -121,7 +121,7 @@
           <Border Grid.Row="1" Grid.Column="0" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
             <StackPanel Spacing="2">
               <StackPanel Orientation="Horizontal" Spacing="4">
-                <Label AutomationProperties.AutomationId="ImagePallet_Index5_Label" Content="5" Width="20" />
+                <Label AutomationProperties.AutomationId="ImagePallet_Index5_Label" Content="5" Width="30" />
                 <Image AutomationProperties.AutomationId="ImagePallet_P5_Image" Name="P5Swatch" Width="40" Height="20" />
               </StackPanel>
               <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R5_Input" Name="R5Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
@@ -133,7 +133,7 @@
           <Border Grid.Row="1" Grid.Column="1" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
             <StackPanel Spacing="2">
               <StackPanel Orientation="Horizontal" Spacing="4">
-                <Label AutomationProperties.AutomationId="ImagePallet_Index6_Label" Content="6" Width="20" />
+                <Label AutomationProperties.AutomationId="ImagePallet_Index6_Label" Content="6" Width="30" />
                 <Image AutomationProperties.AutomationId="ImagePallet_P6_Image" Name="P6Swatch" Width="40" Height="20" />
               </StackPanel>
               <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R6_Input" Name="R6Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
@@ -145,7 +145,7 @@
           <Border Grid.Row="1" Grid.Column="2" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
             <StackPanel Spacing="2">
               <StackPanel Orientation="Horizontal" Spacing="4">
-                <Label AutomationProperties.AutomationId="ImagePallet_Index7_Label" Content="7" Width="20" />
+                <Label AutomationProperties.AutomationId="ImagePallet_Index7_Label" Content="7" Width="30" />
                 <Image AutomationProperties.AutomationId="ImagePallet_P7_Image" Name="P7Swatch" Width="40" Height="20" />
               </StackPanel>
               <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R7_Input" Name="R7Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
@@ -157,7 +157,7 @@
           <Border Grid.Row="1" Grid.Column="3" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
             <StackPanel Spacing="2">
               <StackPanel Orientation="Horizontal" Spacing="4">
-                <Label AutomationProperties.AutomationId="ImagePallet_Index8_Label" Content="8" Width="20" />
+                <Label AutomationProperties.AutomationId="ImagePallet_Index8_Label" Content="8" Width="30" />
                 <Image AutomationProperties.AutomationId="ImagePallet_P8_Image" Name="P8Swatch" Width="40" Height="20" />
               </StackPanel>
               <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R8_Input" Name="R8Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
@@ -170,7 +170,7 @@
           <Border Grid.Row="2" Grid.Column="0" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
             <StackPanel Spacing="2">
               <StackPanel Orientation="Horizontal" Spacing="4">
-                <Label AutomationProperties.AutomationId="ImagePallet_Index9_Label" Content="9" Width="20" />
+                <Label AutomationProperties.AutomationId="ImagePallet_Index9_Label" Content="9" Width="30" />
                 <Image AutomationProperties.AutomationId="ImagePallet_P9_Image" Name="P9Swatch" Width="40" Height="20" />
               </StackPanel>
               <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R9_Input" Name="R9Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
@@ -182,7 +182,7 @@
           <Border Grid.Row="2" Grid.Column="1" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
             <StackPanel Spacing="2">
               <StackPanel Orientation="Horizontal" Spacing="4">
-                <Label AutomationProperties.AutomationId="ImagePallet_Index10_Label" Content="10" Width="20" />
+                <Label AutomationProperties.AutomationId="ImagePallet_Index10_Label" Content="10" Width="30" />
                 <Image AutomationProperties.AutomationId="ImagePallet_P10_Image" Name="P10Swatch" Width="40" Height="20" />
               </StackPanel>
               <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R10_Input" Name="R10Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
@@ -194,7 +194,7 @@
           <Border Grid.Row="2" Grid.Column="2" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
             <StackPanel Spacing="2">
               <StackPanel Orientation="Horizontal" Spacing="4">
-                <Label AutomationProperties.AutomationId="ImagePallet_Index11_Label" Content="11" Width="20" />
+                <Label AutomationProperties.AutomationId="ImagePallet_Index11_Label" Content="11" Width="30" />
                 <Image AutomationProperties.AutomationId="ImagePallet_P11_Image" Name="P11Swatch" Width="40" Height="20" />
               </StackPanel>
               <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R11_Input" Name="R11Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
@@ -206,7 +206,7 @@
           <Border Grid.Row="2" Grid.Column="3" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
             <StackPanel Spacing="2">
               <StackPanel Orientation="Horizontal" Spacing="4">
-                <Label AutomationProperties.AutomationId="ImagePallet_Index12_Label" Content="12" Width="20" />
+                <Label AutomationProperties.AutomationId="ImagePallet_Index12_Label" Content="12" Width="30" />
                 <Image AutomationProperties.AutomationId="ImagePallet_P12_Image" Name="P12Swatch" Width="40" Height="20" />
               </StackPanel>
               <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R12_Input" Name="R12Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
@@ -219,7 +219,7 @@
           <Border Grid.Row="3" Grid.Column="0" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
             <StackPanel Spacing="2">
               <StackPanel Orientation="Horizontal" Spacing="4">
-                <Label AutomationProperties.AutomationId="ImagePallet_Index13_Label" Content="13" Width="20" />
+                <Label AutomationProperties.AutomationId="ImagePallet_Index13_Label" Content="13" Width="30" />
                 <Image AutomationProperties.AutomationId="ImagePallet_P13_Image" Name="P13Swatch" Width="40" Height="20" />
               </StackPanel>
               <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R13_Input" Name="R13Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
@@ -231,7 +231,7 @@
           <Border Grid.Row="3" Grid.Column="1" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
             <StackPanel Spacing="2">
               <StackPanel Orientation="Horizontal" Spacing="4">
-                <Label AutomationProperties.AutomationId="ImagePallet_Index14_Label" Content="14" Width="20" />
+                <Label AutomationProperties.AutomationId="ImagePallet_Index14_Label" Content="14" Width="30" />
                 <Image AutomationProperties.AutomationId="ImagePallet_P14_Image" Name="P14Swatch" Width="40" Height="20" />
               </StackPanel>
               <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R14_Input" Name="R14Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
@@ -243,7 +243,7 @@
           <Border Grid.Row="3" Grid.Column="2" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
             <StackPanel Spacing="2">
               <StackPanel Orientation="Horizontal" Spacing="4">
-                <Label AutomationProperties.AutomationId="ImagePallet_Index15_Label" Content="15" Width="20" />
+                <Label AutomationProperties.AutomationId="ImagePallet_Index15_Label" Content="15" Width="30" />
                 <Image AutomationProperties.AutomationId="ImagePallet_P15_Image" Name="P15Swatch" Width="40" Height="20" />
               </StackPanel>
               <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R15_Input" Name="R15Box" Value="0" Increment="8" Minimum="0" Maximum="255" />
@@ -255,7 +255,7 @@
           <Border Grid.Row="3" Grid.Column="3" BorderBrush="LightGray" BorderThickness="1" Padding="4" Margin="2">
             <StackPanel Spacing="2">
               <StackPanel Orientation="Horizontal" Spacing="4">
-                <Label AutomationProperties.AutomationId="ImagePallet_Index16_Label" Content="16" Width="20" />
+                <Label AutomationProperties.AutomationId="ImagePallet_Index16_Label" Content="16" Width="30" />
                 <Image AutomationProperties.AutomationId="ImagePallet_P16_Image" Name="P16Swatch" Width="40" Height="20" />
               </StackPanel>
               <NumericUpDown AutomationProperties.AutomationId="ImagePallet_R16_Input" Name="R16Box" Value="0" Increment="8" Minimum="0" Maximum="255" />


### PR DESCRIPTION
## Summary

Two cosmetic Avalonia AXAML layout fixes reported by @OrionNebula12 in discussion #1674 (Avalonia `ver_20260628.21`, macOS Tahoe / Apple Silicon M1, FE8U). Both are macOS font-metric clipping bugs — fixed-pixel widths sized for Windows fonts clipped content under macOS's larger default UI font.

### #1689 — AI Script Editor: Address "button" too small for its content
`FEBuilderGBA.Avalonia/Views/AIScriptView.axaml` — the clickable, blue/underlined **Detail Address** link (`AIScript_DetailAddress_Label`, the Avalonia analog of WF `AIScriptForm.AddressTextBox`) had a fixed `Width="140"`. The formatted address (`0x{X08}`, 10 chars) was clipped on macOS.

- **Before:** `Width="140"` — fixed footprint, clips the address text on macOS.
- **After:** `MinWidth="140"` — keeps the same minimum footprint but auto-grows to fit the address and never clips. Matches the canonical sibling `ImageBattleScreenView` address label (which auto-sizes).

### #1690 — Palette Editor: black box crops the numeric values
`FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml` — each of the 16 palette cells shows an index `Label` (`ImagePallet_IndexN_Label`) followed by the swatch `Image` (a dark/black box). The index labels were fixed at `Width="20"`, too narrow for the 2-digit indices **10–16** under macOS fonts, so the digit's right edge was clipped and the adjacent black swatch appeared to "cut off a bit of the numbers" (reporter's wording).

- **Before:** `Width="20"` on all 16 index labels.
- **After:** `Width="30"` on all 16 index labels — gives the 2-digit numbers full room. Matches the sibling `ImageUnitPaletteView` (index column = 30). Swatch `Image` and the R/G/B NumericUpDowns are untouched.

## Plan reference
Plans accepted with **no blocking findings** by Copilot CLI review: #1689 (comment) + #1690 (comment).

## Scope
- Closes #1689
- Closes #1690

Also extends the existing `--screenshot-window` PR-proof tooling (`App.axaml.cs`, the #1467 real-Skia off-screen renderer) by 2 `switch` arms so these two editors can be rendered to PNG (used to produce the screenshots below; the headless test backend uses `UseHeadlessDrawing` and cannot capture a real frame).

## Screenshots

**AI Script Editor (#1689)** — the `0x00000000` Detail Address link is now fully visible / unclipped:

![AI Script Editor — Address link unclipped](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/issue-assets/pr-screenshots/pr1700-aiscript.png)

**Palette Editor (#1690)** — index numbers 1–16 (incl. 2-digit 10–16) are fully visible to the left of the swatches, no longer cropped:

![Palette Editor — index numbers not cropped](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/issue-assets/pr-screenshots/pr1700-palette.png)

> Rendered with the real desktop Skia rasterizer via `FEBuilderGBA.Avalonia.exe --screenshot-window=AIScriptView|ImagePalletView`. No ROM needed — the empty editor lays out the geometry under test.

## GUI Test Report

| # | Editor | Check | Result |
|---|--------|-------|--------|
| 1 | AI Script Editor (`AIScriptView`) | `0x00000000` Detail Address link renders fully, not clipped (`MinWidth="140"`) | PASS |
| 2 | Palette Editor (`ImagePalletView`) | Single-digit indices 1–9 fully visible next to swatch | PASS |
| 3 | Palette Editor (`ImagePalletView`) | 2-digit indices 10–16 fully visible, NOT cropped by the adjacent black swatch (`Width="30"`) | PASS |
| 4 | Palette Editor (`ImagePalletView`) | Swatches, R/G/B NumericUpDowns, Preview, buttons unaffected | PASS |

Rendered via the real-Skia `--screenshot-window` path on a built Avalonia app; both PNGs verified non-blank and visually inspected.

## Test plan
- [x] Added `FEBuilderGBA.Avalonia.Tests/PaletteAndAIScriptLayoutTests.cs` — 2 pure-XML structure tests: (a) `AIScript_DetailAddress_Label` has **no** `Width` and a `MinWidth >= 140`; (b) all 16 `ImagePallet_IndexN_Label` have `Width`/`MinWidth >= 30` and **none** remains at `Width="20"`.
- [x] Ran the 2 new tests locally — **2 passed, 0 failed** (test project builds 0 errors).
- [x] Both AXAML files validated as well-formed XML.
- [x] Confirmed the diff touches only the intended attributes (1× MinWidth on AIScript link; 16× Width=30 on palette index labels) — swatch `Image` and R/G/B boxes untouched.
- [x] Built the Avalonia app and rendered both editors via the real-Skia `--screenshot-window` path; visually confirmed both fixes (address link unclipped; palette indices 10–16 not cropped).
- [x] `FindProjectRoot` test helper simplified to a `DirectoryInfo` parent-walk per Copilot inline review.

Original request: review and reply discussions, create issues for reported bugs, resolve them via dev-flow
🤖 Generated with Claude Code (Opus 4.8, 1M context)
