### PR TITLE
fix(avalonia): round-3a #1674 — Move Cost overlap+tofu, Battle Screen palette overlap, Unit Color Apply centering

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/ApplyButtonAlignmentTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ApplyButtonAlignmentTests.cs
@@ -20,6 +20,9 @@ namespace FEBuilderGBA.Avalonia.Tests
             var apply = view.FindControl<Button>("ApplyButton");
             Assert.NotNull(apply);
             Assert.Equal(VerticalAlignment.Center, apply!.VerticalAlignment);
+            // #1727: VerticalContentAlignment must also be Center so the "Apply"
+            // glyph sits in the middle of the 40px button instead of above centre.
+            Assert.Equal(VerticalAlignment.Center, apply!.VerticalContentAlignment);
         }
 
         [AvaloniaFact]

--- a/FEBuilderGBA.Avalonia.Tests/FieldSpacingLayoutTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/FieldSpacingLayoutTests.cs
@@ -128,14 +128,17 @@ namespace FEBuilderGBA.Avalonia.Tests
             string src = File.ReadAllText(path);
 
             // The label must use ellipsis trimming so long terrain names are
-            // truncated cleanly inside the fixed 140-wide column instead of
-            // overflowing into the neighbouring cell.
+            // truncated cleanly inside the fixed 92-wide column instead of
+            // overflowing into the neighbouring cell. (#1721 narrowed the label
+            // from 140->92 so the 5 columns fit a 1440px macOS screen.)
             Assert.Contains("TextTrimming = global::Avalonia.Media.TextTrimming.CharacterEllipsis", src);
-            Assert.Contains("Width = 140", src);
+            Assert.Contains("Width = 92", src);
 
             // The NUD must have an explicit Width and left alignment — relying
             // on MinWidth alone let the spinner buttons bleed into the neighbour.
-            Assert.Contains("Width = 110", src);
+            // (#1721 raised the NUD from 110->120 so it clears the ~120px Avalonia
+            // NumericUpDown min-width instead of clamping wider and overflowing.)
+            Assert.Contains("Width = 120", src);
             Assert.Contains("HorizontalAlignment = HorizontalAlignment.Left", src);
 
             // Guard against the regressed pattern returning.

