### PR TITLE
fix(avalonia): gate GbaImageControl wheel-zoom behind Ctrl/⌘ + add pinch-to-zoom (#1726)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GbaImageControlWheelZoomTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GbaImageControlWheelZoomTests.cs
@@ -159,11 +159,12 @@ public class GbaImageControlWheelZoomTests
         Assert.Equal(GbaImageControl.ZoomMax, control.Zoom);
         Assert.True(up.Handled);
 
-        // At min zoom, Ctrl+wheel down stays clamped.
+        // At min zoom, Ctrl+wheel down stays clamped (and still consumes the event).
         control.Zoom = GbaImageControl.ZoomMin;
         var down = MakeWheelArgs(image!, control, KeyModifiers.Control, deltaY: -1);
         control.OnPointerWheelChanged(image, down);
         Assert.Equal(GbaImageControl.ZoomMin, control.Zoom);
+        Assert.True(down.Handled);
     }
 
     /// <summary>
@@ -191,22 +192,30 @@ public class GbaImageControlWheelZoomTests
         control.Zoom = 4; // 256x256 content in a 120x120 viewport => scrollable
 
         var window = new Window { Width = 140, Height = 140, Content = control };
-        window.Show();
-        Dispatcher.UIThread.RunJobs(DispatcherPriority.Loaded);
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs(DispatcherPriority.Loaded);
 
-        // Park at a non-extreme offset so the ScrollViewer COULD scroll the wheel
-        // (the case where a bubble-phase handler would never see the event).
-        scroller!.Offset = new Vector(30, 30);
-        Dispatcher.UIThread.RunJobs(DispatcherPriority.Render);
+            // Park at a non-extreme offset so the ScrollViewer COULD scroll the wheel
+            // (the case where a bubble-phase handler would never see the event).
+            scroller!.Offset = new Vector(30, 30);
+            Dispatcher.UIThread.RunJobs(DispatcherPriority.Render);
 
-        control.Zoom = 4;
-        image!.RaiseEvent(MakeWheelArgs(image, control, KeyModifiers.Control, deltaY: 1));
-        Assert.Equal(5, control.Zoom);
+            control.Zoom = 4;
+            image!.RaiseEvent(MakeWheelArgs(image, control, KeyModifiers.Control, deltaY: 1));
+            Assert.Equal(5, control.Zoom);
 
-        control.Zoom = 4;
-        image.RaiseEvent(MakeWheelArgs(image, control, KeyModifiers.None, deltaY: 1));
-        Assert.Equal(4, control.Zoom);
-
-        window.Close();
+            control.Zoom = 4;
+            image.RaiseEvent(MakeWheelArgs(image, control, KeyModifiers.None, deltaY: 1));
+            Assert.Equal(4, control.Zoom);
+        }
+        finally
+        {
+            // Always close the window — if an assertion above throws, leaving it
+            // open can leak visuals/dispatcher state and make later AvaloniaFact
+            // tests flaky (Copilot review on PR #1738).
+            window.Close();
+        }
     }
 }

