### PR TITLE
fix(avalonia): add CJK/glyph font fallback so text doesn't render as tofu (esp. macOS)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/FontFallbackTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/FontFallbackTests.cs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Tests for the app-level CJK/glyph font fallbacks registered in Program.cs (#1692).
+//
+// CreateFontManagerOptions() only constructs a FontManagerOptions POCO — it does
+// NOT require Avalonia platform/headless init — so these tests call it directly.
+using System.Linq;
+using Avalonia.Media;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    public class FontFallbackTests
+    {
+        [Fact]
+        public void CreateFontManagerOptions_HasNonEmptyFallbacks()
+        {
+            var options = Program.CreateFontManagerOptions();
+
+            Assert.NotNull(options.FontFallbacks);
+            Assert.True(options.FontFallbacks!.Count > 0);
+        }
+
+        [Fact]
+        public void CreateFontManagerOptions_DoesNotSetDefaultFamilyName()
+        {
+            // DefaultFamilyName is intentionally left null so the primary look
+            // (especially on Windows) is unchanged and to avoid the known
+            // empty/invalid-family startup crash (Avalonia #10614 / #12140).
+            var options = Program.CreateFontManagerOptions();
+
+            Assert.Null(options.DefaultFamilyName);
+        }
+
+        [Fact]
+        public void CreateFontManagerOptions_IncludesCjkFamilies()
+        {
+            var options = Program.CreateFontManagerOptions();
+
+            var familyNames = options.FontFallbacks!
+                .Select(f => f.FontFamily.Name)
+                .ToList();
+
+            // One representative per platform: macOS, Windows, Linux.
+            Assert.Contains("PingFang SC", familyNames);
+            Assert.Contains("Microsoft YaHei", familyNames);
+            Assert.Contains("Noto Sans CJK SC", familyNames);
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/Program.cs
+++ b/FEBuilderGBA.Avalonia/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using Avalonia;
+using Avalonia.Media;
 
 namespace FEBuilderGBA.Avalonia
 {
@@ -36,6 +37,59 @@ namespace FEBuilderGBA.Avalonia
         public static AppBuilder BuildAvaloniaApp()
             => AppBuilder.Configure<App>()
                 .UsePlatformDetect()
+                .With(CreateFontManagerOptions())
                 .LogToTrace();
+
+        /// <summary>
+        /// Builds the app-level <see cref="FontManagerOptions"/> used to register
+        /// cross-platform CJK / glyph font fallbacks (issue #1692).
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This ONLY populates <see cref="FontManagerOptions.FontFallbacks"/>, which Avalonia's
+        /// <c>FontManager</c> consults <em>per codepoint</em> — and only when the primary font
+        /// lacks a glyph for that codepoint. It does NOT change which font is used by default for
+        /// text the primary font can already render.
+        /// </para>
+        /// <para>
+        /// <see cref="FontManagerOptions.DefaultFamilyName"/> is intentionally left null. Setting a
+        /// default family would override the primary look on every platform (especially Windows,
+        /// which already substitutes CJK glyphs well) and risks the known Avalonia startup crash
+        /// when the configured family is empty or not installed (Avalonia issues #10614 / #12140).
+        /// </para>
+        /// <para>
+        /// Each platform lists its native CJK families first. Families that are not installed on a
+        /// given OS are silently skipped by Avalonia's <c>FontManager.TryMatchCharacter</c> — it
+        /// calls <c>TryGetGlyphTypeface</c>, which fails-and-continues to the next candidate, and
+        /// finally falls through to the platform default font. The list is needed most on macOS,
+        /// where the OS does NOT auto-substitute a CJK font when the primary UI font lacks the
+        /// glyph, causing ROM-decoded names and Japanese labels to render as "tofu" boxes.
+        /// </para>
+        /// </remarks>
+        internal static FontManagerOptions CreateFontManagerOptions()
+        {
+            // DefaultFamilyName is intentionally NOT set — see the remarks above.
+            return new FontManagerOptions
+            {
+                FontFallbacks = new[]
+                {
+                    // macOS — the OS does not auto-substitute CJK; these cover SC/JP/KR + Arial Unicode.
+                    new FontFallback { FontFamily = new FontFamily("PingFang SC") },
+                    new FontFallback { FontFamily = new FontFamily("Hiragino Sans") },
+                    new FontFallback { FontFamily = new FontFamily("Apple SD Gothic Neo") },
+                    new FontFallback { FontFamily = new FontFamily("Arial Unicode MS") },
+
+                    // Windows — kept after macOS; Windows already substitutes well, these are harmless.
+                    new FontFallback { FontFamily = new FontFamily("Microsoft YaHei") },
+                    new FontFallback { FontFamily = new FontFamily("Yu Gothic") },
+                    new FontFallback { FontFamily = new FontFamily("Malgun Gothic") },
+
+                    // Linux — Noto / WenQuanYi CJK families.
+                    new FontFallback { FontFamily = new FontFamily("Noto Sans CJK SC") },
+                    new FontFallback { FontFamily = new FontFamily("Noto Sans CJK JP") },
+                    new FontFallback { FontFamily = new FontFamily("WenQuanYi Micro Hei") },
+                },
+            };
+        }
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/MapSettingFE6View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MapSettingFE6View.axaml
@@ -10,7 +10,7 @@
       <TextBlock DockPanel.Dock="Top" Text="先頭アドレス" Margin="2,0,2,2" FontWeight="Bold" />
       <TextBlock DockPanel.Dock="Top" Text="読込数" Margin="2,0,2,2" Foreground="Gray" FontSize="11" />
       <Button AutomationProperties.AutomationId="MapSettingFE6_ExpandList_Button" DockPanel.Dock="Top" Name="ExpandListButton" Content="Data Expansion" Margin="2" />
-      <Button AutomationProperties.AutomationId="MapSettingFE6_Refetch_Button" DockPanel.Dock="Top" Name="RefetchButton" Content="再取得" Margin="2" />
+      <Button AutomationProperties.AutomationId="MapSettingFE6_Refetch_Button" DockPanel.Dock="Top" Name="RefetchButton" Content="Reload" Margin="2" />
       <controls:AddressListControl AutomationProperties.AutomationId="MapSettingFE6_Entry_List" Name="EntryList" />
     </DockPanel>
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ dotnet run --project FEBuilderGBA.Avalonia -- --gap-sweep-all --out=docs/avaloni
 dotnet test FEBuilderGBA.Core.Tests/FEBuilderGBA.Core.Tests.csproj
 ```
 
+> **macOS / CJK text note:** The Avalonia GUI registers cross-platform CJK font fallbacks
+> (`FontManagerOptions.FontFallbacks`) so ROM-decoded names and Japanese labels render correctly
+> on macOS instead of as "tofu" boxes (#1692).
+
 ### Decomp Project Support (preview)
 
 FEBuilderGBA can open a **decompilation project** directory (a source tree that


### PR DESCRIPTION
## Summary
Fixes the missing-glyph / "tofu" (and unexpected-CJK) rendering reported in #1692 by @OrionNebula12 (macOS Tahoe / Apple Silicon M1, FE8U) in the **Item Shop** and **Map Setting** editors.

### Root cause
- `FEBuilderGBA.Avalonia/Program.cs` `BuildAvaloniaApp()` configured the AppBuilder with only `.UsePlatformDetect().LogToTrace()` — **no `FontManagerOptions`** — and `App.axaml` uses a bare `<FluentTheme />` with no `DefaultFamilyName` / `FontFallbacks` / embedded font. So there was no app-level font fallback.
- The "tofu boxes" come from **ROM-decoded names** rendered in `Controls/AddressListControl` and name labels (shop names, map names, item names — game text that can include CJK and special glyphs). On Windows the system font manager auto-falls-back to an installed CJK font; on **macOS the chosen UI font has no glyph and macOS does not auto-substitute**, so the codepoint renders as `.notdef` tofu.
- One *additional* "unexpected CJK" source was a hard-coded Japanese button label the recent l10n pass (#1694) missed.

### Fix
1. **Font fallback (core fix)** — add `FontManagerOptions.FontFallbacks` (fallbacks only) in `Program.BuildAvaloniaApp()` via a new `internal static FontManagerOptions CreateFontManagerOptions()` helper. Families: macOS (PingFang SC, Hiragino Sans, Apple SD Gothic Neo, Arial Unicode MS), Windows (Microsoft YaHei, Yu Gothic, Malgun Gothic), Linux (Noto Sans CJK SC, Noto Sans CJK JP, WenQuanYi Micro Hei).
2. **One missed label** — `MapSettingFE6View.axaml` Refetch button `Content="再取得"` → `Content="Reload"` (the English source literal the Avalonia localizer maps back via `config/translate` — en.txt already has `再取得 -> Reload`). This matches #1694's localization approach. The Expand List buttons are **already** handled on master by #1694 (`Content="Data Expansion"`), so this PR deliberately does **not** touch them.

### Why the font-fallback change is safe (verified against Avalonia 11.2 source `FontManager.TryMatchCharacter`)
- Fallbacks are consulted **only when the primary font lacks a codepoint** (per-glyph). `DefaultFamilyName` is left **null**, so the primary look on Windows/Linux is **unchanged**.
- For each fallback Avalonia calls `TryGetGlyphTypeface` then `TryGetGlyph`; **if a family is not installed on the current OS the load fails and the loop simply continues** — listing fonts that don't exist on a platform is harmless. It then falls through to `PlatformImpl.TryMatchCharacter` (the existing default), so nothing is lost.
- We deliberately do **not** set `DefaultFamilyName` (avoids the known empty/invalid-family startup crash — Avalonia issues #10614 / #12140).

## Plan reference
Plan + Copilot CLI review (both findings accepted/folded in): https://github.com/laqieer/FEBuilderGBA/issues/1692

## Scope
Closes #1692

(Out of scope, noted for a possible follow-up: `MapSettingFE6View.axaml` still has many FE6-only Japanese *field* labels — `先頭アドレス`, `攻略評価`, … — which do not affect the FE8U reporter and are a separate, larger FE6-localization effort.)

## Test plan
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests --filter "FullyQualifiedName~FontFallback"` — 3 new unit tests pass (non-empty `FontFallbacks`; `DefaultFamilyName == null`; includes PingFang SC / Microsoft YaHei / Noto Sans CJK SC). Verified locally: Failed 0, Passed 3.
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests --filter "FullyQualifiedName~JapaneseExpandButton"` — master's existing l10n regression test (#1691) still passes, confirming the Expand List buttons keep `Content="Data Expansion"` and its ja/zh translate entries. Verified locally: Failed 0, Passed 2.
- [x] `git diff --name-only origin/master` is exactly the 4 intended files (Program.cs, FontFallbackTests.cs, MapSettingFE6View.axaml, README.md); branch rebased onto current `origin/master` (0 behind).
- [x] Confirmed `config/translate/en.txt` maps `再取得` → `Reload`, so the new label is translatable consistent with #1694.

## macOS re-verification requested
This is a **best-effort, inspection-grounded** fix. The reporter is on macOS Tahoe / Apple Silicon; CI builds+tests on Windows/Linux/macOS but does not visually render macOS glyph fallback, and I cannot reproduce the macOS rendering locally (Windows host). The change is grounded in the Avalonia 11.2 `FontManager.TryMatchCharacter` fallback logic. **@OrionNebula12 — could you please re-verify on macOS** that the Item Shop / Map Setting text now renders correctly (no tofu) once a build with this change is available? If a specific glyph still doesn't resolve, please share which characters so we can add the right family.

## Screenshots
Scoped `fix(avalonia):` — the change is a global font-fallback registration + one translatable label; behavior is per-codepoint glyph fallback that is platform/installed-font dependent and not meaningfully visible in a Windows screenshot (Windows already substitutes CJK). Proof is the passing unit tests above and the macOS re-verification request. (Scoped per the task; no hosted screenshot.)

Original request: review and reply discussions, create issues for reported bugs, resolve them via dev-flow
🤖 Generated with Claude Code (Opus 4.8, 1M context)
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