--- a/FEBuilderGBA.Avalonia.Tests/ImageBattleScreenPaletteLayoutTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ImageBattleScreenPaletteLayoutTests.cs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Layout regression tests for ImageBattleScreenView's Palette grid (#1724).
+//
+// Root cause: the 16-column palette grid holds 48 R/G/B NumericUpDowns at
+// Width=60 columns (Increment=8, Margin=2 => ~56px inner). Each NUD clamps to
+// its ~120px spinner-chrome minimum and overlaps neighbours. Widening to >=120px
+// x 16 = 1920px is rejected (pushes colours off-screen), so we collapse the
+// spinners instead: a Grid.Styles implicit style sets ShowButtonSpinner=False
+// scoped to PaletteGrid, turning each NUD into a compact text field that fits
+// 56px. AllowSpin stays true so focused wheel/keyboard +/-8 still works.
+//
+// This DOES reproduce on Windows headless, so these tests are meaningful here.
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.VisualTree;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    public class ImageBattleScreenPaletteLayoutTests
+    {
+        private readonly ITestOutputHelper _output;
+        public ImageBattleScreenPaletteLayoutTests(ITestOutputHelper output) => _output = output;
+
+        /// <summary>
+        /// Every NumericUpDown inside PaletteGrid must have its spinner buttons
+        /// collapsed (ShowButtonSpinner=false) so it fits the 56px inner column.
+        /// </summary>
+        [AvaloniaFact]
+        public void PaletteNuds_HaveSpinnerButtonsCollapsed()
+        {
+            var view = new ImageBattleScreenView();
+            view.Show();
+            try
+            {
+                view.UpdateLayout();
+                var grid = view.FindControl<Grid>("PaletteGrid");
+                Assert.NotNull(grid);
+
+                var nuds = grid!.GetVisualDescendants().OfType<NumericUpDown>().ToList();
+                // 16 columns x 3 (R/G/B) = 48 palette spinners.
+                Assert.Equal(48, nuds.Count);
+
+                foreach (var nud in nuds)
+                {
+                    Assert.False(nud.ShowButtonSpinner,
+                        $"Palette NUD '{nud.Name}' must have ShowButtonSpinner=false so it fits " +
+                        "the 56px column without overlapping its neighbour (#1724).");
+                    // AllowSpin must remain true so focused wheel/keyboard +/-8 works.
+                    Assert.True(nud.AllowSpin,
+                        $"Palette NUD '{nud.Name}' should keep AllowSpin=true for wheel/keyboard editing.");
+                }
+            }
+            finally
+            {
+                view.Close();
+            }
+        }
+
+        /// <summary>
+        /// With the spinners collapsed, adjacent palette NUDs (left-to-right) must
+        /// not overlap at the 60px column width.
+        /// </summary>
+        [AvaloniaFact]
+        public void PaletteNuds_DoNotOverlapHorizontally()
+        {
+            var view = new ImageBattleScreenView();
+            view.Show();
+            try
+            {
+                view.Width = 1280;
+                view.Height = 900;
+                view.Measure(new Size(1280, 900));
+                view.Arrange(new Rect(0, 0, 1280, 900));
+                view.UpdateLayout();
+
+                var grid = view.FindControl<Grid>("PaletteGrid");
+                Assert.NotNull(grid);
+
+                var nuds = grid!.GetVisualDescendants().OfType<NumericUpDown>()
+                    .Select(n => new { N = n, P = n.TranslatePoint(new Point(0, 0), view) })
+                    .Where(x => x.P.HasValue && x.N.Bounds.Width > 0)
+                    .ToList();
+                Assert.True(nuds.Count >= 48, $"expected 48 palette NUDs, got {nuds.Count}");
+
+                // Group into rows by Y, then check left-to-right adjacency per row.
+                var rows = nuds.GroupBy(x => System.Math.Round(x.P!.Value.Y / 4) * 4);
+                int overlaps = 0;
+                foreach (var row in rows)
+                {
+                    var ordered = row.OrderBy(x => x.P!.Value.X).ToList();
+                    for (int i = 0; i + 1 < ordered.Count; i++)
+                    {
+                        double aRight = ordered[i].P!.Value.X + ordered[i].N.Bounds.Width;
+                        double bLeft = ordered[i + 1].P!.Value.X;
+                        if (aRight > bLeft + 0.5)
+                        {
+                            overlaps++;
+                            _output.WriteLine(
+                                $"overlap: #{i} right={aRight:F0} > #{i + 1} left={bLeft:F0} (y~{ordered[i].P!.Value.Y:F0})");
+                        }
+                    }
+                }
+
+                Assert.True(overlaps == 0,
+                    $"{overlaps} adjacent palette NUD pair(s) overlap at 60px columns (#1724).");
+            }
+            finally
+            {
+                view.Close();
+            }
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/MoveCostEditorLayoutTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/MoveCostEditorLayoutTests.cs
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Layout regression tests for MoveCostEditorView (#1721).
+//
+// Root cause (verified against the reporter's 1440x900 macOS screenshot): each
+// terrain cell is a horizontal StackPanel [TextBlock label][NumericUpDown] placed
+// into a 5-column Grid with ColumnDefinitions="*,*,*,*,*". The window is
+// Width=1601 SizeToContent=WidthAndHeight; on a 1440px macOS screen the window is
+// clamped, and because the right-pane ScrollViewer had horizontal scrolling
+// disabled (Avalonia default), the 5 "*" columns were forced to share the clamped
+// viewport. Under macOS's wider system font each fixed-width cell (label +
+// NumericUpDown) exceeds its share, so the NUD's spinner buttons overlap the NEXT
+// column's "0xNN Name" label (clearly visible in the issue screenshot).
+//
+// Fix: Auto (content-sized) grid columns + narrower label (92) + wider NUD (120,
+// >= the ~120px Avalonia NUD minimum) + HorizontalScrollBarVisibility=Auto.
+//
+// TEST NOTE (honest discrimination): the headless Windows layout engine sizes
+// "*" columns to MAX(proportional-share, content-desired-width) and never
+// compresses them below content — so it cannot reproduce the macOS wider-font
+// compression that triggers the overlap. The primary discriminator here is
+// therefore STRUCTURAL: TerrainGrid's columns must be Auto (content-sized), which
+// is the exact invariant that makes the columns immune to compression-overlap on
+// ANY font/screen. A secondary geometric guard asserts no sibling overlap at the
+// realized layout (catches future width-budget regressions).
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
+using Avalonia.VisualTree;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    public class MoveCostEditorLayoutTests
+    {
+        private readonly ITestOutputHelper _output;
+        public MoveCostEditorLayoutTests(ITestOutputHelper output) => _output = output;
+
+        [AvaloniaFact]
+        public void MoveCostEditorView_CanInstantiate()
+        {
+            var v = new MoveCostEditorView();
+            Assert.NotNull(v.Content);
+        }
+
+        /// <summary>
+        /// The right-pane content ScrollViewer must allow horizontal scrolling so
+        /// the grid stays reachable on screens narrower than its content (#1721).
+        /// </summary>
+        [AvaloniaFact]
+        public void ContentScrollViewer_AllowsHorizontalScroll()
+        {
+            var v = new MoveCostEditorView();
+            var scroller = v.GetLogicalDescendants().OfType<ScrollViewer>()
+                .FirstOrDefault(sv => Grid.GetColumn(sv) == 1)
+                ?? v.GetLogicalDescendants().OfType<ScrollViewer>().FirstOrDefault();
+            Assert.NotNull(scroller);
+            Assert.Equal(global::Avalonia.Controls.Primitives.ScrollBarVisibility.Auto,
+                scroller!.HorizontalScrollBarVisibility);
+        }
+
+        /// <summary>
+        /// PRIMARY discrimination guard (#1721). The TerrainGrid's 5 columns must
+        /// be content-sized (GridUnitType.Auto), NOT star ("*"). Auto columns grow
+        /// to fit each cell's content on any font/screen, so they can never be
+        /// compressed below content width — which is exactly the macOS wider-font
+        /// compression that pushed each NUD's spinner over the next column's label.
+        /// This FAILS against the pre-fix "*,*,*,*,*" layout and PASSES on the fix,
+        /// independent of the headless engine's "*"-sizing quirk.
+        /// </summary>
+        [AvaloniaFact]
+        public void TerrainGrid_Columns_AreContentSized_NotStar()
+        {
+            var view = new MoveCostEditorView();
+            try
+            {
+                var grid = view.FindControl<Grid>("TerrainGrid");
+                Assert.NotNull(grid);
+                Assert.Equal(5, grid!.ColumnDefinitions.Count);
+
+                foreach (var col in grid.ColumnDefinitions)
+                {
+                    Assert.True(col.Width.IsAuto,
+                        $"TerrainGrid column must be Auto (content-sized) so it cannot compress " +
+                        $"below content and overlap the neighbour on macOS (#1721); found '{col.Width}'.");
+                    Assert.False(col.Width.IsStar,
+                        "TerrainGrid columns must NOT be '*' — star columns compress under the " +
+                        "macOS wider font and the NUD spinner overlaps the next column's label (#1721).");
+                }
+            }
+            finally
+            {
+                (view as Window)?.Close();
+            }
+        }
+
+        /// <summary>
+        /// SECONDARY geometric guard (#1721): at the realized layout, no terrain
+        /// NUD's right edge may cross into the next column's label left edge. This
+        /// catches a future width-budget regression (e.g. someone re-widening the
+        /// label past the NUD column gap) even while the columns stay Auto. (On the
+        /// headless engine Auto columns never compress, so this is a guard, not the
+        /// primary pre-fix discriminator — see the structural test above.)
+        /// </summary>
+        [AvaloniaFact]
+        public void TerrainGrid_NudsDoNotOverlapNextColumnLabel_AtRealizedLayout()
+        {
+            var view = new MoveCostEditorView();
+            view.Show();
+            try
+            {
+                view.UpdateLayout();
+
+                var grid = view.FindControl<Grid>("TerrainGrid");
+                Assert.NotNull(grid);
+
+                var labels = grid!.GetVisualDescendants().OfType<TextBlock>()
+                    .Select(t => new Box(t, t.TranslatePoint(new Point(0, 0), grid), t.Bounds.Width))
+                    .Where(b => b.P.HasValue && b.W > 0)
+                    .ToList();
+                var nuds = grid.GetVisualDescendants().OfType<NumericUpDown>()
+                    .Select(n => new Box(n, n.TranslatePoint(new Point(0, 0), grid), n.Bounds.Width))
+                    .Where(b => b.P.HasValue && b.W > 0)
+                    .ToList();
+
+                Assert.Equal(65, nuds.Count);
+                Assert.Equal(65, labels.Count);
+
+                int overlaps = 0;
+                var detail = new List<string>();
+
+                foreach (var nud in nuds)
+                {
+                    double nudLeft = nud.P!.Value.X;
+                    double nudRight = nudLeft + nud.W;
+                    double nudY = nud.P!.Value.Y;
+
+                    Box? nextLabel = labels
+                        .Where(l => l.P!.Value.X > nudLeft + 1 // strictly to the right
+                                    && System.Math.Abs(l.P!.Value.Y - nudY) < 14) // same row band
+                        .OrderBy(l => l.P!.Value.X)
+                        .FirstOrDefault();
+
+                    if (nextLabel == null) continue; // last column on this row
+
+                    double labelLeft = nextLabel.P!.Value.X;
+                    if (nudRight > labelLeft + 0.5)
+                    {
+                        overlaps++;
+                        detail.Add($"NUD right={nudRight:F0} > nextLabel left={labelLeft:F0} (y~{nudY:F0})");
+                    }
+                }
+
+                _output.WriteLine($"checked {nuds.Count} NUDs; overlaps={overlaps}");
+                if (detail.Count > 0)
+                    _output.WriteLine(string.Join("\n", detail.Take(10)));
+
+                Assert.True(overlaps == 0,
+                    $"{overlaps} terrain NUD(s) overlap the next column's label (#1721). " +
+                    $"Sample:\n{string.Join("\n", detail.Take(5))}");
+            }
+            finally
+            {
+                view.Close();
+            }
+        }
+
+        private sealed class Box
+        {
+            public Control C { get; }
+            public Point? P { get; }
+            public double W { get; }
+            public Box(Control c, Point? p, double w) { C = c; P = p; W = w; }
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/MoveCostTerrainNameSanitizeTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/MoveCostTerrainNameSanitizeTests.cs
@@ -1,0 +1,49 @@
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    /// <summary>
+    /// #1722: Move Cost editor terrain names must not contain control / non-printable
+    /// characters (they render as tofu (box) on macOS). FE8U's terrain-name table
+    /// decodes most names with a trailing U+001F byte and empty slots as U+007F U+007F.
+    /// <see cref="MoveCostEditorViewModel.LoadTerrainNames"/> now sanitizes the
+    /// decoded name via <c>U.ToOneLineCaption</c> before composing the display label.
+    ///
+    /// Loads a real ROM via <see cref="RomTestHelper"/>; skips cleanly (no asserts)
+    /// when no ROM is available (CI without roms.zip).
+    /// </summary>
+    [Collection("SharedState")]
+    public class MoveCostTerrainNameSanitizeTests
+    {
+        [Theory]
+        [InlineData("FE8U")]
+        [InlineData("FE7U")]
+        [InlineData("FE8J")]
+        [InlineData("FE7J")]
+        [InlineData("FE6")]
+        public void TerrainNames_ContainNoControlChars(string version)
+        {
+            RomTestHelper.WithRom(version, () =>
+            {
+                var vm = new MoveCostEditorViewModel();
+                vm.LoadTerrainNames();
+
+                Assert.NotNull(vm.TerrainNames);
+                Assert.Equal(MoveCostEditorViewModel.TerrainCount, vm.TerrainNames.Length);
+
+                for (int i = 0; i < vm.TerrainNames.Length; i++)
+                {
+                    string name = vm.TerrainNames[i] ?? "";
+                    foreach (char c in name)
+                    {
+                        Assert.False(char.IsControl(c),
+                            $"[{version}] terrain name #{i} (\"{name}\") contains control char " +
+                            $"U+{((int)c):X4} which renders as tofu on macOS (#1722).");
+                    }
+                }
+            });
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/ViewModels/MoveCostEditorViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/MoveCostEditorViewModel.cs
@@ -312,6 +312,11 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                                     decoded = FETextDecode.Direct(textId);
                             }
                         }
+                        // #1722: decoded terrain names (esp. FE8U non-multibyte,
+                        // Huffman-decoded) can carry trailing/embedded FE control
+                        // or other non-printable characters that render as tofu (□)
+                        // on macOS. Reduce to one clean caption line before use.
+                        decoded = U.ToOneLineCaption(decoded);
                         if (!string.IsNullOrEmpty(decoded))
                             name = $"0x{i:X2} {decoded}";
                     }

--- a/FEBuilderGBA.Avalonia/Views/EventUnitColorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EventUnitColorView.axaml
@@ -14,9 +14,13 @@
                    Text="Please specify the color you want to change."
                    HorizontalAlignment="Center" VerticalAlignment="Center" TextWrapping="Wrap" />
       </Border>
+      <!-- #1727: VerticalContentAlignment=Center (+ symmetric Padding) so the
+           "Apply" glyph sits in the middle of the 40px button instead of above
+           centre. (HorizontalContentAlignment + VerticalAlignment came from #1703.) -->
       <Button AutomationProperties.AutomationId="EventUnitColor_Apply_Button" Grid.Column="1"
               Name="ApplyButton" Content="Apply" Width="150" Height="40"
               VerticalAlignment="Center" HorizontalContentAlignment="Center"
+              VerticalContentAlignment="Center" Padding="8,0"
               Margin="8,0,0,0" Click="Apply_Click" />
     </Grid>
 

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml
@@ -155,6 +155,21 @@
 
               <!-- 16-column palette grid (Swatch + Index + R/G/B) -->
               <Grid Name="PaletteGrid">
+                <!-- #1724: collapse the 48 palette R/G/B spinner buttons AND drop
+                     the global 120px NumericUpDown MinWidth (set in App.axaml) so
+                     each NUD becomes a compact text field that fits the 56px inner
+                     column. Widening the NUDs to their 120px clamp minimum would
+                     push 16 colour columns to ~1920px (off-screen), so we shrink
+                     them instead. AllowSpin stays true, so focused mouse-wheel ±8
+                     and keyboard up/down ±8 still work. Scoped to PaletteGrid only
+                     — the read-only PaletteAddressBox (outside this grid) keeps the
+                     global 120px MinWidth. -->
+                <Grid.Styles>
+                  <Style Selector="NumericUpDown">
+                    <Setter Property="ShowButtonSpinner" Value="False" />
+                    <Setter Property="MinWidth" Value="0" />
+                  </Style>
+                </Grid.Styles>
                 <Grid.RowDefinitions>
                   <RowDefinition Height="36" />
                   <RowDefinition Height="32" />

--- a/FEBuilderGBA.Avalonia/Views/MoveCostEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MoveCostEditorView.axaml
@@ -7,7 +7,7 @@
   <Grid ColumnDefinitions="250,*">
     <controls:AddressListControl AutomationProperties.AutomationId="MoveCostEditor_Class_List" Grid.Column="0" Name="ClassList" Margin="4" />
 
-    <ScrollViewer Grid.Column="1" Margin="4">
+    <ScrollViewer Grid.Column="1" Margin="4" HorizontalScrollBarVisibility="Auto">
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="Move Cost Editor" FontSize="18" FontWeight="Bold" />
 
@@ -26,9 +26,12 @@
 
         <TextBlock AutomationProperties.AutomationId="MoveCostEditor_CostType_Label" Name="CostTypeLabel" Text="Terrain Move Costs (65 terrains: 0x00 - 0x40):" FontWeight="SemiBold" Margin="0,4,0,4" />
 
-        <!-- 5 columns of terrain costs, 13 rows each -->
+        <!-- 5 columns of terrain costs, 13 rows each.
+             #1721: Auto (content-sized) columns so each fixed-width cell never
+             compresses below its content; on a narrow (1440px) macOS screen the
+             5 * columns previously squeezed to ~230px and overlapped. -->
         <Border BorderBrush="Gray" BorderThickness="1" Padding="8" CornerRadius="4">
-          <Grid Name="TerrainGrid" ColumnDefinitions="*,*,*,*,*" />
+          <Grid Name="TerrainGrid" ColumnDefinitions="Auto,Auto,Auto,Auto,Auto" />
         </Border>
       </StackPanel>
     </ScrollViewer>

--- a/FEBuilderGBA.Avalonia/Views/MoveCostEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MoveCostEditorView.axaml.cs
@@ -50,14 +50,17 @@ namespace FEBuilderGBA.Avalonia.Views
 
                     var rowPanel = new StackPanel { Orientation = global::Avalonia.Layout.Orientation.Horizontal, Spacing = 6, Margin = new Thickness(0, 1) };
 
-                    // #1685: terrain names can be long. Keep the fixed 140-wide
-                    // label column (so the rows stay aligned) but trim with an
-                    // ellipsis inside that width so a long name is truncated
-                    // cleanly instead of overflowing into the neighbouring cell.
+                    // #1685: terrain names can be long. Keep a fixed label column
+                    // (so the rows stay aligned) but trim with an ellipsis inside
+                    // that width so a long name is truncated cleanly instead of
+                    // overflowing into the neighbouring cell.
+                    // #1721: narrow the label to 92 (was 140) so the 5 content-sized
+                    // (Auto) columns fit a 1440px macOS screen without compressing
+                    // and overlapping into the next column's label.
                     var label = new TextBlock
                     {
                         Text = $"0x{index:X2}",
-                        Width = 140,
+                        Width = 92,
                         TextTrimming = global::Avalonia.Media.TextTrimming.CharacterEllipsis,
                         VerticalAlignment = VerticalAlignment.Center,
                         Margin = new Thickness(0, 0, 4, 0),
@@ -67,12 +70,14 @@ namespace FEBuilderGBA.Avalonia.Views
 
                     // #1685: pin an explicit width + left alignment so the spinner buttons
                     // stay inside the field and never overlap the adjacent column.
+                    // #1721: raise to 120 (was 110) so the NUD meets Avalonia's ~120px
+                    // minimum width and does not clamp-overflow its declared box.
                     var nud = new NumericUpDown
                     {
                         Minimum = 0,
                         Maximum = 255,
                         Value = 0,
-                        Width = 110,
+                        Width = 120,
                         HorizontalAlignment = HorizontalAlignment.Left,
                         FontSize = 11,
                         Tag = index,

--- a/FEBuilderGBA.Avalonia/Views/PackedMemorySlotView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/PackedMemorySlotView.axaml
@@ -13,8 +13,10 @@
         <TextBlock AutomationProperties.AutomationId="PackedMemorySlot_Message_Label" Name="MESSAGE" Text="Packed Memory Slot"
                    HorizontalAlignment="Center" VerticalAlignment="Center" />
       </Border>
+      <!-- #1727: VerticalContentAlignment=Center so the "Apply" glyph is centred
+           in the 40px button (sibling of EventUnitColorView; same latent defect). -->
       <Button AutomationProperties.AutomationId="PackedMemorySlot_Apply_Button" Grid.Column="1" Name="ApplyButton" Content="Apply" Width="181" Height="40"
-              VerticalAlignment="Center"
+              VerticalAlignment="Center" VerticalContentAlignment="Center"
               Margin="8,0,0,0" Click="Apply_Click" />
     </Grid>
     <!-- Main panel: A = B + C combo boxes (WinForms panel8 674x82) -->

--- a/FEBuilderGBA.Avalonia/Views/UbyteBitFlagView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/UbyteBitFlagView.axaml
@@ -13,8 +13,10 @@
         <TextBlock AutomationProperties.AutomationId="UbyteBitFlag_MESSAGE_Label" Name="MESSAGE" Text="Byte Bit Flags (8-bit)"
                    HorizontalAlignment="Center" VerticalAlignment="Center" />
       </Border>
+      <!-- #1727: VerticalContentAlignment=Center so the "Apply" glyph is centred
+           in the 40px button (sibling of EventUnitColorView; same latent defect). -->
       <Button AutomationProperties.AutomationId="UbyteBitFlag_Apply_Button" Grid.Column="1" Name="ApplyButton" Content="Apply" Width="181" Height="40"
-              VerticalAlignment="Center"
+              VerticalAlignment="Center" VerticalContentAlignment="Center"
               Margin="8,0,0,0" Click="OK_Click" />
     </Grid>
     <!-- Main panel: GroupBox with hex NumericUpDown + 8 checkboxes (WinForms panel8 674x317) -->

--- a/FEBuilderGBA.Avalonia/Views/UshortBitFlagView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/UshortBitFlagView.axaml
@@ -13,8 +13,10 @@
         <TextBlock AutomationProperties.AutomationId="UshortBitFlag_MESSAGE_Label" Name="MESSAGE" Text="Short Bit Flags (16-bit)"
                    HorizontalAlignment="Center" VerticalAlignment="Center" />
       </Border>
+      <!-- #1727: VerticalContentAlignment=Center so the "Apply" glyph is centred
+           in the 40px button (sibling of EventUnitColorView; same latent defect). -->
       <Button AutomationProperties.AutomationId="UshortBitFlag_Apply_Button" Grid.Column="1" Name="ApplyButton" Content="Apply" Width="181" Height="40"
-              VerticalAlignment="Center"
+              VerticalAlignment="Center" VerticalContentAlignment="Center"
               Margin="8,0,0,0" Click="OK_Click" />
     </Grid>
     <!-- Main panel: Two side-by-side GroupBoxes (WinForms J_40 333x316 + J_41 333x316) -->

--- a/FEBuilderGBA.Avalonia/Views/UwordBitFlagView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/UwordBitFlagView.axaml
@@ -13,8 +13,10 @@
         <TextBlock AutomationProperties.AutomationId="UwordBitFlag_MESSAGE_Label" Name="MESSAGE" Text="Word Bit Flags (32-bit)"
                    HorizontalAlignment="Center" VerticalAlignment="Center" />
       </Border>
+      <!-- #1727: VerticalContentAlignment=Center so the "Apply" glyph is centred
+           in the 40px button (sibling of EventUnitColorView; same latent defect). -->
       <Button AutomationProperties.AutomationId="UwordBitFlag_Apply_Button" Grid.Column="1" Name="ApplyButton" Content="Apply" Width="181" Height="40"
-              VerticalAlignment="Center"
+              VerticalAlignment="Center" VerticalContentAlignment="Center"
               Margin="8,0,0,0" Click="OK_Click" />
     </Grid>
     <!-- Main panel: Four side-by-side GroupBoxes (WinForms J_40/41/42/43) -->

--- a/FEBuilderGBA.Core.Tests/UToOneLineCaptionTests.cs
+++ b/FEBuilderGBA.Core.Tests/UToOneLineCaptionTests.cs
@@ -1,0 +1,120 @@
+using Xunit;
+using FEBuilderGBA;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    /// <summary>
+    /// #1722: <see cref="U.ToOneLineCaption(string)"/> sanitizes a decoded ROM
+    /// string into a single clean caption line, stripping control / non-printable
+    /// code points (which render as tofu (box) on macOS) while preserving
+    /// legitimate printable glyphs (incl. non-ASCII).
+    ///
+    /// The synthetic strings below use the EXACT offending code points captured
+    /// empirically from FE8U's terrain-name table:
+    ///   - terrain names decode with a trailing U+001F control byte
+    ///     (e.g. FETextDecode.Direct returns "Plain" for terrain 0x01);
+    ///   - empty slots decode to U+007F U+007F (two DELETE chars).
+    /// We embed these via \u escapes so the compiler bakes the real control
+    /// code points into the test input (the test would be meaningless otherwise).
+    /// </summary>
+    public class UToOneLineCaptionTests
+    {
+        // The exact two offending code points found in the FE8U dump.
+        const char US = (char)0x1F;   // UNIT SEPARATOR — trailing on terrain names
+        const char DEL = (char)0x7F;  // DELETE — empty terrain slots (x2)
+
+        [Fact]
+        public void StripsTrailingU001FControlByte_FE8UTerrainNameCase()
+        {
+            // "Plain" — the EXACT shape FETextDecode.Direct returns for FE8U
+            // terrain name 0x01. The trailing U+001F is the tofu source on macOS.
+            string raw = "Plain" + US;
+            Assert.Contains(raw, char.IsControl); // precondition: input is dirty
+            string clean = U.ToOneLineCaption(raw);
+            Assert.Equal("Plain", clean);
+            AssertNoControlChars(clean);
+        }
+
+        [Fact]
+        public void EmptySlotOfTwoDeleteChars_BecomesEmpty()
+        {
+            // Empty terrain slots (0x00, 0x2C, 0x2E) decode to U+007F U+007F — two
+            // DELETE chars that render as two tofu boxes. They must collapse away.
+            string raw = new string(new[] { DEL, DEL });
+            Assert.Contains(raw, char.IsControl); // precondition: input is dirty
+            string clean = U.ToOneLineCaption(raw);
+            Assert.Equal("", clean);
+            AssertNoControlChars(clean);
+        }
+
+        [Fact]
+        public void TakesOnlyFirstLine_OfMultiLineInput()
+        {
+            string raw = "First line\r\nSecond line\nThird";
+            string clean = U.ToOneLineCaption(raw);
+            Assert.Equal("First line", clean);
+            AssertNoControlChars(clean);
+        }
+
+        [Fact]
+        public void StripsEmbeddedControlChars_KeepsSurroundingText()
+        {
+            // Embedded control bytes anywhere (not just trailing) are removed,
+            // while the printable text around them is preserved.
+            string raw = "Vil" + US + "lage" + US;
+            string clean = U.ToOneLineCaption(raw);
+            Assert.Equal("Village", clean);
+            AssertNoControlChars(clean);
+        }
+
+        [Fact]
+        public void PreservesPrintableNonAsciiGlyphs()
+        {
+            // Localized names (CJK, accented Latin) must survive intact — we only
+            // strip control/non-printable, NOT legitimate glyphs.
+            string raw = "草原" + US;        // "草原" + trailing tofu byte
+            string clean = U.ToOneLineCaption(raw);
+            Assert.Equal("草原", clean);
+            AssertNoControlChars(clean);
+
+            string accented = "Forêt" + US;     // "Forêt" + tofu byte
+            Assert.Equal("Forêt", U.ToOneLineCaption(accented));
+        }
+
+        [Fact]
+        public void PreservesInteriorSpaces_TrimsOuterWhitespace()
+        {
+            string raw = "  Sand Bar  " + US;
+            string clean = U.ToOneLineCaption(raw);
+            Assert.Equal("Sand Bar", clean);
+            AssertNoControlChars(clean);
+        }
+
+        [Fact]
+        public void PreservesSupplementaryPlaneSurrogatePair()
+        {
+            // A real supplementary-plane glyph (😀, U+1F600) is a surrogate pair —
+            // it must NOT be dropped as a "surrogate" non-printable.
+            string raw = "Map \U0001F600" + US;
+            string clean = U.ToOneLineCaption(raw);
+            Assert.Equal("Map \U0001F600", clean);
+            AssertNoControlChars(clean);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void NullOrEmpty_ReturnsEmpty(string? input)
+        {
+            string clean = U.ToOneLineCaption(input!);
+            Assert.Equal("", clean);
+        }
+
+        static void AssertNoControlChars(string s)
+        {
+            foreach (char c in s)
+                Assert.False(char.IsControl(c),
+                    $"sanitized caption must contain no control chars, found U+{((int)c):X4}");
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/UToOneLineCaptionTests.cs
+++ b/FEBuilderGBA.Core.Tests/UToOneLineCaptionTests.cs
@@ -14,8 +14,9 @@ namespace FEBuilderGBA.Core.Tests
     ///   - terrain names decode with a trailing U+001F control byte
     ///     (e.g. FETextDecode.Direct returns "Plain" for terrain 0x01);
     ///   - empty slots decode to U+007F U+007F (two DELETE chars).
-    /// We embed these via \u escapes so the compiler bakes the real control
-    /// code points into the test input (the test would be meaningless otherwise).
+    /// We embed these via <c>const char</c> casts (<c>(char)0x1F</c> / <c>(char)0x7F</c>)
+    /// so the compiler bakes the real control code points into the test input (the
+    /// test would be meaningless otherwise).
     /// </summary>
     public class UToOneLineCaptionTests
     {

--- a/FEBuilderGBA.Core/U.cs
+++ b/FEBuilderGBA.Core/U.cs
@@ -1345,16 +1345,21 @@ namespace FEBuilderGBA
         /// terrain names) can carry trailing/embedded FE control or other
         /// non-printable characters which render as tofu (□) on macOS where no
         /// font has a glyph for them. We:
-        ///   - take only the first line (split on CR/LF), and
-        ///   - drop control characters (<see cref="char.IsControl(char)"/>) and
-        ///     other non-printable code points,
-        /// while PRESERVING all legitimate printable glyphs (incl. non-ASCII CJK,
-        /// accented letters, symbols) so localized names are unaffected.
-        /// Surrogate pairs are kept intact.
+        ///   - take only the first line (split on CR/LF),
+        ///   - drop control characters (<see cref="char.IsControl(char)"/>) plus
+        ///     the <see cref="System.Globalization.UnicodeCategory.Format"/>,
+        ///     lone-surrogate and unassigned categories, and
+        ///   - trim outer whitespace from the result.
+        /// All legitimate printable glyphs (incl. non-ASCII CJK, accented letters,
+        /// symbols) are PRESERVED so localized names are unaffected, and surrogate
+        /// pairs (real supplementary-plane glyphs) are kept intact.
+        /// Note: dropping the Format category also removes zero-width joiners and
+        /// variation selectors — harmless for ROM terrain/name captions.
+        /// Accepts <c>null</c> (returns an empty string).
         /// </summary>
-        public static string ToOneLineCaption(string text)
+        public static string ToOneLineCaption(string? text)
         {
-            if (string.IsNullOrEmpty(text)) return text ?? "";
+            if (string.IsNullOrEmpty(text)) return "";
 
             var sb = new System.Text.StringBuilder(text.Length);
             for (int i = 0; i < text.Length; i++)

--- a/FEBuilderGBA.Core/U.cs
+++ b/FEBuilderGBA.Core/U.cs
@@ -1338,6 +1338,55 @@ namespace FEBuilderGBA
         public static string nl2none(string lines) { return lines.Replace("\r\n", ""); }
         public static string nl2br(string lines) { return lines.Replace("\\r\\n", "\r\n"); }
         public static string br2nl(string lines) { return lines.Replace("\r\n", "\\r\\n"); }
+
+        /// <summary>
+        /// #1722: Reduce a decoded ROM string to a single clean caption line that
+        /// is safe to render as a UI list/label entry. Decoded names (e.g. FE8U
+        /// terrain names) can carry trailing/embedded FE control or other
+        /// non-printable characters which render as tofu (□) on macOS where no
+        /// font has a glyph for them. We:
+        ///   - take only the first line (split on CR/LF), and
+        ///   - drop control characters (<see cref="char.IsControl(char)"/>) and
+        ///     other non-printable code points,
+        /// while PRESERVING all legitimate printable glyphs (incl. non-ASCII CJK,
+        /// accented letters, symbols) so localized names are unaffected.
+        /// Surrogate pairs are kept intact.
+        /// </summary>
+        public static string ToOneLineCaption(string text)
+        {
+            if (string.IsNullOrEmpty(text)) return text ?? "";
+
+            var sb = new System.Text.StringBuilder(text.Length);
+            for (int i = 0; i < text.Length; i++)
+            {
+                char c = text[i];
+
+                // Stop at the first line break: a caption is a single line.
+                if (c == '\r' || c == '\n') break;
+
+                // Keep surrogate pairs (real supplementary-plane glyphs) intact.
+                if (char.IsHighSurrogate(c) && i + 1 < text.Length && char.IsLowSurrogate(text[i + 1]))
+                {
+                    sb.Append(c);
+                    sb.Append(text[i + 1]);
+                    i++;
+                    continue;
+                }
+
+                // Drop control chars and any other non-printable code point
+                // (format chars, lone surrogates, etc.). Keep everything else,
+                // including printable non-ASCII glyphs.
+                if (char.IsControl(c)) continue;
+                System.Globalization.UnicodeCategory cat = char.GetUnicodeCategory(c);
+                if (cat == System.Globalization.UnicodeCategory.Format
+                    || cat == System.Globalization.UnicodeCategory.Surrogate
+                    || cat == System.Globalization.UnicodeCategory.OtherNotAssigned)
+                    continue;
+
+                sb.Append(c);
+            }
+            return sb.ToString().Trim();
+        }
         public static string ToUnicode(uint code) { return code == 0 ? "" : ((char)code).ToString(); }
         public static string Reverse(string str) { char[] arr = str.ToCharArray(); Array.Reverse(arr); return new string(arr); }
         public static uint UpdateCheckBitBox(bool ch, uint a, uint bit)


### PR DESCRIPTION
## Summary

Round-3a of the #1674 macOS Avalonia campaign — four deterministic, Windows-verifiable GUI fixes, each in its own commit:

- **#1721 — Move Cost Editor grid overlap.** The 5 `*` columns compressed on the reporter's 1440px Mac screen (window asks for 1601px; right pane `ScrollViewer` had horizontal scrolling disabled), so each `[label 140][NumericUpDown 110]` cell overflowed into the next column's label. Fix: label→92 / NUD→120 (closes the budget at `5×≈218 + 250 ≈ 1380 < 1440`), `TerrainGrid` columns → `Auto` (no compression), and `HorizontalScrollBarVisibility="Auto"` as a safety net.
- **#1722 — Move Cost terrain-name tofu (□).** FE8U terrain names from `FETextDecode.Direct` carried control/non-printable chars that render as tofu on macOS. Fix: new reusable `U.ToOneLineCaption` (Core) strips control/non-printable + collapses to one line; applied in `LoadTerrainNames`. Legitimate names (Thicket, Wreck, Glacier…) are preserved.
- **#1724 — Battle Screen Palette 16-column overlap.** 16×60px columns each held an R/G/B `NumericUpDown` that clamps to ~120px and overlapped. Widening to 16×120px would push colours off-screen, so the spinners are collapsed via `ShowButtonSpinner="False"` (scoped to `PaletteGrid`; `AllowSpin`/keyboard ±8 preserved). The read-only `PaletteAddressBox` (outside the grid) is untouched.
- **#1727 — Unit Color "Apply" above centre.** The button set `HorizontalContentAlignment` but not `VerticalContentAlignment`. Fix: `VerticalContentAlignment="Center"` on all five shared clone dialogs (so the existing `ApplyButtonAlignmentTests` enforce it); `EventUnitColorView`'s Apply button additionally gets symmetric `Padding="8,0"`.

Plan + Copilot CLI plan review: https://github.com/laqieer/FEBuilderGBA/issues/1721#issuecomment-4841032121 (all five conditions incorporated). #1726 (shared `GbaImageControl` wheel/pinch zoom) is intentionally split into a separate PR.

## Scope

Closes #1721
Closes #1722
Closes #1724
Closes #1727

## Test plan

- [x] `MoveCostEditorLayoutTests` — **primary discriminator** `TerrainGrid_Columns_AreContentSized_NotStar` asserts the 5 columns are `Auto` (content-sized, not `*`); this is the structural invariant that prevents macOS-font column compression — it **fails on the pre-fix `*,*,*,*,*` layout and passes on the fix**. Plus `ContentScrollViewer_AllowsHorizontalScroll` and an unpinned realized-layout geometric guard. (Honest note: the **headless** layout engine sizes `*` columns to `MAX(share, content)` and never compresses them below content, so a font-metric-driven 1440px overlap repro cannot run on CI — the structural `Auto`-columns assertion is the reliable cross-platform discriminator. Earlier plan text describing a "1440×900-pinned overlap test" was superseded by this stronger structural approach.)
- [x] `FieldSpacingLayoutTests.MoveCostEditor_TerrainGridBuilder_TrimsNames_AndPinsNudWidth` — the pre-existing #1685 source-text width guard updated to the new label/NUD literals (`Width = 92` / `Width = 120`).
- [x] `MoveCostTerrainNameSanitizeTests` + `UToOneLineCaptionTests` (Core) — assert no sanitized terrain name contains a control char; cover control-char + multi-line synthetic inputs.
- [x] `ImageBattleScreenPaletteLayoutTests` — asserts the palette NUDs have `ShowButtonSpinner == false` and adjacent NUD bounds do not overlap at the 60px column width (reproduces on Windows).
- [x] `ApplyButtonAlignmentTests` — extended to assert `VerticalContentAlignment == Center` on all five clone dialogs (EventUnitColor, PackedMemorySlot, Ubyte/Ushort/Uword bit-flag).
- [x] All three desktop test projects pass locally (Core.Tests, Avalonia.Tests, FEBuilderGBA.Tests).

## GUI Test Report

Headless desktop-Skia renders (FE8U) of each affected editor after the fix:

| Editor | Issue | Result |
|---|---|---|
| Move Cost Editor | #1721 grid overlap | ✅ PASS — 5 columns + spinners no longer overlap |
| Move Cost Editor | #1722 terrain tofu | ✅ PASS — names render clean (no □), legitimate text intact |
| Battle Screen → Palette | #1724 16-col overlap | ✅ PASS — R/G/B fields compact, no overlap |
| Unit Color | #1727 Apply centring | ✅ PASS (Windows) — Apply glyph centred |

> #1727's root cause is partly macOS font-metric driven and cannot be visually reproduced on the Windows CI host; the fix is structurally verified by the alignment test, and macOS visual confirmation is requested from the reporter before final sign-off.

## Screenshots

**Move Cost Editor (#1721 + #1722)** — grid no longer overlaps, terrain names tofu-free:

![Move Cost editor](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr1721-1722-movecost-fe8u.png)

**Battle Screen → Palette (#1724)** — 16-column R/G/B grid no longer overlapping:

![Battle Screen palette](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr1724-battlescreen-palette-fe8u.png)

**Unit Color (#1727)** — Apply button glyph centred:

![Unit Color Apply](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr1727-unitcolor-apply.png)

---
_Generated with Claude Code — Opus 4.8 (1M context), model `claude-opus-4-8[1m]`._