--- a/FEBuilderGBA.Avalonia.Tests/GbaImageControlWheelZoomTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GbaImageControlWheelZoomTests.cs
@@ -1,0 +1,212 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using FEBuilderGBA.Avalonia.Controls;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+/// <summary>
+/// Tests for the #1726 wheel/pinch zoom fix in <see cref="GbaImageControl"/>:
+/// plain wheel / macOS two-finger scroll must PAN (let the inner ScrollViewer
+/// scroll), while Ctrl/⌘+wheel and pinch ZOOM. The wheel handler is registered
+/// on the TUNNEL phase so it runs before the ScrollViewer even when the image is
+/// zoomed-in / scrollable.
+/// </summary>
+public class GbaImageControlWheelZoomTests
+{
+    // ---- Pure helper: ShouldWheelZoom (modifier gating) ----
+
+    [Theory]
+    [InlineData(KeyModifiers.Control, true)]
+    [InlineData(KeyModifiers.Meta, true)]
+    [InlineData(KeyModifiers.Control | KeyModifiers.Shift, true)]
+    [InlineData(KeyModifiers.Control | KeyModifiers.Meta, true)]
+    [InlineData(KeyModifiers.None, false)]
+    [InlineData(KeyModifiers.Shift, false)]
+    [InlineData(KeyModifiers.Alt, false)]
+    public void ShouldWheelZoom_OnlyWithControlOrMeta(KeyModifiers modifiers, bool expected)
+    {
+        Assert.Equal(expected, GbaImageControl.ShouldWheelZoom(modifiers));
+    }
+
+    // ---- Pure helper: PinchScaleToZoom (cumulative scale -> clamped int zoom) ----
+
+    [Theory]
+    [InlineData(1, 2.0, 2)]    // 1 * 2.0 = 2
+    [InlineData(4, 0.5, 2)]    // 4 * 0.5 = 2
+    [InlineData(2, 2.0, 4)]    // 2 * 2.0 = 4
+    [InlineData(8, 2.0, 8)]    // 16 -> clamp to max 8
+    [InlineData(1, 0.1, 1)]    // 0.1 -> round 0 -> clamp to min 1
+    [InlineData(1, 1.0, 1)]    // identity
+    [InlineData(2, 1.49, 3)]   // 2.98 -> round 3
+    [InlineData(2, 1.50, 3)]   // 3.00 -> 3
+    [InlineData(3, 0.5, 2)]    // 1.5 -> round away-from-zero -> 2
+    public void PinchScaleToZoom_RoundsAndClamps(int baseZoom, double scale, int expected)
+    {
+        Assert.Equal(expected, GbaImageControl.PinchScaleToZoom(baseZoom, scale));
+    }
+
+    [Fact]
+    public void PinchScaleToZoom_AlwaysWithinZoomRange()
+    {
+        for (int b = GbaImageControl.ZoomMin; b <= GbaImageControl.ZoomMax; b++)
+        {
+            foreach (double s in new[] { 0.01, 0.5, 1.0, 1.7, 4.0, 100.0 })
+            {
+                int z = GbaImageControl.PinchScaleToZoom(b, s);
+                Assert.InRange(z, GbaImageControl.ZoomMin, GbaImageControl.ZoomMax);
+            }
+        }
+    }
+
+    // ---- Structural: pinch gesture is wired up ----
+
+    [AvaloniaFact]
+    public void Constructor_RegistersPinchGestureRecognizer()
+    {
+        var control = new GbaImageControl();
+        var scroller = control.FindControl<ScrollViewer>("ImageScroller");
+        Assert.NotNull(scroller);
+
+        bool hasPinch = false;
+        foreach (var gr in scroller!.GestureRecognizers)
+        {
+            if (gr is PinchGestureRecognizer) { hasPinch = true; break; }
+        }
+        Assert.True(hasPinch, "ImageScroller should have a PinchGestureRecognizer for #1726 pinch-to-zoom.");
+    }
+
+    // ---- Routed-event smoke test: tunnel registration, non-extreme scroll state ----
+
+    static PointerWheelEventArgs MakeWheelArgs(Visual source, Visual root, KeyModifiers modifiers, double deltaY)
+    {
+        var pointer = new Pointer(0, PointerType.Mouse, isPrimary: true);
+        var props = new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.Other);
+        return new PointerWheelEventArgs(
+            source, pointer, root, new Point(40, 40), 0UL, props, modifiers, new Vector(0, deltaY))
+        {
+            RoutedEvent = InputElement.PointerWheelChangedEvent,
+        };
+    }
+
+    /// <summary>
+    /// Deterministic logic test: the wheel handler must zoom only with Ctrl/⌘ and
+    /// must leave a plain wheel UNHANDLED so the ScrollViewer can pan it (#1726).
+    /// </summary>
+    [AvaloniaFact]
+    public void OnPointerWheelChanged_GatesZoomAndLeavesPlainWheelUnhandled()
+    {
+        var control = new GbaImageControl();
+        var image = control.FindControl<Image>("ImageDisplay");
+        Assert.NotNull(image);
+
+        byte[] rgba = new byte[64 * 64 * 4];
+        for (int i = 0; i < rgba.Length; i++) rgba[i] = 0xFF;
+        control.SetRgbaData(rgba, 64, 64);
+
+        const int VP = 120;
+        control.Measure(new Size(VP, VP));
+        control.Arrange(new Rect(0, 0, VP, VP));
+
+        // Ctrl+wheel up: zooms in (4 -> 5) and consumes the event.
+        control.Zoom = 4;
+        var ctrlUp = MakeWheelArgs(image!, control, KeyModifiers.Control, deltaY: 1);
+        control.OnPointerWheelChanged(image, ctrlUp);
+        Assert.Equal(5, control.Zoom);
+        Assert.True(ctrlUp.Handled, "modifier-wheel zoom must mark the event handled (suppresses scroll)");
+
+        // Meta(⌘)+wheel down: zooms out (5 -> 4).
+        var metaDown = MakeWheelArgs(image!, control, KeyModifiers.Meta, deltaY: -1);
+        control.OnPointerWheelChanged(image, metaDown);
+        Assert.Equal(4, control.Zoom);
+        Assert.True(metaDown.Handled);
+
+        // Plain wheel up: does NOT zoom and is left UNHANDLED so the ScrollViewer pans.
+        var plainUp = MakeWheelArgs(image!, control, KeyModifiers.None, deltaY: 1);
+        control.OnPointerWheelChanged(image, plainUp);
+        Assert.Equal(4, control.Zoom);
+        Assert.False(plainUp.Handled, "plain wheel must stay unhandled so the ScrollViewer pans");
+
+        // Shift+wheel (horizontal scroll intent) also must not zoom.
+        var shiftUp = MakeWheelArgs(image!, control, KeyModifiers.Shift, deltaY: 1);
+        control.OnPointerWheelChanged(image, shiftUp);
+        Assert.Equal(4, control.Zoom);
+        Assert.False(shiftUp.Handled);
+    }
+
+    [AvaloniaFact]
+    public void OnPointerWheelChanged_RespectsZoomClamp()
+    {
+        var control = new GbaImageControl();
+        var image = control.FindControl<Image>("ImageDisplay");
+        Assert.NotNull(image);
+
+        byte[] rgba = new byte[16 * 16 * 4];
+        for (int i = 0; i < rgba.Length; i++) rgba[i] = 0xFF;
+        control.SetRgbaData(rgba, 16, 16);
+        control.Measure(new Size(120, 120));
+        control.Arrange(new Rect(0, 0, 120, 120));
+
+        // At max zoom, Ctrl+wheel up stays clamped (and still consumes the event).
+        control.Zoom = GbaImageControl.ZoomMax;
+        var up = MakeWheelArgs(image!, control, KeyModifiers.Control, deltaY: 1);
+        control.OnPointerWheelChanged(image, up);
+        Assert.Equal(GbaImageControl.ZoomMax, control.Zoom);
+        Assert.True(up.Handled);
+
+        // At min zoom, Ctrl+wheel down stays clamped.
+        control.Zoom = GbaImageControl.ZoomMin;
+        var down = MakeWheelArgs(image!, control, KeyModifiers.Control, deltaY: -1);
+        control.OnPointerWheelChanged(image, down);
+        Assert.Equal(GbaImageControl.ZoomMin, control.Zoom);
+    }
+
+    /// <summary>
+    /// Routing proof for the #1726 fix: with the image zoomed-in (scrollable) and
+    /// at a NON-EXTREME scroll offset, a Ctrl+wheel event RAISED ON THE INNER IMAGE
+    /// must still change Zoom. This only works because the handler is registered on
+    /// the TUNNEL phase (it runs before the ScrollViewer); a bubble-phase
+    /// registration would let the ScrollViewer consume the wheel first and zoom
+    /// would silently fail — the exact v1 defect the review board caught. The
+    /// control is hosted in a headless window so the routed event traverses a real,
+    /// rooted visual tree.
+    /// </summary>
+    [AvaloniaFact]
+    public void CtrlWheel_RoutesThroughTunnel_EvenWhenScrollable()
+    {
+        var control = new GbaImageControl();
+        var image = control.FindControl<Image>("ImageDisplay");
+        var scroller = control.FindControl<ScrollViewer>("ImageScroller");
+        Assert.NotNull(image);
+        Assert.NotNull(scroller);
+
+        byte[] rgba = new byte[64 * 64 * 4];
+        for (int i = 0; i < rgba.Length; i++) rgba[i] = 0xFF;
+        control.SetRgbaData(rgba, 64, 64);
+        control.Zoom = 4; // 256x256 content in a 120x120 viewport => scrollable
+
+        var window = new Window { Width = 140, Height = 140, Content = control };
+        window.Show();
+        Dispatcher.UIThread.RunJobs(DispatcherPriority.Loaded);
+
+        // Park at a non-extreme offset so the ScrollViewer COULD scroll the wheel
+        // (the case where a bubble-phase handler would never see the event).
+        scroller!.Offset = new Vector(30, 30);
+        Dispatcher.UIThread.RunJobs(DispatcherPriority.Render);
+
+        control.Zoom = 4;
+        image!.RaiseEvent(MakeWheelArgs(image, control, KeyModifiers.Control, deltaY: 1));
+        Assert.Equal(5, control.Zoom);
+
+        control.Zoom = 4;
+        image.RaiseEvent(MakeWheelArgs(image, control, KeyModifiers.None, deltaY: 1));
+        Assert.Equal(4, control.Zoom);
+
+        window.Close();
+    }
+}

