### PR TITLE
fix(avalonia): widen Event Unit move-path grid so spinners don't overlap (#1713)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/EventUnitMovePathLayoutTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EventUnitMovePathLayoutTests.cs
@@ -66,34 +66,41 @@ namespace FEBuilderGBA.Avalonia.Tests
             window.Width = 1902;
             window.Height = 1047;
             window.Show();
-            window.UpdateLayout();
-
-            // All realized spinners in the list (8 per row).
-            var nuds = list.GetVisualDescendants().OfType<NumericUpDown>().ToList();
-            Assert.True(nuds.Count >= 8, $"expected >=8 realized NumericUpDowns, got {nuds.Count}");
-
-            // Take the first realized row (the 8 left-most by window X), ordered L->R.
-            var firstRow = nuds
-                .Select(n => new { Nud = n, P = n.TranslatePoint(new Point(0, 0), window) })
-                .Where(x => x.P.HasValue)
-                .OrderBy(x => x.P!.Value.Y).ThenBy(x => x.P!.Value.X)
-                .Take(8)
-                .OrderBy(x => x.P!.Value.X)
-                .ToList();
-            Assert.Equal(8, firstRow.Count);
-
-            string dump = string.Join(" | ", firstRow.Select((x, i) =>
-                $"#{i} x={x.P!.Value.X:F0} w={x.Nud.Bounds.Width:F0} r={x.P!.Value.X + x.Nud.Bounds.Width:F0}"));
-
-            // No spinner's right edge may pass the next spinner's left edge.
-            for (int i = 0; i + 1 < firstRow.Count; i++)
+            try
             {
-                double aRight = firstRow[i].P!.Value.X + firstRow[i].Nud.Bounds.Width;
-                double bLeft = firstRow[i + 1].P!.Value.X;
-                Assert.True(
-                    aRight <= bLeft + 0.5,
-                    $"NumericUpDown #{i} (right={aRight:F1}) overlaps #{i + 1} (left={bLeft:F1}) " +
-                    $"— After Coordinate Move Path spinners are colliding (#1713). [{dump}]");
+                window.UpdateLayout();
+
+                // All realized spinners in the list (8 per row).
+                var nuds = list.GetVisualDescendants().OfType<NumericUpDown>().ToList();
+                Assert.True(nuds.Count >= 8, $"expected >=8 realized NumericUpDowns, got {nuds.Count}");
+
+                // Take the first realized row (the 8 left-most by window X), ordered L->R.
+                var firstRow = nuds
+                    .Select(n => new { Nud = n, P = n.TranslatePoint(new Point(0, 0), window) })
+                    .Where(x => x.P.HasValue)
+                    .OrderBy(x => x.P!.Value.Y).ThenBy(x => x.P!.Value.X)
+                    .Take(8)
+                    .OrderBy(x => x.P!.Value.X)
+                    .ToList();
+                Assert.Equal(8, firstRow.Count);
+
+                string dump = string.Join(" | ", firstRow.Select((x, i) =>
+                    $"#{i} x={x.P!.Value.X:F0} w={x.Nud.Bounds.Width:F0} r={x.P!.Value.X + x.Nud.Bounds.Width:F0}"));
+
+                // No spinner's right edge may pass the next spinner's left edge.
+                for (int i = 0; i + 1 < firstRow.Count; i++)
+                {
+                    double aRight = firstRow[i].P!.Value.X + firstRow[i].Nud.Bounds.Width;
+                    double bLeft = firstRow[i + 1].P!.Value.X;
+                    Assert.True(
+                        aRight <= bLeft + 0.5,
+                        $"NumericUpDown #{i} (right={aRight:F1}) overlaps #{i + 1} (left={bLeft:F1}) " +
+                        $"— After Coordinate Move Path spinners are colliding (#1713). [{dump}]");
+                }
+            }
+            finally
+            {
+                window.Close();
             }
         }
     }

