### PR TITLE
fix(avalonia): stop NumericUpDown spinner overflow in CSkillSys/FE8N skill editors (#1728, #1729, #1730, #1731, #1732)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/SkillEditorLayoutTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/SkillEditorLayoutTests.cs
@@ -1,0 +1,480 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Layout regression tests for the CSkillSys / FE8N skill editors (#1728-#1732).
+//
+// Root cause: Avalonia 11.2.3 NumericUpDown has a ~120px effective minimum
+// width (the spinner-button chrome). When a NUD is placed in a fixed <=80px
+// Grid column (or given Width<=80 / Width=50), it renders at its ~120px minimum
+// and overflows into the adjacent label / box / next NUD. Because the columns
+// are FIXED-pixel (not star), the overflow reproduces headlessly on Windows too.
+//
+// Three layout-only remedies (no ViewModel/ROM changes) are applied:
+//   (1) Read-only / disabled NUDs -> ShowButtonSpinner="False" (removes the
+//       useless spinner chrome; a consistent read-only policy).
+//   (2) Editable single-NUD rows  -> widen the NUD column 80 -> 120 (a sibling
+//       */Auto column absorbs the extra width). ShowFrameUpDown gets an explicit
+//       element-level Width=120 instead (it lives in a StackPanel-ish row).
+//   (3) Editable NUDs in dense multi-NUD grids (12 FE8N condition NUDs, 16 FE8N
+//       ext-byte NUDs) -> ShowButtonSpinner="False" (keyboard up/down + typing
+//       preserved because AllowSpin stays true).
+//
+// NOTE: App.axaml sets a *global* `NumericUpDown { MinWidth=120 }`. ShowButtonSpinner
+// is therefore independent of footprint: a strategy-(1)/(3) NUD stays ~120px wide
+// after the spinner is collapsed (only `MinWidth=0`, as in #1724's PaletteGrid,
+// would shrink it). So the discriminating assertion differs per strategy:
+//   * STRUCTURAL  (visibility/tab independent, found by Name): every strategy
+//     (1)/(3) NUD must have ShowButtonSpinner==false (and AllowSpin==true for the
+//     editable dense ones). These pass regardless of tab / IsVisible state, so
+//     they cover the hidden N1/X-level panels and the second (Ext Bytes) tab.
+//   * GEOMETRIC  (no-overlap after a forced layout pass) is asserted ONLY for the
+//     strategy-(2) WIDENED rows -- where the 80->120 column genuinely lets the
+//     ~120px NUD fit (FE8N Icon ID / Skill Name; FE8U Skill Name / Description;
+//     the Unit/Class N1 level-up rows, force-showing their hidden panel). The
+//     strategy-(1)/(3) NUDs are NOT geometric targets (they stay ~120px by design
+//     under the global MinWidth) -- the plan covers them structurally instead.
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    public class SkillEditorLayoutTests
+    {
+        private readonly ITestOutputHelper _output;
+        public SkillEditorLayoutTests(ITestOutputHelper output) => _output = output;
+
+        // ==================================================================
+        // Helpers
+        // ==================================================================
+
+        static NumericUpDown Nud(Window view, string name)
+        {
+            var nud = view.FindControl<NumericUpDown>(name);
+            Assert.True(nud != null, $"NumericUpDown '{name}' must exist in the view's name scope.");
+            return nud!;
+        }
+
+        /// <summary>
+        /// Every named NUD must have its spinner buttons collapsed
+        /// (strategy (1)/(3)). AllowSpin must stay true so the keyboard /
+        /// wheel editing path still works.
+        /// </summary>
+        static void AssertSpinnerCollapsed(Window view, params string[] names)
+        {
+            foreach (var name in names)
+            {
+                var nud = Nud(view, name);
+                Assert.False(nud.ShowButtonSpinner,
+                    $"NUD '{name}' must have ShowButtonSpinner=false so its spinner chrome does " +
+                    "not overflow the narrow/fixed column (#1728-#1732).");
+                // The global App.axaml `NumericUpDown { MinWidth=120 }` keeps a
+                // spinner-less NUD at 120px and STILL overflowing an 80px/50px slot.
+                // MinWidth=0 lets it shrink to fit its cell — the exact remedy from
+                // the merged #1724 ImageBattleScreenView PaletteGrid.
+                Assert.Equal(0, nud.MinWidth);
+                Assert.True(nud.AllowSpin,
+                    $"NUD '{name}' must keep AllowSpin=true so keyboard/wheel editing still works.");
+            }
+        }
+
+        /// <summary>
+        /// Effective minimum width of a NUD: its explicit Width if set, else the
+        /// absolute pixel width of the Grid column it occupies. Column-widened
+        /// NUDs keep Width=NaN (only ShowFrameUpDown sets an element-level Width),
+        /// so for those we read the parent Grid's column width instead.
+        /// </summary>
+        static double EffectiveMinWidth(NumericUpDown nud)
+        {
+            if (!double.IsNaN(nud.Width)) return nud.Width;
+            var grid = nud.FindLogicalAncestorOfType<Grid>();
+            if (grid != null)
+            {
+                int col = Grid.GetColumn(nud);
+                if (col >= 0 && col < grid.ColumnDefinitions.Count)
+                {
+                    var w = grid.ColumnDefinitions[col].Width;
+                    if (w.IsAbsolute) return w.Value;
+                }
+            }
+            return double.NaN;
+        }
+
+        static void AssertEffectiveMinWidthAtLeast120(Window view, params string[] names)
+        {
+            foreach (var name in names)
+            {
+                var nud = Nud(view, name);
+                double w = EffectiveMinWidth(nud);
+                Assert.True(w >= 120,
+                    $"NUD '{name}' must have an effective minimum width >=120 (explicit Width or its " +
+                    $"Grid column's absolute width); got {w}. Without it the ~120px spinner chrome " +
+                    "overflows the old 80px column (#1728-#1732).");
+            }
+        }
+
+        static void ForceLayout(Window view)
+        {
+            view.UpdateLayout();
+            var size = new Size(1600, 1200);
+            view.Measure(size);
+            view.Arrange(new Rect(size));
+            view.UpdateLayout();
+        }
+
+        /// <summary>
+        /// Counts, per grid row (partitioned by Grid.GetRow so multi-row grids are
+        /// handled correctly), how many adjacent (left-to-right) child pairs
+        /// overlap where at least one child is a NumericUpDown. A NUD whose ~120px
+        /// footprint overflows its narrow cell crosses the next cell's left edge;
+        /// after the 80->120 widening every NUD fits its cell so the count is zero.
+        /// </summary>
+        static int CountNudOverflows(Grid grid, Visual root, ITestOutputHelper output, string tag)
+        {
+            int overlaps = 0;
+            foreach (var rowGroup in grid.Children.GroupBy(c => Grid.GetRow(c)))
+            {
+                var kids = rowGroup
+                    .Select(c => new { C = c, P = c.TranslatePoint(new Point(0, 0), root) })
+                    .Where(x => x.P.HasValue && x.C.Bounds.Width > 0)
+                    .OrderBy(x => x.P!.Value.X)
+                    .ToList();
+
+                for (int i = 0; i + 1 < kids.Count; i++)
+                {
+                    bool nudInvolved = kids[i].C is NumericUpDown || kids[i + 1].C is NumericUpDown;
+                    if (!nudInvolved) continue;
+
+                    double aRight = kids[i].P!.Value.X + kids[i].C.Bounds.Width;
+                    double bLeft = kids[i + 1].P!.Value.X;
+                    if (aRight > bLeft + 0.5)
+                    {
+                        overlaps++;
+                        output.WriteLine(
+                            $"{tag}: '{(kids[i].C as Control)?.Name}' right={aRight:F1} > " +
+                            $"'{(kids[i + 1].C as Control)?.Name}' left={bLeft:F1}");
+                    }
+                }
+            }
+            return overlaps;
+        }
+
+        /// <summary>
+        /// Force any IsVisible-hidden container(s) visible so their NUD rows lay
+        /// out and can be geometrically checked. The plan permits this for the
+        /// hidden N1/X-level panels ("force ... panel IsVisible=true before the
+        /// geometric check"). The set is a local value applied after Show(); no
+        /// data update re-asserts the binding during the synchronous test pass.
+        /// </summary>
+        static void ForceVisible(Window view, params string[] controlNames)
+        {
+            foreach (var n in controlNames)
+            {
+                var c = view.FindControl<Control>(n);
+                if (c != null) c.IsVisible = true;
+            }
+        }
+
+        /// <summary>
+        /// Geometric no-overlap over the (now-laid-out) row that owns each named
+        /// strategy-(2) widened NUD. Asserts the NUD is actually realized
+        /// (Bounds.Width>0) so the check can never pass vacuously, then that no
+        /// NUD-involved adjacent pair overlaps.
+        /// </summary>
+        void AssertRowsHaveNoNudOverflow(Window view, string tag, params string[] nudNames)
+        {
+            foreach (var name in nudNames)
+            {
+                var nud = Nud(view, name);
+                Assert.True(nud.Bounds.Width > 0,
+                    $"Widened NUD '{name}' must be laid out (Bounds.Width>0) for the geometric check.");
+                var grid = nud.FindLogicalAncestorOfType<Grid>();
+                Assert.True(grid != null, $"NUD '{name}' must live inside a Grid.");
+                int overlaps = CountNudOverflows(grid!, view, _output, $"{tag}/{name}");
+                Assert.True(overlaps == 0,
+                    $"{overlaps} NUD overflow(s) in the row owning '{name}' ({tag}); the 80->120 column " +
+                    "widening must let the ~120px NUD sit in its cell without crossing the next control.");
+            }
+        }
+
+        // ==================================================================
+        // #1728  SkillAssignmentUnitCSkillSysView
+        // ==================================================================
+
+        [AvaloniaFact]
+        public void Unit_ReadOnlyNuds_SpinnerCollapsed()
+        {
+            var view = new SkillAssignmentUnitCSkillSysView();
+            view.Show();
+            try
+            {
+                AssertSpinnerCollapsed(view,
+                    "AddressBox", "BlockSizeBox", "SelectedAddressBox",
+                    "N1AddressBox", "N1BlockSizeBox", "N1SelectedAddressBox");
+            }
+            finally { view.Close(); }
+        }
+
+        [AvaloniaFact]
+        public void Unit_EditableNuds_HaveMinWidth120()
+        {
+            var view = new SkillAssignmentUnitCSkillSysView();
+            view.Show();
+            try
+            {
+                AssertEffectiveMinWidthAtLeast120(view,
+                    "N1ReadCountBox", "N1B0Box", "N1B1Box");
+            }
+            finally { view.Close(); }
+        }
+
+        [AvaloniaFact]
+        public void Unit_WidenedN1Rows_NoNudOverflow()
+        {
+            var view = new SkillAssignmentUnitCSkillSysView();
+            view.Show();
+            try
+            {
+                // N1ReadCountBox/N1B0Box/N1B1Box live in LevelUpGroup, hidden via
+                // {Binding HasLevelUpTable} (false without a ROM). Force it visible
+                // so the widened 120px columns can be geometrically verified.
+                ForceVisible(view, "LevelUpGroup");
+                ForceLayout(view);
+                AssertRowsHaveNoNudOverflow(view, "Unit/N1",
+                    "N1ReadCountBox", "N1B0Box", "N1B1Box");
+            }
+            finally { view.Close(); }
+        }
+
+        // ==================================================================
+        // #1729  SkillAssignmentClassCSkillSysView
+        // ==================================================================
+
+        [AvaloniaFact]
+        public void Class_ReadOnlyNuds_SpinnerCollapsed()
+        {
+            var view = new SkillAssignmentClassCSkillSysView();
+            view.Show();
+            try
+            {
+                AssertSpinnerCollapsed(view,
+                    "AddressBox", "BlockSizeBox", "SelectedAddressBox",
+                    "N1AddressBox", "N1BlockSizeBox", "N1SelectedAddressBox");
+            }
+            finally { view.Close(); }
+        }
+
+        [AvaloniaFact]
+        public void Class_EditableNuds_HaveMinWidth120()
+        {
+            var view = new SkillAssignmentClassCSkillSysView();
+            view.Show();
+            try
+            {
+                AssertEffectiveMinWidthAtLeast120(view,
+                    "N1ReadCountBox", "N1B0Box", "N1B1Box", "XLvValueBox");
+            }
+            finally { view.Close(); }
+        }
+
+        [AvaloniaFact]
+        public void Class_WidenedN1Rows_NoNudOverflow()
+        {
+            var view = new SkillAssignmentClassCSkillSysView();
+            view.Show();
+            try
+            {
+                // The Class N1 rows are always visible (no IsVisible binding);
+                // XLvValueBox lives in the hidden XLevelAddPanel, so force it.
+                ForceVisible(view, "XLevelAddPanel");
+                ForceLayout(view);
+                AssertRowsHaveNoNudOverflow(view, "Class/N1",
+                    "N1ReadCountBox", "N1B0Box", "N1B1Box", "XLvValueBox");
+            }
+            finally { view.Close(); }
+        }
+
+        // ==================================================================
+        // #1730 / #1731  SkillConfigFE8NSkillView
+        // ==================================================================
+
+        static readonly string[] Fe8nCondNuds =
+        {
+            "CondUnit1Box", "CondUnit2Box", "CondUnit3Box", "CondUnit4Box",
+            "CondClass1Box", "CondClass2Box", "CondClass3Box", "CondClass4Box",
+            "CondItem1Box", "CondItem2Box", "CondItem3Box", "CondItem4Box",
+        };
+
+        static readonly string[] Fe8nExtNuds =
+        {
+            "ExtB16Box", "ExtB17Box", "ExtB18Box", "ExtB19Box",
+            "ExtB20Box", "ExtB21Box", "ExtB22Box", "ExtB23Box",
+            "ExtB24Box", "ExtB25Box", "ExtB26Box", "ExtB27Box",
+            "ExtB28Box", "ExtB29Box", "ExtB30Box", "ExtB31Box",
+        };
+
+        [AvaloniaFact]
+        public void Fe8n_DisabledAndDenseNuds_SpinnerCollapsed()
+        {
+            var view = new SkillConfigFE8NSkillView();
+            view.Show();
+            try
+            {
+                AssertSpinnerCollapsed(view, "AddressBox", "BlockSizeBox", "AnimationPointerBox");
+                AssertSpinnerCollapsed(view, Fe8nCondNuds);
+                AssertSpinnerCollapsed(view, Fe8nExtNuds);
+            }
+            finally { view.Close(); }
+        }
+
+        [AvaloniaFact]
+        public void Fe8n_IconAndNameNuds_HaveMinWidth120()
+        {
+            var view = new SkillConfigFE8NSkillView();
+            view.Show();
+            try
+            {
+                AssertEffectiveMinWidthAtLeast120(view, "IconIdBox", "TextDetailBox");
+            }
+            finally { view.Close(); }
+        }
+
+        [AvaloniaFact]
+        public void Fe8n_IconAndNameRows_NoNudOverflow()
+        {
+            var view = new SkillConfigFE8NSkillView();
+            view.Show();
+            try
+            {
+                ForceLayout(view);
+                // Icon ID / Skill Name rows are strategy-(2) widened (80->120) and
+                // always visible on the default tab. The dense condition rows are
+                // covered by Fe8n_ConditionRows_NoNudOverflow below.
+                AssertRowsHaveNoNudOverflow(view, "FE8N", "IconIdBox", "TextDetailBox");
+            }
+            finally { view.Close(); }
+        }
+
+        [AvaloniaFact]
+        public void Fe8n_DenseNuds_KeepAllowSpin()
+        {
+            var view = new SkillConfigFE8NSkillView();
+            view.Show();
+            try
+            {
+                foreach (var name in Fe8nCondNuds.Concat(Fe8nExtNuds))
+                    Assert.True(Nud(view, name).AllowSpin,
+                        $"Dense-grid NUD '{name}' must keep AllowSpin=true (keyboard editing) after the spinner is collapsed.");
+            }
+            finally { view.Close(); }
+        }
+
+        // ==================================================================
+        // #1732  SkillConfigFE8UCSkillSys09xView
+        // ==================================================================
+
+        [AvaloniaFact]
+        public void Fe8u_DisabledNuds_SpinnerCollapsed()
+        {
+            var view = new SkillConfigFE8UCSkillSys09xView();
+            view.Show();
+            try
+            {
+                AssertSpinnerCollapsed(view, "AddressBox", "BlockSizeBox");
+            }
+            finally { view.Close(); }
+        }
+
+        [AvaloniaFact]
+        public void Fe8u_EditableNuds_HaveMinWidth120()
+        {
+            var view = new SkillConfigFE8UCSkillSys09xView();
+            view.Show();
+            try
+            {
+                // SkillNameBox / DescriptionBox are column-widened; ShowFrameUpDown
+                // gets an explicit element-level Width=120 (it lives in the hidden
+                // AnimationPanel so it is found by Name, not by realized layout).
+                AssertEffectiveMinWidthAtLeast120(view,
+                    "SkillNameBox", "DescriptionBox", "ShowFrameUpDown");
+            }
+            finally { view.Close(); }
+        }
+
+        [AvaloniaFact]
+        public void Fe8u_NameAndDescriptionRows_NoNudOverflow()
+        {
+            var view = new SkillConfigFE8UCSkillSys09xView();
+            view.Show();
+            try
+            {
+                ForceLayout(view);
+                AssertRowsHaveNoNudOverflow(view, "FE8U", "SkillNameBox", "DescriptionBox");
+            }
+            finally { view.Close(); }
+        }
+
+        // ==================================================================
+        // Strategy-(1)/(3) no-overlap — proves the MinWidth=0 (#1724 precedent)
+        // fix. Each row below FAILS without MinWidth=0: the global App.axaml
+        // `NumericUpDown { MinWidth=120 }` keeps a spinner-less NUD at 120px and
+        // overflowing its fixed 80px slot; with MinWidth=0 the NUD fits its cell.
+        // ==================================================================
+
+        [AvaloniaFact]
+        public void Unit_SelectionBars_NoNudOverflow()
+        {
+            var view = new SkillAssignmentUnitCSkillSysView();
+            view.Show();
+            try
+            {
+                // BlockSizeBox (top bar) and N1BlockSizeBox (N1 bar) are read-only
+                // NUDs in fixed 80px Grid columns; N1 lives in the binding-hidden
+                // LevelUpGroup, so force it visible.
+                ForceVisible(view, "LevelUpGroup");
+                ForceLayout(view);
+                AssertRowsHaveNoNudOverflow(view, "Unit/bars", "BlockSizeBox", "N1BlockSizeBox");
+            }
+            finally { view.Close(); }
+        }
+
+        [AvaloniaFact]
+        public void Fe8n_ConditionRows_NoNudOverflow()
+        {
+            var view = new SkillConfigFE8NSkillView();
+            view.Show();
+            try
+            {
+                // The 3 Icon-Display-Condition rows (4 NUDs each in 100,80,80,80,80)
+                // are on the default tab. Pre-fix they overlapped each other (#1730).
+                ForceLayout(view);
+                AssertRowsHaveNoNudOverflow(view, "FE8N/cond",
+                    "CondUnit1Box", "CondClass1Box", "CondItem1Box");
+            }
+            finally { view.Close(); }
+        }
+
+        [AvaloniaFact]
+        public void Fe8n_ExtByteRows_NoNudOverflow()
+        {
+            var view = new SkillConfigFE8NSkillView();
+            view.Show();
+            try
+            {
+                // Ext Bytes (B16..B31, 80px NUD columns) live on the "Unit Skill
+                // List" tab (#1731). Select it so the rows realize, then verify.
+                // AssertRowsHaveNoNudOverflow asserts Bounds.Width>0, so a wrong tab
+                // would fail loudly rather than pass vacuously.
+                var tabs = view.FindControl<TabControl>("MainTabControl");
+                Assert.NotNull(tabs);
+                tabs!.SelectedIndex = 1;
+                ForceLayout(view);
+                AssertRowsHaveNoNudOverflow(view, "FE8N/ext", "ExtB16Box", "ExtB17Box");
+            }
+            finally { view.Close(); }
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassCSkillSysView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassCSkillSysView.axaml
@@ -76,17 +76,17 @@
               <TextBlock AutomationProperties.AutomationId="SkillAssignmentClassCSkillSys_AddrLabel"
                          Grid.Column="0" Text="Address:" VerticalAlignment="Center" Margin="0,0,8,0" />
               <NumericUpDown AutomationProperties.AutomationId="SkillAssignmentClassCSkillSys_Addr_Input"
-                             Grid.Column="1" Name="AddressBox" FormatString="0" IsReadOnly="True"
+                             Grid.Column="1" Name="AddressBox" FormatString="0" IsReadOnly="True" ShowButtonSpinner="False" MinWidth="0"
                              Minimum="0" Maximum="2147483647" Margin="0,0,8,0" />
               <TextBlock AutomationProperties.AutomationId="SkillAssignmentClassCSkillSys_SizeLabel"
                          Grid.Column="2" Text="Size:" VerticalAlignment="Center" Margin="0,0,8,0" />
               <NumericUpDown AutomationProperties.AutomationId="SkillAssignmentClassCSkillSys_BlockSize_Input"
-                             Grid.Column="3" Name="BlockSizeBox" IsReadOnly="True"
+                             Grid.Column="3" Name="BlockSizeBox" IsReadOnly="True" ShowButtonSpinner="False" MinWidth="0"
                              Minimum="0" Maximum="64" Margin="0,0,8,0" />
               <TextBlock AutomationProperties.AutomationId="SkillAssignmentClassCSkillSys_SelectAddrLabel"
                          Grid.Column="4" Text="Selected:" VerticalAlignment="Center" Margin="0,0,8,0" />
               <NumericUpDown AutomationProperties.AutomationId="SkillAssignmentClassCSkillSys_SelectedAddress_Input"
-                             Grid.Column="5" Name="SelectedAddressBox" IsReadOnly="True" FormatString="0"
+                             Grid.Column="5" Name="SelectedAddressBox" IsReadOnly="True" ShowButtonSpinner="False" MinWidth="0" FormatString="0"
                              Minimum="0" Maximum="2147483647" Margin="0,0,8,0" />
               <Button AutomationProperties.AutomationId="SkillAssignmentClassCSkillSys_Write_Button"
                       Grid.Column="6" Name="WriteButton" Content="Write" Click="OnWrite" MinWidth="100"
@@ -96,7 +96,7 @@
 
           <Border BorderBrush="Gray" BorderThickness="1" Padding="6" CornerRadius="2">
             <StackPanel Spacing="6">
-              <Grid ColumnDefinitions="*,Auto,80,Auto">
+              <Grid ColumnDefinitions="*,Auto,120,Auto">
                 <TextBlock AutomationProperties.AutomationId="SkillAssignmentClassCSkillSys_N1_LevelUpAddrLabel"
                            Grid.Column="0" Text="Level-up Skill Table Address"
                            VerticalAlignment="Center" FontWeight="Bold" />
@@ -125,7 +125,7 @@
 
                 <StackPanel Grid.Column="1" Spacing="6">
 
-                  <Grid ColumnDefinitions="Auto,80,Auto,Auto,Auto">
+                  <Grid ColumnDefinitions="Auto,120,Auto,Auto,Auto">
                     <TextBlock AutomationProperties.AutomationId="SkillAssignmentClassCSkillSys_N1_LevelLabel"
                                Grid.Column="0" Text="Acquired Level" VerticalAlignment="Center"
                                Margin="0,0,8,0" FontWeight="Bold" />
@@ -145,7 +145,7 @@
                   <Border AutomationProperties.AutomationId="SkillAssignmentClassCSkillSys_X_LevelAddPanel"
                           Name="XLevelAddPanel" IsVisible="False"
                           BorderBrush="LightGray" BorderThickness="1" Padding="6" CornerRadius="2">
-                    <Grid ColumnDefinitions="160,Auto,80,Auto,*" RowDefinitions="Auto,Auto,Auto">
+                    <Grid ColumnDefinitions="160,Auto,120,Auto,*" RowDefinitions="Auto,Auto,Auto">
                       <TextBlock AutomationProperties.AutomationId="SkillAssignmentClassCSkillSys_X_LV_BreakdownLabel"
                                  Grid.Row="0" Grid.RowSpan="3" Grid.Column="0" Text="Acquired Level Breakdown"
                                  TextWrapping="Wrap" VerticalAlignment="Center" FontWeight="Bold" Margin="0,0,8,0" />
@@ -169,7 +169,7 @@
                     </Grid>
                   </Border>
 
-                  <Grid ColumnDefinitions="Auto,80,Auto,*,Auto">
+                  <Grid ColumnDefinitions="Auto,120,Auto,*,Auto">
                     <TextBlock AutomationProperties.AutomationId="SkillAssignmentClassCSkillSys_N1_SkillLabel"
                                Grid.Column="0" Text="Skill" VerticalAlignment="Center"
                                Margin="0,0,8,0" FontWeight="Bold" />
@@ -191,17 +191,17 @@
                     <TextBlock AutomationProperties.AutomationId="SkillAssignmentClassCSkillSys_N1_AddrLabel"
                                Grid.Column="0" Text="Address:" VerticalAlignment="Center" Margin="0,0,8,0" />
                     <NumericUpDown AutomationProperties.AutomationId="SkillAssignmentClassCSkillSys_N1_Addr_Input"
-                                   Grid.Column="1" Name="N1AddressBox" FormatString="0" IsReadOnly="True"
+                                   Grid.Column="1" Name="N1AddressBox" FormatString="0" IsReadOnly="True" ShowButtonSpinner="False" MinWidth="0"
                                    Minimum="0" Maximum="2147483647" Margin="0,0,8,0" />
                     <TextBlock AutomationProperties.AutomationId="SkillAssignmentClassCSkillSys_N1_SizeLabel"
                                Grid.Column="2" Text="Size:" VerticalAlignment="Center" Margin="0,0,8,0" />
                     <NumericUpDown AutomationProperties.AutomationId="SkillAssignmentClassCSkillSys_N1_BlockSize_Input"
-                                   Grid.Column="3" Name="N1BlockSizeBox" IsReadOnly="True"
+                                   Grid.Column="3" Name="N1BlockSizeBox" IsReadOnly="True" ShowButtonSpinner="False" MinWidth="0"
                                    Minimum="0" Maximum="64" Margin="0,0,8,0" />
                     <TextBlock AutomationProperties.AutomationId="SkillAssignmentClassCSkillSys_N1_SelectAddrLabel"
                                Grid.Column="4" Text="Selected:" VerticalAlignment="Center" Margin="0,0,8,0" />
                     <NumericUpDown AutomationProperties.AutomationId="SkillAssignmentClassCSkillSys_N1_SelectedAddress_Input"
-                                   Grid.Column="5" Name="N1SelectedAddressBox" IsReadOnly="True" FormatString="0"
+                                   Grid.Column="5" Name="N1SelectedAddressBox" IsReadOnly="True" ShowButtonSpinner="False" MinWidth="0" FormatString="0"
                                    Minimum="0" Maximum="2147483647" Margin="0,0,8,0" />
                     <Button AutomationProperties.AutomationId="SkillAssignmentClassCSkillSys_N1_Write_Button"
                             Grid.Column="6" Name="N1WriteButton" Content="Write" Click="OnN1Write" MinWidth="100"

--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentUnitCSkillSysView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentUnitCSkillSysView.axaml
@@ -74,17 +74,17 @@
               <TextBlock AutomationProperties.AutomationId="SkillAssignmentUnitCSkillSys_Addr_Label"
                          Grid.Column="0" Text="Address:" VerticalAlignment="Center" Margin="0,0,8,0" />
               <NumericUpDown AutomationProperties.AutomationId="SkillAssignmentUnitCSkillSys_Addr_Input"
-                             Grid.Column="1" Name="AddressBox" FormatString="0" IsReadOnly="True"
+                             Grid.Column="1" Name="AddressBox" FormatString="0" IsReadOnly="True" ShowButtonSpinner="False" MinWidth="0"
                              Minimum="0" Maximum="2147483647" Margin="0,0,8,0" />
               <TextBlock AutomationProperties.AutomationId="SkillAssignmentUnitCSkillSys_Size_Label"
                          Grid.Column="2" Text="Size:" VerticalAlignment="Center" Margin="0,0,8,0" />
               <NumericUpDown AutomationProperties.AutomationId="SkillAssignmentUnitCSkillSys_BlockSize_Input"
-                             Grid.Column="3" Name="BlockSizeBox" IsReadOnly="True"
+                             Grid.Column="3" Name="BlockSizeBox" IsReadOnly="True" ShowButtonSpinner="False" MinWidth="0"
                              Minimum="0" Maximum="64" Margin="0,0,8,0" />
               <TextBlock AutomationProperties.AutomationId="SkillAssignmentUnitCSkillSys_SelectAddr_Label"
                          Grid.Column="4" Text="Selected:" VerticalAlignment="Center" Margin="0,0,8,0" />
               <NumericUpDown AutomationProperties.AutomationId="SkillAssignmentUnitCSkillSys_SelectedAddress_Input"
-                             Grid.Column="5" Name="SelectedAddressBox" IsReadOnly="True" FormatString="0"
+                             Grid.Column="5" Name="SelectedAddressBox" IsReadOnly="True" ShowButtonSpinner="False" MinWidth="0" FormatString="0"
                              Minimum="0" Maximum="2147483647" Margin="0,0,8,0" />
               <Button AutomationProperties.AutomationId="SkillAssignmentUnitCSkillSys_Write_Button"
                       Grid.Column="6" Name="WriteButton" Content="Write" Click="OnWrite" MinWidth="100" />
@@ -99,7 +99,7 @@
                   AutomationProperties.AutomationId="SkillAssignmentUnitCSkillSys_LevelUp_Control"
                   Name="LevelUpGroup" IsVisible="{Binding HasLevelUpTable}">
             <StackPanel Spacing="6">
-              <Grid ColumnDefinitions="*,Auto,140,Auto,80,Auto">
+              <Grid ColumnDefinitions="*,Auto,140,Auto,120,Auto">
                 <TextBlock AutomationProperties.AutomationId="SkillAssignmentUnitCSkillSys_N1_LevelUpAddr_Label"
                            Grid.Column="0" Text="Level-up Skill Table Address"
                            VerticalAlignment="Center" FontWeight="Bold" />
@@ -128,7 +128,7 @@
 
                 <StackPanel Grid.Column="1" Spacing="6">
 
-                  <Grid ColumnDefinitions="Auto,80,Auto,Auto,Auto">
+                  <Grid ColumnDefinitions="Auto,120,Auto,Auto,Auto">
                     <TextBlock AutomationProperties.AutomationId="SkillAssignmentUnitCSkillSys_N1_Level_Label"
                                Grid.Column="0" Text="Acquired Level" VerticalAlignment="Center"
                                Margin="0,0,8,0" FontWeight="Bold" />
@@ -137,7 +137,7 @@
                                    Minimum="0" Maximum="255" Margin="0,0,8,0" />
                   </Grid>
 
-                  <Grid ColumnDefinitions="Auto,80,Auto,Auto,Auto">
+                  <Grid ColumnDefinitions="Auto,120,Auto,*,Auto">
                     <TextBlock AutomationProperties.AutomationId="SkillAssignmentUnitCSkillSys_N1_Skill_Label"
                                Grid.Column="0" Text="Skill" VerticalAlignment="Center"
                                Margin="0,0,8,0" FontWeight="Bold" />
@@ -149,7 +149,7 @@
                            Width="32" Height="32" Margin="0,0,8,0" />
                     <TextBox AutomationProperties.AutomationId="SkillAssignmentUnitCSkillSys_N1_SkillName_Label"
                              Grid.Column="3" Name="N1SkillNameTextBox" IsReadOnly="True"
-                             Width="200" Margin="0,0,8,0" />
+                             Margin="0,0,8,0" />
                   </Grid>
                   <TextBox AutomationProperties.AutomationId="SkillAssignmentUnitCSkillSys_N1_SkillText_Label"
                            Name="N1SkillTextTextBox" IsReadOnly="True" AcceptsReturn="True"
@@ -159,17 +159,17 @@
                     <TextBlock AutomationProperties.AutomationId="SkillAssignmentUnitCSkillSys_N1_Addr_Label"
                                Grid.Column="0" Text="Address:" VerticalAlignment="Center" Margin="0,0,8,0" />
                     <NumericUpDown AutomationProperties.AutomationId="SkillAssignmentUnitCSkillSys_N1_Addr_Input"
-                                   Grid.Column="1" Name="N1AddressBox" FormatString="0" IsReadOnly="True"
+                                   Grid.Column="1" Name="N1AddressBox" FormatString="0" IsReadOnly="True" ShowButtonSpinner="False" MinWidth="0"
                                    Minimum="0" Maximum="2147483647" Margin="0,0,8,0" />
                     <TextBlock AutomationProperties.AutomationId="SkillAssignmentUnitCSkillSys_N1_Size_Label"
                                Grid.Column="2" Text="Size:" VerticalAlignment="Center" Margin="0,0,8,0" />
                     <NumericUpDown AutomationProperties.AutomationId="SkillAssignmentUnitCSkillSys_N1_BlockSize_Input"
-                                   Grid.Column="3" Name="N1BlockSizeBox" IsReadOnly="True"
+                                   Grid.Column="3" Name="N1BlockSizeBox" IsReadOnly="True" ShowButtonSpinner="False" MinWidth="0"
                                    Minimum="0" Maximum="64" Margin="0,0,8,0" />
                     <TextBlock AutomationProperties.AutomationId="SkillAssignmentUnitCSkillSys_N1_SelectAddr_Label"
                                Grid.Column="4" Text="Selected:" VerticalAlignment="Center" Margin="0,0,8,0" />
                     <NumericUpDown AutomationProperties.AutomationId="SkillAssignmentUnitCSkillSys_N1_SelectedAddress_Input"
-                                   Grid.Column="5" Name="N1SelectedAddressBox" IsReadOnly="True" FormatString="0"
+                                   Grid.Column="5" Name="N1SelectedAddressBox" IsReadOnly="True" ShowButtonSpinner="False" MinWidth="0" FormatString="0"
                                    Minimum="0" Maximum="2147483647" Margin="0,0,8,0" />
                     <Button AutomationProperties.AutomationId="SkillAssignmentUnitCSkillSys_N1_Write_Button"
                             Grid.Column="6" Name="N1WriteButton" Content="Write" Click="OnN1Write" MinWidth="100" />

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NSkillView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NSkillView.axaml
@@ -46,12 +46,12 @@
       <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
         <Label Content="Address:" VerticalAlignment="Center" />
         <NumericUpDown AutomationProperties.AutomationId="SkillConfigFE8NSkill_Address_Input"
-                       FormatString="0" Name="AddressBox" Width="120"
+                       FormatString="0" Name="AddressBox" Width="120" ShowButtonSpinner="False" MinWidth="0"
                        Minimum="0" Maximum="4294967295"
                        IsEnabled="False" VerticalAlignment="Center" />
         <Label Content="Size:" VerticalAlignment="Center" />
         <NumericUpDown AutomationProperties.AutomationId="SkillConfigFE8NSkill_BlockSize_Input"
-                       FormatString="0" Name="BlockSizeBox" Width="50"
+                       FormatString="0" Name="BlockSizeBox" Width="50" ShowButtonSpinner="False" MinWidth="0"
                        Minimum="0" Maximum="65535"
                        IsEnabled="False" VerticalAlignment="Center" Value="32" />
         <Label Content="Selected Address:" VerticalAlignment="Center" />
@@ -133,7 +133,7 @@
             </Grid>
 
             <!-- Icon ID row (W0): label + NumericUpDown. -->
-            <Grid ColumnDefinitions="140,80,*" RowDefinitions="Auto">
+            <Grid ColumnDefinitions="140,120,*" RowDefinitions="Auto">
               <Label Grid.Column="0"
                      AutomationProperties.AutomationId="SkillConfigFE8NSkill_IconId_Label"
                      Content="Icon ID" VerticalAlignment="Center" />
@@ -149,7 +149,7 @@
             </Grid>
 
             <!-- Text Detail row (W2): label + NumericUpDown + read-only resolved name. -->
-            <Grid ColumnDefinitions="140,80,*" RowDefinitions="Auto">
+            <Grid ColumnDefinitions="140,120,*" RowDefinitions="Auto">
               <Label Grid.Column="0"
                      AutomationProperties.AutomationId="SkillConfigFE8NSkill_TextDetail_Label"
                      Content="Skill Name" VerticalAlignment="Center" />
@@ -197,19 +197,19 @@
                      Content="Unit" VerticalAlignment="Center" FontWeight="SemiBold" />
               <NumericUpDown Grid.Column="1"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_CondUnit1_Input"
-                             FormatString="0" Name="CondUnit1Box"
+                             FormatString="0" Name="CondUnit1Box" ShowButtonSpinner="False" MinWidth="0"
                              Minimum="0" Maximum="255" />
               <NumericUpDown Grid.Column="2"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_CondUnit2_Input"
-                             FormatString="0" Name="CondUnit2Box"
+                             FormatString="0" Name="CondUnit2Box" ShowButtonSpinner="False" MinWidth="0"
                              Minimum="0" Maximum="255" />
               <NumericUpDown Grid.Column="3"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_CondUnit3_Input"
-                             FormatString="0" Name="CondUnit3Box"
+                             FormatString="0" Name="CondUnit3Box" ShowButtonSpinner="False" MinWidth="0"
                              Minimum="0" Maximum="255" />
               <NumericUpDown Grid.Column="4"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_CondUnit4_Input"
-                             FormatString="0" Name="CondUnit4Box"
+                             FormatString="0" Name="CondUnit4Box" ShowButtonSpinner="False" MinWidth="0"
                              Minimum="0" Maximum="255" />
             </Grid>
 
@@ -220,19 +220,19 @@
                      Content="Class" VerticalAlignment="Center" FontWeight="SemiBold" />
               <NumericUpDown Grid.Column="1"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_CondClass1_Input"
-                             FormatString="0" Name="CondClass1Box"
+                             FormatString="0" Name="CondClass1Box" ShowButtonSpinner="False" MinWidth="0"
                              Minimum="0" Maximum="255" />
               <NumericUpDown Grid.Column="2"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_CondClass2_Input"
-                             FormatString="0" Name="CondClass2Box"
+                             FormatString="0" Name="CondClass2Box" ShowButtonSpinner="False" MinWidth="0"
                              Minimum="0" Maximum="255" />
               <NumericUpDown Grid.Column="3"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_CondClass3_Input"
-                             FormatString="0" Name="CondClass3Box"
+                             FormatString="0" Name="CondClass3Box" ShowButtonSpinner="False" MinWidth="0"
                              Minimum="0" Maximum="255" />
               <NumericUpDown Grid.Column="4"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_CondClass4_Input"
-                             FormatString="0" Name="CondClass4Box"
+                             FormatString="0" Name="CondClass4Box" ShowButtonSpinner="False" MinWidth="0"
                              Minimum="0" Maximum="255" />
             </Grid>
 
@@ -243,19 +243,19 @@
                      Content="Item" VerticalAlignment="Center" FontWeight="SemiBold" />
               <NumericUpDown Grid.Column="1"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_CondItem1_Input"
-                             FormatString="0" Name="CondItem1Box"
+                             FormatString="0" Name="CondItem1Box" ShowButtonSpinner="False" MinWidth="0"
                              Minimum="0" Maximum="255" />
               <NumericUpDown Grid.Column="2"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_CondItem2_Input"
-                             FormatString="0" Name="CondItem2Box"
+                             FormatString="0" Name="CondItem2Box" ShowButtonSpinner="False" MinWidth="0"
                              Minimum="0" Maximum="255" />
               <NumericUpDown Grid.Column="3"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_CondItem3_Input"
-                             FormatString="0" Name="CondItem3Box"
+                             FormatString="0" Name="CondItem3Box" ShowButtonSpinner="False" MinWidth="0"
                              Minimum="0" Maximum="255" />
               <NumericUpDown Grid.Column="4"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_CondItem4_Input"
-                             FormatString="0" Name="CondItem4Box"
+                             FormatString="0" Name="CondItem4Box" ShowButtonSpinner="False" MinWidth="0"
                              Minimum="0" Maximum="255" />
             </Grid>
 
@@ -266,7 +266,7 @@
                      Content="Animation" VerticalAlignment="Center" />
               <NumericUpDown Grid.Column="1"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_AnimationPointer_Input"
-                             FormatString="0" Name="AnimationPointerBox"
+                             FormatString="0" Name="AnimationPointerBox" ShowButtonSpinner="False" MinWidth="0"
                              Minimum="0" Maximum="4294967295" IsEnabled="False" />
               <WrapPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center">
                 <Button AutomationProperties.AutomationId="SkillConfigFE8NSkill_AnimationImport_Button"
@@ -342,7 +342,7 @@
               <Label Grid.Row="0" Grid.Column="0" Content="B16" VerticalAlignment="Center" Margin="0,0,4,6" />
               <NumericUpDown Grid.Row="0" Grid.Column="1" Margin="0,0,8,6"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_ExtB16_Input"
-                             FormatString="0" Name="ExtB16Box" Minimum="0" Maximum="255"
+                             FormatString="0" Name="ExtB16Box" ShowButtonSpinner="False" MinWidth="0" Minimum="0" Maximum="255"
                              ValueChanged="ExtByteBox_ValueChanged" />
               <TextBlock Grid.Row="0" Grid.Column="2" Margin="0,0,16,6" VerticalAlignment="Center"
                          TextTrimming="CharacterEllipsis" Foreground="Gray"
@@ -352,7 +352,7 @@
               <Label Grid.Row="0" Grid.Column="3" Content="B17" VerticalAlignment="Center" Margin="0,0,4,6" />
               <NumericUpDown Grid.Row="0" Grid.Column="4" Margin="0,0,8,6"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_ExtB17_Input"
-                             FormatString="0" Name="ExtB17Box" Minimum="0" Maximum="255"
+                             FormatString="0" Name="ExtB17Box" ShowButtonSpinner="False" MinWidth="0" Minimum="0" Maximum="255"
                              ValueChanged="ExtByteBox_ValueChanged" />
               <TextBlock Grid.Row="0" Grid.Column="5" Margin="0,0,0,6" VerticalAlignment="Center"
                          TextTrimming="CharacterEllipsis" Foreground="Gray"
@@ -363,7 +363,7 @@
               <Label Grid.Row="1" Grid.Column="0" Content="B18" VerticalAlignment="Center" Margin="0,0,4,6" />
               <NumericUpDown Grid.Row="1" Grid.Column="1" Margin="0,0,8,6"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_ExtB18_Input"
-                             FormatString="0" Name="ExtB18Box" Minimum="0" Maximum="255"
+                             FormatString="0" Name="ExtB18Box" ShowButtonSpinner="False" MinWidth="0" Minimum="0" Maximum="255"
                              ValueChanged="ExtByteBox_ValueChanged" />
               <TextBlock Grid.Row="1" Grid.Column="2" Margin="0,0,16,6" VerticalAlignment="Center"
                          TextTrimming="CharacterEllipsis" Foreground="Gray"
@@ -373,7 +373,7 @@
               <Label Grid.Row="1" Grid.Column="3" Content="B19" VerticalAlignment="Center" Margin="0,0,4,6" />
               <NumericUpDown Grid.Row="1" Grid.Column="4" Margin="0,0,8,6"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_ExtB19_Input"
-                             FormatString="0" Name="ExtB19Box" Minimum="0" Maximum="255"
+                             FormatString="0" Name="ExtB19Box" ShowButtonSpinner="False" MinWidth="0" Minimum="0" Maximum="255"
                              ValueChanged="ExtByteBox_ValueChanged" />
               <TextBlock Grid.Row="1" Grid.Column="5" Margin="0,0,0,6" VerticalAlignment="Center"
                          TextTrimming="CharacterEllipsis" Foreground="Gray"
@@ -384,7 +384,7 @@
               <Label Grid.Row="2" Grid.Column="0" Content="B20" VerticalAlignment="Center" Margin="0,0,4,6" />
               <NumericUpDown Grid.Row="2" Grid.Column="1" Margin="0,0,8,6"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_ExtB20_Input"
-                             FormatString="0" Name="ExtB20Box" Minimum="0" Maximum="255"
+                             FormatString="0" Name="ExtB20Box" ShowButtonSpinner="False" MinWidth="0" Minimum="0" Maximum="255"
                              ValueChanged="ExtByteBox_ValueChanged" />
               <TextBlock Grid.Row="2" Grid.Column="2" Margin="0,0,16,6" VerticalAlignment="Center"
                          TextTrimming="CharacterEllipsis" Foreground="Gray"
@@ -394,7 +394,7 @@
               <Label Grid.Row="2" Grid.Column="3" Content="B21" VerticalAlignment="Center" Margin="0,0,4,6" />
               <NumericUpDown Grid.Row="2" Grid.Column="4" Margin="0,0,8,6"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_ExtB21_Input"
-                             FormatString="0" Name="ExtB21Box" Minimum="0" Maximum="255"
+                             FormatString="0" Name="ExtB21Box" ShowButtonSpinner="False" MinWidth="0" Minimum="0" Maximum="255"
                              ValueChanged="ExtByteBox_ValueChanged" />
               <TextBlock Grid.Row="2" Grid.Column="5" Margin="0,0,0,6" VerticalAlignment="Center"
                          TextTrimming="CharacterEllipsis" Foreground="Gray"
@@ -405,7 +405,7 @@
               <Label Grid.Row="3" Grid.Column="0" Content="B22" VerticalAlignment="Center" Margin="0,0,4,6" />
               <NumericUpDown Grid.Row="3" Grid.Column="1" Margin="0,0,8,6"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_ExtB22_Input"
-                             FormatString="0" Name="ExtB22Box" Minimum="0" Maximum="255"
+                             FormatString="0" Name="ExtB22Box" ShowButtonSpinner="False" MinWidth="0" Minimum="0" Maximum="255"
                              ValueChanged="ExtByteBox_ValueChanged" />
               <TextBlock Grid.Row="3" Grid.Column="2" Margin="0,0,16,6" VerticalAlignment="Center"
                          TextTrimming="CharacterEllipsis" Foreground="Gray"
@@ -415,7 +415,7 @@
               <Label Grid.Row="3" Grid.Column="3" Content="B23" VerticalAlignment="Center" Margin="0,0,4,6" />
               <NumericUpDown Grid.Row="3" Grid.Column="4" Margin="0,0,8,6"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_ExtB23_Input"
-                             FormatString="0" Name="ExtB23Box" Minimum="0" Maximum="255"
+                             FormatString="0" Name="ExtB23Box" ShowButtonSpinner="False" MinWidth="0" Minimum="0" Maximum="255"
                              ValueChanged="ExtByteBox_ValueChanged" />
               <TextBlock Grid.Row="3" Grid.Column="5" Margin="0,0,0,6" VerticalAlignment="Center"
                          TextTrimming="CharacterEllipsis" Foreground="Gray"
@@ -426,7 +426,7 @@
               <Label Grid.Row="4" Grid.Column="0" Content="B24" VerticalAlignment="Center" Margin="0,0,4,6" />
               <NumericUpDown Grid.Row="4" Grid.Column="1" Margin="0,0,8,6"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_ExtB24_Input"
-                             FormatString="0" Name="ExtB24Box" Minimum="0" Maximum="255"
+                             FormatString="0" Name="ExtB24Box" ShowButtonSpinner="False" MinWidth="0" Minimum="0" Maximum="255"
                              ValueChanged="ExtByteBox_ValueChanged" />
               <TextBlock Grid.Row="4" Grid.Column="2" Margin="0,0,16,6" VerticalAlignment="Center"
                          TextTrimming="CharacterEllipsis" Foreground="Gray"
@@ -436,7 +436,7 @@
               <Label Grid.Row="4" Grid.Column="3" Content="B25" VerticalAlignment="Center" Margin="0,0,4,6" />
               <NumericUpDown Grid.Row="4" Grid.Column="4" Margin="0,0,8,6"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_ExtB25_Input"
-                             FormatString="0" Name="ExtB25Box" Minimum="0" Maximum="255"
+                             FormatString="0" Name="ExtB25Box" ShowButtonSpinner="False" MinWidth="0" Minimum="0" Maximum="255"
                              ValueChanged="ExtByteBox_ValueChanged" />
               <TextBlock Grid.Row="4" Grid.Column="5" Margin="0,0,0,6" VerticalAlignment="Center"
                          TextTrimming="CharacterEllipsis" Foreground="Gray"
@@ -447,7 +447,7 @@
               <Label Grid.Row="5" Grid.Column="0" Content="B26" VerticalAlignment="Center" Margin="0,0,4,6" />
               <NumericUpDown Grid.Row="5" Grid.Column="1" Margin="0,0,8,6"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_ExtB26_Input"
-                             FormatString="0" Name="ExtB26Box" Minimum="0" Maximum="255"
+                             FormatString="0" Name="ExtB26Box" ShowButtonSpinner="False" MinWidth="0" Minimum="0" Maximum="255"
                              ValueChanged="ExtByteBox_ValueChanged" />
               <TextBlock Grid.Row="5" Grid.Column="2" Margin="0,0,16,6" VerticalAlignment="Center"
                          TextTrimming="CharacterEllipsis" Foreground="Gray"
@@ -457,7 +457,7 @@
               <Label Grid.Row="5" Grid.Column="3" Content="B27" VerticalAlignment="Center" Margin="0,0,4,6" />
               <NumericUpDown Grid.Row="5" Grid.Column="4" Margin="0,0,8,6"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_ExtB27_Input"
-                             FormatString="0" Name="ExtB27Box" Minimum="0" Maximum="255"
+                             FormatString="0" Name="ExtB27Box" ShowButtonSpinner="False" MinWidth="0" Minimum="0" Maximum="255"
                              ValueChanged="ExtByteBox_ValueChanged" />
               <TextBlock Grid.Row="5" Grid.Column="5" Margin="0,0,0,6" VerticalAlignment="Center"
                          TextTrimming="CharacterEllipsis" Foreground="Gray"
@@ -468,7 +468,7 @@
               <Label Grid.Row="6" Grid.Column="0" Content="B28" VerticalAlignment="Center" Margin="0,0,4,6" />
               <NumericUpDown Grid.Row="6" Grid.Column="1" Margin="0,0,8,6"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_ExtB28_Input"
-                             FormatString="0" Name="ExtB28Box" Minimum="0" Maximum="255"
+                             FormatString="0" Name="ExtB28Box" ShowButtonSpinner="False" MinWidth="0" Minimum="0" Maximum="255"
                              ValueChanged="ExtByteBox_ValueChanged" />
               <TextBlock Grid.Row="6" Grid.Column="2" Margin="0,0,16,6" VerticalAlignment="Center"
                          TextTrimming="CharacterEllipsis" Foreground="Gray"
@@ -478,7 +478,7 @@
               <Label Grid.Row="6" Grid.Column="3" Content="B29" VerticalAlignment="Center" Margin="0,0,4,6" />
               <NumericUpDown Grid.Row="6" Grid.Column="4" Margin="0,0,8,6"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_ExtB29_Input"
-                             FormatString="0" Name="ExtB29Box" Minimum="0" Maximum="255"
+                             FormatString="0" Name="ExtB29Box" ShowButtonSpinner="False" MinWidth="0" Minimum="0" Maximum="255"
                              ValueChanged="ExtByteBox_ValueChanged" />
               <TextBlock Grid.Row="6" Grid.Column="5" Margin="0,0,0,6" VerticalAlignment="Center"
                          TextTrimming="CharacterEllipsis" Foreground="Gray"
@@ -489,7 +489,7 @@
               <Label Grid.Row="7" Grid.Column="0" Content="B30" VerticalAlignment="Center" Margin="0,0,4,0" />
               <NumericUpDown Grid.Row="7" Grid.Column="1" Margin="0,0,8,0"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_ExtB30_Input"
-                             FormatString="0" Name="ExtB30Box" Minimum="0" Maximum="255"
+                             FormatString="0" Name="ExtB30Box" ShowButtonSpinner="False" MinWidth="0" Minimum="0" Maximum="255"
                              ValueChanged="ExtByteBox_ValueChanged" />
               <TextBlock Grid.Row="7" Grid.Column="2" Margin="0,0,16,0" VerticalAlignment="Center"
                          TextTrimming="CharacterEllipsis" Foreground="Gray"
@@ -499,7 +499,7 @@
               <Label Grid.Row="7" Grid.Column="3" Content="B31" VerticalAlignment="Center" Margin="0,0,4,0" />
               <NumericUpDown Grid.Row="7" Grid.Column="4" Margin="0,0,8,0"
                              AutomationProperties.AutomationId="SkillConfigFE8NSkill_ExtB31_Input"
-                             FormatString="0" Name="ExtB31Box" Minimum="0" Maximum="255"
+                             FormatString="0" Name="ExtB31Box" ShowButtonSpinner="False" MinWidth="0" Minimum="0" Maximum="255"
                              ValueChanged="ExtByteBox_ValueChanged" />
               <TextBlock Grid.Row="7" Grid.Column="5" Margin="0,0,0,0" VerticalAlignment="Center"
                          TextTrimming="CharacterEllipsis" Foreground="Gray"

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8UCSkillSys09xView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8UCSkillSys09xView.axaml
@@ -24,12 +24,12 @@
       <StackPanel Orientation="Horizontal" Spacing="6" Margin="4">
         <Label Content="Address:" VerticalAlignment="Center" />
         <NumericUpDown AutomationProperties.AutomationId="SkillConfigFE8UCSkillSys09x_Address_Input"
-                       FormatString="0" Name="AddressBox" Width="120"
+                       FormatString="0" Name="AddressBox" Width="120" ShowButtonSpinner="False" MinWidth="0"
                        Minimum="0" Maximum="4294967295"
                        IsEnabled="False" VerticalAlignment="Center" />
         <Label Content="Size:" VerticalAlignment="Center" />
         <NumericUpDown AutomationProperties.AutomationId="SkillConfigFE8UCSkillSys09x_BlockSize_Input"
-                       FormatString="0" Name="BlockSizeBox" Width="50"
+                       FormatString="0" Name="BlockSizeBox" Width="50" ShowButtonSpinner="False" MinWidth="0"
                        Minimum="0" Maximum="65535"
                        IsEnabled="False" VerticalAlignment="Center" Value="8" />
         <Label Content="Selected Address:" VerticalAlignment="Center" />
@@ -96,7 +96,7 @@
         </Grid>
 
         <!-- Skill Name row: text id + resolved name TextBox -->
-        <Grid ColumnDefinitions="100,80,*" RowDefinitions="Auto">
+        <Grid ColumnDefinitions="100,120,*" RowDefinitions="Auto">
           <Label Grid.Column="0"
                  AutomationProperties.AutomationId="SkillConfigFE8UCSkillSys09x_SkillName_Label"
                  Content="Skill Name:" VerticalAlignment="Center" />
@@ -110,7 +110,7 @@
         </Grid>
 
         <!-- Description row: text id + resolved description TextBox (multiline) -->
-        <Grid ColumnDefinitions="100,80,*" RowDefinitions="Auto">
+        <Grid ColumnDefinitions="100,120,*" RowDefinitions="Auto">
           <Label Grid.Column="0"
                  AutomationProperties.AutomationId="SkillConfigFE8UCSkillSys09x_Description_Label"
                  Content="Description:" VerticalAlignment="Center" />
@@ -175,7 +175,7 @@
                      Content="Frame" VerticalAlignment="Center" />
               <NumericUpDown Grid.Row="1" Grid.Column="1"
                              AutomationProperties.AutomationId="SkillConfigFE8UCSkillSys09x_ShowFrame_Input"
-                             FormatString="0" Name="ShowFrameUpDown" Width="80"
+                             FormatString="0" Name="ShowFrameUpDown" Width="120"
                              Minimum="0" Maximum="255" ValueChanged="ShowFrameUpDown_ValueChanged" />
             </Grid>
             <Border BorderBrush="DarkGray" BorderThickness="1" HorizontalAlignment="Left" Padding="2">


### PR DESCRIPTION
## Summary

Round-3c of the #1674 macOS Avalonia campaign — five CSkillSys / FE8N skill-editor layout bugs, all the **same root cause** as the merged round-3a #1721/#1724: Avalonia 11.2.3 `NumericUpDown` has a ~120px effective min width (spinner chrome), but these editors placed NUDs in fixed ≤80px Grid columns / `Width≤80`, so the spinner + value overflowed into the adjacent label / box / next NUD (reported on macOS; reproduces headlessly because the columns are fixed-px).

Layout-only fixes (no ViewModel/ROM changes) across 4 view files:
- **Read-only / disabled NUDs** (Address, Size/BlockSize, SelectedAddress, AnimationPointer) → `ShowButtonSpinner="False"` **+ `MinWidth="0"`**. The spinner-off alone is **not** enough — `App.axaml` sets a global `NumericUpDown { MinWidth=120 }`, so a spinner-less NUD still rendered at 120px and overflowed; `MinWidth="0"` lets it shrink to fit (the exact remedy already shipped in the merged #1724 `ImageBattleScreenView` PaletteGrid).
- **Editable single-NUD rows** (Icon ID, Skill Name, Description, Acquired Level, Read Count, Skill, X-level value) → widen the NUD column 80→120 (a sibling `*`/Auto column absorbs it, so the `SizeToContent` windows don't grow); `ShowFrameUpDown` gets `Width=120`. The Unit "Skill" grid is restructured to `Auto,120,Auto,*,Auto` (dropping a hardcoded `TextBox Width=200`) to match the Class view.
- **Editable NUDs in dense multi-NUD grids** (12 FE8N Icon-Display-Condition bytes; 16 FE8N ext-byte fields B16..B31) → `ShowButtonSpinner="False"` + `MinWidth="0"` (keyboard ↑/↓ + typing preserved; `AllowSpin` stays true).

## Plan & review

Plan v2 (accepted): https://github.com/laqieer/FEBuilderGBA/issues/1728#issuecomment-4845646786 — board round-2 approval: https://github.com/laqieer/FEBuilderGBA/issues/1728#issuecomment-4845685720

> **Note (honest disclosure):** the cross-model plan board approved a per-control table that specified only `ShowButtonSpinner="False"` for the read-only/dense NUDs. During implementation, the global `App.axaml NumericUpDown MinWidth=120` was found to defeat spinner-off alone (the NUD stays 120px and still overflows). This was corrected by adding `MinWidth="0"` (the #1724 precedent), and the layout tests were strengthened with geometric no-overlap checks on those rows (which the structural-only checks could not catch).

## Scope

Closes #1728
Closes #1729
Closes #1730
Closes #1731
Closes #1732

Layout-only; no behaviour change. Disjoint views, same defect class (matches the round-2 #1706 / round-3a #1734 combined-PR precedent).

## Test plan

- [x] **`SkillEditorLayoutTests` (new, 16 [AvaloniaFact] — all pass):**
  - **Structural** (visibility/tab-independent, by control Name): every spinner-collapsed NUD asserts `ShowButtonSpinner==false` **and `MinWidth==0`** (the latter fails under the global 120 default → discriminating) and `AllowSpin==true`; every widened NUD asserts effective min width ≥120 (explicit `Width` or its Grid column's absolute width).
  - **Geometric no-overlap** (forced layout, `TranslatePoint`+`Bounds` adjacency per Grid row): the strategy-(2) widened N1 rows (Unit/Class, force-showing the hidden `LevelUpGroup`/`XLevelAddPanel`), the FE8N Icon ID / Skill Name rows, the FE8U Skill Name / Description rows, **and** the strategy-(1)/(3) rows that prove the `MinWidth=0` fix — Unit selection/N1 bars (BlockSize in 80px cols), the FE8N condition rows (12 NUDs), and the FE8N Ext-Bytes rows (Tab 2). Each asserts `Bounds.Width>0` so it can't pass vacuously.
- [x] **Full Avalonia suite:** `dotnet test FEBuilderGBA.Avalonia.Tests` → **9260 passed, 0 failed, 7 skipped** (no regression across the editors).
- [x] **Core suite:** `dotnet test FEBuilderGBA.Core.Tests` → **6395 passed, 0 failed, 6 skipped** (Avalonia-independent change; `config/patch2` submodule initialised in the worktree).
- [x] **WinForms suite:** `dotnet test FEBuilderGBA.Tests` → **1927 passed, 0 failed** (incl. `AvaloniaFieldCompletenessTests` — the fix adds only attributes, no named-control add/remove).

## GUI Test Report

The fixes are layout-only; verified by the 16 headless `[AvaloniaFact]` layout tests above (the geometric no-overlap tests are the discriminating proof) and by desktop-Skia renders of each editor:

| Editor | Issue | Result |
|---|---|---|
| Skill Assignment - Unit (CSkillSys) | #1728 Size/Selected overlap | ✅ PASS — selection/N1 bars no overlap (geometric test) |
| Skill Assignment - Class (CSkillSys) | #1729 element overlap | ✅ PASS — widened N1 rows no overlap |
| Skill Configuration FE8N (Skill Detail) | #1730 Icon/Name/Condition overlap | ✅ PASS — Icon/Name widened, 12 condition NUDs fit (geometric) |
| Skill Configuration FE8N (Ext Bytes) | #1731 B16 overlap | ✅ PASS — 16 ext-byte NUDs fit their 80px cols (geometric, Tab 2) |
| Skill Configuration (CSkillSys 0.9x) | #1732 down-arrow collision | ✅ PASS — Skill Name/Description arrows in their own 120px column |

## Screenshots

Desktop-Skia renders (FE8U). Stock FE8U has no skill-system patch installed, so the editors show the "patch required" banner, but the **NUD layout under test renders regardless** — e.g. the CSkillSys 0.9x render below clearly shows the #1732 fix (the Skill Name / Description spinner arrows now sit in their own 120px column, not colliding with the adjacent box) and the compact "Size" field:

**Skill Configuration (CSkillSys 0.9x) — #1732:**
![CSkillSys 0.9x](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr1732-skillconfig-cskillsys09x-fe8u.png)

**Skill Configuration FE8N — #1730/#1731:**
![FE8N](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr1730-1731-skillconfig-fe8n-fe8u.png)

**Skill Assignment - Unit (CSkillSys) — #1728:**
![Unit CSkillSys](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr1728-skillassign-unit-cskillsys-fe8u.png)

**Skill Assignment - Class (CSkillSys) — #1729:**
![Class CSkillSys](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr1729-skillassign-class-cskillsys-fe8u.png)

---
Copilot CLI: 1.0.66
Model: Claude Opus 4.8 (claude-opus-4.8)