--- a/FEBuilderGBA.Avalonia/Controls/GbaImageControl.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Controls/GbaImageControl.axaml.cs
@@ -26,23 +26,38 @@ namespace FEBuilderGBA.Avalonia.Controls
         double _scrollStartX;
         double _scrollStartY;
 
+        // Pinch-to-zoom state (#1726). PinchEventArgs.Scale is cumulative from
+        // 1.0 for the duration of a gesture, so we capture the zoom at gesture
+        // start and scale from it, resetting when the gesture ends.
+        bool _isPinching;
+        int _pinchBaseZoom;
+
         /// <summary>Minimum zoom factor.</summary>
         public const int ZoomMin = 1;
 
         /// <summary>Maximum zoom factor.</summary>
         public const int ZoomMax = 8;
 
-        /// <summary>Zoom multiplier per wheel notch (1.1 = 10% per notch).</summary>
-        internal const double WheelZoomFactor = 1.1;
-
         public GbaImageControl()
         {
             InitializeComponent();
             UpdateZoomLabel();
-            PointerWheelChanged += OnPointerWheelChanged;
+
+            // #1726: intercept the wheel in the TUNNEL phase so this handler runs
+            // BEFORE the inner ScrollViewer's bubble-phase scroll handler. On the
+            // modifier-zoom path we set e.Handled (pure zoom, no competing scroll);
+            // on plain wheel we leave it unhandled so the ScrollViewer pans. Tunnel
+            // ONLY (PointerWheelChangedEvent is Tunnel|Bubble) to avoid a double-fire.
+            AddHandler(PointerWheelChangedEvent, OnPointerWheelChanged, RoutingStrategies.Tunnel);
+
             ImageScroller.PointerPressed += OnScrollerPointerPressed;
             ImageScroller.PointerMoved += OnScrollerPointerMoved;
             ImageScroller.PointerReleased += OnScrollerPointerReleased;
+
+            // #1726: pinch-to-zoom for macOS trackpads / touch screens.
+            ImageScroller.GestureRecognizers.Add(new PinchGestureRecognizer());
+            Gestures.AddPinchHandler(ImageScroller, OnPinch);
+            Gestures.AddPinchEndedHandler(ImageScroller, OnPinchEnded);
         }
 
         /// <summary>Zoom factor (1 = 1:1, 2 = 2x, etc.).</summary>