--- a/FEBuilderGBA.Avalonia.Tests/EventUnitMovePathLayoutTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EventUnitMovePathLayoutTests.cs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1713 — the FE8 "After Coordinate Move Path" grid's NumericUpDown spinners
+// overlapped/squished into adjacent columns (NUD min-width > the 70-90px columns).
+// The fix widens the header + row-template ColumnDefinitions and the per-cell NUD
+// Width so each value+spinner fits inside its column. These headless tests realize
+// a populated row and assert the eight spinners do NOT overlap horizontally.
+using System.Collections.Generic;
+using System.Linq;
+using global::Avalonia;
+using global::Avalonia.Controls;
+using global::Avalonia.Headless.XUnit;
+using global::Avalonia.VisualTree;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    public class EventUnitMovePathLayoutTests
+    {
+        // Public stand-in exposing the same property names the DataTemplate binds
+        // ({Binding X}, {Binding Y}, … {Binding Wait}, {Binding IsAfterRow},
+        // {Binding StartRowMarker}). Avalonia binds by name, so this drives the real
+        // AXAML row template without needing the (private) Fe8CoordRowViewModel.
+        public sealed class Row
+        {
+            public string StartRowMarker { get; set; } = "1";
+            public int X { get; set; } = 10;
+            public int Y { get; set; } = 8;
+            public int Ext { get; set; } = 0;
+            public int Speed { get; set; } = 200;
+            public int UnitId { get; set; } = 255;
+            public int Unk1 { get; set; } = 255;
+            public int Unk2 { get; set; } = 255;
+            public int Wait { get; set; } = 65535;
+            public bool IsAfterRow { get; set; } = true;
+        }
+
+        [AvaloniaFact]
+        public void EventUnitView_CanInstantiate()
+        {
+            var v = new EventUnitView();
+            Assert.NotNull(v.Content);
+        }
+
+        [AvaloniaFact]
+        public void AfterCoordsList_Row_NumericUpDowns_DoNotOverlap()
+        {
+            var v = new EventUnitView();
+
+            // The After-Coordinate-Move-Path panel is FE8-gated (hidden until a FE8
+            // ROM loads). Force it visible so the list realizes in this ROM-less test.
+            var panel = v.FindControl<Control>("AfterCoordsPanel");
+            Assert.NotNull(panel);
+            panel!.IsVisible = true;
+
+            var list = v.FindControl<ListBox>("AfterCoordsList");
+            Assert.NotNull(list);
+
+            // Non-virtualizing panel so both rows realize deterministically headless.
+            list!.ItemsPanel = new global::Avalonia.Controls.Templates.FuncTemplate<Panel?>(
+                () => new StackPanel());
+            list!.ItemsSource = new List<Row> { new Row(), new Row() };
+
+            // EventUnitView is itself a Window (top-level) — show it directly.
+            var window = v;
+            window.Width = 1902;
+            window.Height = 1047;
+            window.Show();
+            window.UpdateLayout();
+
+            // All realized spinners in the list (8 per row).
+            var nuds = list.GetVisualDescendants().OfType<NumericUpDown>().ToList();
+            Assert.True(nuds.Count >= 8, $"expected >=8 realized NumericUpDowns, got {nuds.Count}");
+
+            // Take the first realized row (the 8 left-most by window X), ordered L->R.
+            var firstRow = nuds
+                .Select(n => new { Nud = n, P = n.TranslatePoint(new Point(0, 0), window) })
+                .Where(x => x.P.HasValue)
+                .OrderBy(x => x.P!.Value.Y).ThenBy(x => x.P!.Value.X)
+                .Take(8)
+                .OrderBy(x => x.P!.Value.X)
+                .ToList();
+            Assert.Equal(8, firstRow.Count);
+
+            string dump = string.Join(" | ", firstRow.Select((x, i) =>
+                $"#{i} x={x.P!.Value.X:F0} w={x.Nud.Bounds.Width:F0} r={x.P!.Value.X + x.Nud.Bounds.Width:F0}"));
+
+            // No spinner's right edge may pass the next spinner's left edge.
+            for (int i = 0; i + 1 < firstRow.Count; i++)
+            {
+                double aRight = firstRow[i].P!.Value.X + firstRow[i].Nud.Bounds.Width;
+                double bLeft = firstRow[i + 1].P!.Value.X;
+                Assert.True(
+                    aRight <= bLeft + 0.5,
+                    $"NumericUpDown #{i} (right={aRight:F1}) overlaps #{i + 1} (left={bLeft:F1}) " +
+                    $"— After Coordinate Move Path spinners are colliding (#1713). [{dump}]");
+            }
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/Views/EventUnitView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EventUnitView.axaml
@@ -156,7 +156,7 @@
               <Button AutomationProperties.AutomationId="EventUnit_RemoveCoord_Button" Content="Remove Coord" Name="RemoveCoordBtn" Click="RemoveCoord_Click" IsEnabled="False" />
             </StackPanel>
             <TextBlock Text="Row 0 is the start position (X/Y/Ext persist to W4). Rows 1+ are the move-path steps." Foreground="Gray" TextWrapping="Wrap" />
-            <Grid ColumnDefinitions="40,70,70,70,80,90,70,70,80">
+            <Grid ColumnDefinitions="44,130,130,130,130,130,130,130,140">
               <TextBlock Grid.Column="0" Text="#" FontWeight="Bold" />
               <TextBlock Grid.Column="1" Text="X" FontWeight="Bold" />
               <TextBlock Grid.Column="2" Text="Y" FontWeight="Bold" />
@@ -171,16 +171,16 @@
                      SelectionChanged="AfterCoordsList_SelectionChanged" MaxHeight="280">
               <ListBox.ItemTemplate>
                 <DataTemplate>
-                  <Grid ColumnDefinitions="40,70,70,70,80,90,70,70,80">
+                  <Grid ColumnDefinitions="44,130,130,130,130,130,130,130,140">
                     <TextBlock Grid.Column="0" Text="{Binding StartRowMarker}" VerticalAlignment="Center" />
-                    <NumericUpDown Grid.Column="1" FormatString="0" Minimum="0" Maximum="63" Width="64" Value="{Binding X}" />
-                    <NumericUpDown Grid.Column="2" FormatString="0" Minimum="0" Maximum="63" Width="64" Value="{Binding Y}" />
-                    <NumericUpDown Grid.Column="3" FormatString="0" Minimum="0" Maximum="7" Width="64" Value="{Binding Ext}" />
-                    <NumericUpDown Grid.Column="4" FormatString="0" Minimum="0" Maximum="255" Width="74" Value="{Binding Speed}" IsEnabled="{Binding IsAfterRow}" />
-                    <NumericUpDown Grid.Column="5" FormatString="0" Minimum="0" Maximum="255" Width="84" Value="{Binding UnitId}" IsEnabled="{Binding IsAfterRow}" />
-                    <NumericUpDown Grid.Column="6" FormatString="0" Minimum="0" Maximum="255" Width="64" Value="{Binding Unk1}" IsEnabled="{Binding IsAfterRow}" />
-                    <NumericUpDown Grid.Column="7" FormatString="0" Minimum="0" Maximum="255" Width="64" Value="{Binding Unk2}" IsEnabled="{Binding IsAfterRow}" />
-                    <NumericUpDown Grid.Column="8" FormatString="0" Minimum="0" Maximum="65535" Width="74" Value="{Binding Wait}" IsEnabled="{Binding IsAfterRow}" />
+                    <NumericUpDown Grid.Column="1" FormatString="0" Minimum="0" Maximum="63" Width="120" Value="{Binding X}" />
+                    <NumericUpDown Grid.Column="2" FormatString="0" Minimum="0" Maximum="63" Width="120" Value="{Binding Y}" />
+                    <NumericUpDown Grid.Column="3" FormatString="0" Minimum="0" Maximum="7" Width="120" Value="{Binding Ext}" />
+                    <NumericUpDown Grid.Column="4" FormatString="0" Minimum="0" Maximum="255" Width="120" Value="{Binding Speed}" IsEnabled="{Binding IsAfterRow}" />
+                    <NumericUpDown Grid.Column="5" FormatString="0" Minimum="0" Maximum="255" Width="120" Value="{Binding UnitId}" IsEnabled="{Binding IsAfterRow}" />
+                    <NumericUpDown Grid.Column="6" FormatString="0" Minimum="0" Maximum="255" Width="120" Value="{Binding Unk1}" IsEnabled="{Binding IsAfterRow}" />
+                    <NumericUpDown Grid.Column="7" FormatString="0" Minimum="0" Maximum="255" Width="120" Value="{Binding Unk2}" IsEnabled="{Binding IsAfterRow}" />
+                    <NumericUpDown Grid.Column="8" FormatString="0" Minimum="0" Maximum="65535" Width="130" Value="{Binding Wait}" IsEnabled="{Binding IsAfterRow}" />
                   </Grid>
                 </DataTemplate>
               </ListBox.ItemTemplate>


### PR DESCRIPTION
Fixes the overlapping/squished spinners in the FE8 **Event Unit Placement → After Coordinate Move Path** grid (Closes #1713). Reported on macOS (ver_20260628.21) — **via the new in-app Report a Bug form** from #1709. 🎉

## Root cause
The grid gave each `NumericUpDown` only 64–84px in 70–90px columns, but Avalonia's Fluent `NumericUpDown` has a **~120px minimum width**. Every spinner clamped to 120px and overflowed its column, colliding with the next.

## Fix
Widen the header + row-template `ColumnDefinitions` to **130px** (Wait 140) and the per-cell NUD `Width` to 120 so value + spinner fit with a ~10px gap. (`EventUnitView.axaml`, 10 lines.)

## Verification
New headless layout test `EventUnitMovePathLayoutTests.AfterCoordsList_Row_NumericUpDowns_DoNotOverlap` realizes a populated move-path row and asserts the eight spinners don't overlap by **measuring their real bounds** via the actual Avalonia layout engine + AXAML. It caught that a first attempt at 100px columns was *still* too narrow (column pitch 100 vs NUD width 120 → 20px overlap); at 130px the pitch clears the 120px NUDs. 125 related Avalonia tests pass; no new `R._` literals (L10n gate clean).

Before (reporter's screenshot): see #1713.
---
Generated with Claude Code — Opus 4.8 (1M context), `claude-opus-4-8[1m]`.