@@ -167,49 +182,100 @@ namespace FEBuilderGBA.Avalonia.Controls
         }
 
         /// <summary>
-        /// Mouse wheel zoom centered on cursor position.
-        /// Keeps the content point under the cursor stable after zoom.
+        /// Whether a wheel event should zoom (vs. let the ScrollViewer pan).
+        /// Zoom only when Control or Meta (⌘) is held; a plain wheel / macOS
+        /// two-finger scroll pans. Pure helper so it can be unit-tested (#1726).
+        /// </summary>
+        internal static bool ShouldWheelZoom(KeyModifiers modifiers)
+            => (modifiers & (KeyModifiers.Control | KeyModifiers.Meta)) != 0;
+
+        /// <summary>
+        /// Map a cumulative pinch scale (relative to the zoom captured at gesture
+        /// start) to a clamped integer zoom factor. Pure helper for unit tests (#1726).
+        /// </summary>
+        internal static int PinchScaleToZoom(int baseZoom, double scale)
+        {
+            int z = (int)Math.Round(baseZoom * scale, MidpointRounding.AwayFromZero);
+            return Math.Max(ZoomMin, Math.Min(ZoomMax, z));
+        }
+
+        /// <summary>
+        /// Mouse-wheel zoom centered on the cursor, gated behind Ctrl/⌘ (#1726).
+        /// Registered on the tunnel phase so it runs before the inner ScrollViewer:
+        /// a plain wheel returns unhandled (ScrollViewer pans); a modifier wheel
+        /// zooms and marks the event handled (suppressing the scroll).
         /// </summary>
         internal void OnPointerWheelChanged(object? sender, PointerWheelEventArgs e)
         {
-            if (_bitmap == null)
-            {
-                e.Handled = true;
-                return;
-            }
+            // Nothing to zoom — let the event flow so the ScrollViewer can pan.
+            if (_bitmap == null) return;
+
+            // Plain wheel / two-finger scroll: don't handle, so the ScrollViewer pans.
+            if (!ShouldWheelZoom(e.KeyModifiers)) return;
 
             int oldZoom = _zoom;
             int newZoom = e.Delta.Y > 0 ? oldZoom + 1 : oldZoom - 1;
             newZoom = Math.Max(ZoomMin, Math.Min(ZoomMax, newZoom));
-            if (newZoom == oldZoom)
+
+            // Cursor-centered zoom keeps the content point under the cursor stable.
+            if (newZoom != oldZoom)
+                ZoomCenteredOn(newZoom, e.GetPosition(ImageScroller));
+
+            // Consume the modifier-wheel even at the zoom clamp so it doesn't fall
+            // through to the ScrollViewer and scroll instead of zooming.
+            e.Handled = true;
+        }
+
+        /// <summary>Pinch-to-zoom centered on the gesture origin (#1726).</summary>
+        void OnPinch(object? sender, PinchEventArgs e)
+        {
+            if (_bitmap == null) return;
+
+            // e.Scale is cumulative from 1.0 for the whole gesture, so capture the
+            // zoom at the first frame and scale from it.
+            if (!_isPinching)
             {
-                e.Handled = true;
-                return;
+                _isPinching = true;
+                _pinchBaseZoom = _zoom;
             }
 
-            // Get cursor position relative to the ScrollViewer viewport
-            Point cursorInScroller = e.GetPosition(ImageScroller);
+            int newZoom = PinchScaleToZoom(_pinchBaseZoom, e.Scale);
+            if (newZoom != _zoom)
+                ZoomCenteredOn(newZoom, e.ScaleOrigin);
+            e.Handled = true;
+        }
 
-            // Content coordinate under cursor before zoom
-            double contentX = ImageScroller.Offset.X + cursorInScroller.X;
-            double contentY = ImageScroller.Offset.Y + cursorInScroller.Y;
+        void OnPinchEnded(object? sender, PinchEndedEventArgs e)
+        {
+            _isPinching = false;
+            e.Handled = true;
+        }
 
-            // Apply zoom (bypassing property to avoid double UpdateDisplay)
+        /// <summary>
+        /// Apply a new zoom while keeping the content point under
+        /// <paramref name="centerInScroller"/> (a point in ScrollViewer-viewport
+        /// coordinates) stationary. Shared by wheel and pinch zoom (#1726).
+        /// </summary>
+        void ZoomCenteredOn(int newZoom, Point centerInScroller)
+        {
+            int oldZoom = _zoom;
+            if (newZoom == oldZoom) return;
+
+            // Content coordinate under the center before zoom.
+            double contentX = ImageScroller.Offset.X + centerInScroller.X;
+            double contentY = ImageScroller.Offset.Y + centerInScroller.Y;
+
+            // Apply zoom (bypassing the property to avoid a double UpdateDisplay).
             _zoom = newZoom;
             UpdateZoomLabel();
             UpdateDisplay();
 
-            // Scale the content coordinate to the new zoom and compute new scroll offset
-            // so the same image point stays under the cursor
+            // Scale the content coordinate to the new zoom and recompute the scroll
+            // offset so the same image point stays under the center.
             double scale = (double)newZoom / oldZoom;
-            double newOffsetX = contentX * scale - cursorInScroller.X;
-            double newOffsetY = contentY * scale - cursorInScroller.Y;
-
             ImageScroller.Offset = new Vector(
-                Math.Max(0, newOffsetX),
-                Math.Max(0, newOffsetY));
-
-            e.Handled = true;
+                Math.Max(0, contentX * scale - centerInScroller.X),
+                Math.Max(0, contentY * scale - centerInScroller.Y));
         }
 
         /// <summary>

--- a/FEBuilderGBA.Tests/Unit/AvaloniaServiceTests.cs
+++ b/FEBuilderGBA.Tests/Unit/AvaloniaServiceTests.cs
@@ -279,10 +279,12 @@ namespace FEBuilderGBA.Tests.Unit
         public void GbaImageControl_HasCursorCenteredZoom()
         {
             var src = File.ReadAllText(Path.Combine(AvaloniaDir, "Controls", "GbaImageControl.axaml.cs"));
-            // Cursor-centered zoom: must read cursor position and adjust scroll offset
+            // Cursor-centered zoom: must read cursor position and adjust scroll offset.
+            // The offset math is shared by wheel (cursor) and pinch (gesture origin)
+            // zoom via the ZoomCenteredOn(newZoom, centerInScroller) helper (#1726).
             Assert.Contains("GetPosition", src);
             Assert.Contains("ImageScroller.Offset", src);
-            Assert.Contains("cursorInScroller", src);
+            Assert.Contains("centerInScroller", src);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary

Round-3b of the #1674 macOS Avalonia campaign. On macOS the **Battle Screen Layout** editor — and the ~13 image editors that share `GbaImageControl` — could not pan: every two-finger scroll / wheel delta was mapped to a ±1 zoom and the event was always handled, so the inner `ScrollViewer` never panned and zoom coupled to the scroll extremes (wheel up at the top zoomed in, wheel down at the bottom zoomed out, and pinch did nothing).

**Fix** (standard image-viewer convention), all in `FEBuilderGBA.Avalonia/Controls/GbaImageControl.axaml.cs`:
- **Tunnel-phase wheel interception** — register the wheel handler with `AddHandler(PointerWheelChangedEvent, …, RoutingStrategies.Tunnel)` so `GbaImageControl` sees the wheel **before** the inner `ScrollViewer`. A plain wheel returns unhandled → the `ScrollViewer` pans; `Ctrl`/`⌘`+wheel zooms and marks the event handled (pure zoom, no competing scroll) — and works even when the image is zoomed-in / scrollable.
- **Pinch-to-zoom** — a `PinchGestureRecognizer` on `ImageScroller` + `Gestures.Pinch`/`PinchEnded` handlers with an `_isPinching` state machine (`PinchEventArgs.Scale` is cumulative from 1.0), centered on `ScaleOrigin`.
- Extract pure, unit-tested helpers `ShouldWheelZoom(KeyModifiers)` and `PinchScaleToZoom(baseZoom, scale)`; share the cursor/pinch offset math in `ZoomCenteredOn()`; delete the dead `WheelZoomFactor` constant.

## Plan & review

Plan v2 (accepted): https://github.com/laqieer/FEBuilderGBA/issues/1726#issuecomment-4844884538
Cross-model board (claude-sonnet-4.6 / gpt-5.5 / gemini-3.5-flash) round-1 caught a blocking **wheel-routing** defect (a bubble-phase handler would let the ScrollViewer consume the wheel first, so `Ctrl`/`⌘`+wheel zoom would silently fail once scrollable); fixed via the tunnel registration and **approved** round-2: https://github.com/laqieer/FEBuilderGBA/issues/1726#issuecomment-4844989919

## Scope

Closes #1726

Single cross-editor behaviour change (plain wheel pans; `Ctrl`/`⌘`+wheel & pinch zoom) — the standard image-viewer convention — affecting the ~13 editors that embed `GbaImageControl`. No other files changed.

## Test plan

- [x] **`GbaImageControlWheelZoomTests` (new, 21 cases — all pass):**
  - `ShouldWheelZoom` truth table — `Ctrl`/`Meta` ⇒ zoom, `None`/`Shift`/`Alt` ⇒ no-zoom, `Ctrl|Shift` ⇒ zoom.
  - `PinchScaleToZoom` rounding/clamp (e.g. base8×2.0⇒8 clamp, base1×0.1⇒1 clamp, base2×1.49⇒3) + a range invariant.
  - `Constructor_RegistersPinchGestureRecognizer` — asserts the pinch recognizer is wired on `ImageScroller`.
  - `OnPointerWheelChanged_GatesZoomAndLeavesPlainWheelUnhandled` — `Ctrl`/`⌘`+wheel zooms and sets `Handled`; plain/`Shift` wheel does **not** zoom and stays **unhandled** (so the ScrollViewer pans).
  - `OnPointerWheelChanged_RespectsZoomClamp` — clamps at [1,8] and still consumes the modifier-wheel.
  - `CtrlWheel_RoutesThroughTunnel_EvenWhenScrollable` — **routing proof**: hosts the control in a headless `Window`, zooms in so the image is scrollable, parks a non-extreme offset, and asserts a `Ctrl`+wheel event **raised on the inner Image** still zooms (only possible because the handler is tunnel-registered) while a plain wheel does not.
- [x] **`AvaloniaServiceTests.GbaImageControl_HasCursorCenteredZoom`** — updated the source guard for the `cursorInScroller → centerInScroller` rename (cursor/pinch share the offset math).
- [x] **Full Avalonia suite:** `dotnet test FEBuilderGBA.Avalonia.Tests` → **9244 passed, 0 failed, 7 skipped** (no regression across the editors sharing the control).
- [x] **Core suite:** `dotnet test FEBuilderGBA.Core.Tests` → green (the only initial failures were FE8U skill-system tests in the fresh worktree before `git submodule update --init config/patch2`; all 56 pass with the submodule present — unrelated to this Avalonia-only change).
- [x] **WinForms suite:** `dotnet test FEBuilderGBA.Tests` → **1927 passed, 0 failed**.

## GUI Test Report

Behaviour verified by the new headless `[AvaloniaFact]` tests (a wheel/pinch behaviour change is not visible in a static image; the routing test is the real proof):

| Area | Behaviour | Result |
|---|---|---|
| GbaImageControl wheel | Plain wheel ⇒ no zoom, event left unhandled (ScrollViewer pans) | ✅ PASS |
| GbaImageControl wheel | `Ctrl`/`⌘`+wheel ⇒ cursor-centered zoom, event handled | ✅ PASS |
| GbaImageControl wheel | `Ctrl`+wheel still zooms when **scrollable** (tunnel routing, non-extreme offset) | ✅ PASS |
| GbaImageControl zoom | Clamped to [1,8] | ✅ PASS |
| GbaImageControl pinch | `PinchGestureRecognizer` wired; `PinchScaleToZoom` rounds/clamps | ✅ PASS |
| Battle Screen editor | Renders with FE8U data + zoom controls (affected editor) | ✅ PASS (screenshot) |

> The reporter is on macOS Apple Silicon; the wheel/pinch routing is platform-agnostic Avalonia and is covered by the headless tests above. macOS trackpad confirmation is welcome from the reporter.

## Screenshots

**Battle Screen Layout editor (FE8U)** — the image panels are `GbaImageControl`s where the wheel/pinch zoom fix applies (the static appearance is unchanged by this behaviour fix; the new unit tests are the behavioural proof):

![Battle Screen editor](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr1726-battlescreen-fe8u.png)

---
Copilot CLI: 1.0.66
Model: Claude Opus 4.8 (claude-opus-4.8)
