### PR TITLE
feat(avalonia): searchable Insert-command picker in the Event Script Editor (#1736)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/EventScriptViewModelEditTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EventScriptViewModelEditTests.cs
@@ -147,6 +147,83 @@ namespace FEBuilderGBA.Avalonia.Tests
             Assert.Contains("MOVE", vm.Commands[1]);
         }
 
+        // ── #1736 searchable Insert-command picker ──────────────────────
+
+        [Fact]
+        public void FilteredCommands_EmptyFilter_MirrorsFullCatalogWithOriginalIndices()
+        {
+            var vm = MakeVmDisassembled(LoadEnda());
+            Assert.Equal(vm.AvailableCommands.Count, vm.FilteredCommands.Count);
+            for (int i = 0; i < vm.AvailableCommands.Count; i++)
+            {
+                Assert.Equal(i, vm.FilteredCommands[i].Index);
+                Assert.Equal(vm.AvailableCommands[i], vm.FilteredCommands[i].Text);
+            }
+        }
+
+        [Fact]
+        public void CommandFilterText_NarrowsCatalog_PreservingOriginalIndex()
+        {
+            var vm = MakeVmDisassembled(LoadEnda());
+            // AvailableCommands[1] is MOVE; its text is distinct from LOAD1/ENDA.
+            string moveText = vm.AvailableCommands[1];
+
+            vm.CommandFilterText = moveText;
+            Assert.Single(vm.FilteredCommands);
+            Assert.Equal(1, vm.FilteredCommands[0].Index);        // ORIGINAL index preserved
+            Assert.Equal(moveText, vm.FilteredCommands[0].Text);
+        }
+
+        [Fact]
+        public void CommandFilterText_IsCaseInsensitive()
+        {
+            var vm = MakeVmDisassembled(LoadEnda());
+            string moveText = vm.AvailableCommands[1];
+
+            vm.CommandFilterText = moveText.ToLowerInvariant();
+            Assert.Contains(vm.FilteredCommands, en => en.Index == 1);
+            vm.CommandFilterText = moveText.ToUpperInvariant();
+            Assert.Contains(vm.FilteredCommands, en => en.Index == 1);
+        }
+
+        [Fact]
+        public void CommandFilterText_NoMatch_YieldsEmpty_ThenClearRestoresAll()
+        {
+            var vm = MakeVmDisassembled(LoadEnda());
+            int all = vm.AvailableCommands.Count;
+
+            vm.CommandFilterText = "zzz_no_such_command";
+            Assert.Empty(vm.FilteredCommands);
+
+            vm.CommandFilterText = "";
+            Assert.Equal(all, vm.FilteredCommands.Count);
+        }
+
+        [Fact]
+        public void InsertSelectedCatalogCommand_FromFilteredEntryIndex_InsertsSameCommand()
+        {
+            var vm = MakeVmDisassembled(LoadEnda());
+            vm.SelectedCommandIndex = 0;
+            vm.CommandFilterText = vm.AvailableCommands[1]; // filter down to MOVE
+            Assert.Single(vm.FilteredCommands);
+
+            // The view feeds the filtered entry's ORIGINAL index into the picker index.
+            vm.SelectedCommandCatalogIndex = vm.FilteredCommands[0].Index;
+            Assert.True(vm.InsertSelectedCatalogCommand());
+            Assert.Equal(3, vm.CommandCount);
+            Assert.Contains("MOVE", vm.Commands[1]);
+        }
+
+        [Fact]
+        public void InsertSelectedCatalogCommand_NoSelection_IsRejected()
+        {
+            // Mirrors the view path when filtering clears the ComboBox selection
+            // (SelectedItem == null -> index -1).
+            var vm = MakeVmDisassembled(LoadEnda());
+            vm.SelectedCommandCatalogIndex = -1;
+            Assert.False(vm.InsertSelectedCatalogCommand());
+        }
+
         [Fact]
         public void DeleteSelected_RemovesCommand()
         {

--- a/FEBuilderGBA.Avalonia/ViewModels/EventScriptViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/EventScriptViewModel.cs
@@ -33,6 +33,8 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         // Insert support: the command catalog (names) + raw-hex entry.
         ObservableCollection<string> _availableCommands = new();
         int _selectedCommandCatalogIndex = -1;
+        readonly ObservableCollection<CommandCatalogEntry> _filteredCommands = new();
+        string _commandFilterText = "";
         string _insertHexText = "";
         string _importText = "";
 
@@ -119,6 +121,28 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
         /// <summary>Index of the command chosen in the Insert command-picker.</summary>
         public int SelectedCommandCatalogIndex { get => _selectedCommandCatalogIndex; set => SetField(ref _selectedCommandCatalogIndex, value); }
+
+        /// <summary>The catalog filtered by <see cref="CommandFilterText"/> — what the
+        /// searchable Insert-command picker shows. Each entry keeps its ORIGINAL index
+        /// into <see cref="AvailableCommands"/> so filtering never changes what gets
+        /// inserted (#1736).</summary>
+        public ObservableCollection<CommandCatalogEntry> FilteredCommands => _filteredCommands;
+
+        /// <summary>Case-insensitive substring filter for the Insert-command picker;
+        /// empty shows the whole catalog (#1736).</summary>
+        public string CommandFilterText
+        {
+            get => _commandFilterText;
+            set { if (SetField(ref _commandFilterText, value ?? "")) ApplyCommandFilter(); }
+        }
+
+        /// <summary>A catalog entry for the searchable Insert-command picker: the display
+        /// text plus its ORIGINAL index in <see cref="AvailableCommands"/> (#1736). The
+        /// explicit <see cref="ToString"/> keeps the record printing just the text.</summary>
+        public sealed record CommandCatalogEntry(int Index, string Text)
+        {
+            public override string ToString() => Text;
+        }
 
         /// <summary>Raw hex text for the "Insert (hex)" path (e.g. "0100 4200").</summary>
         public string InsertHexText { get => _insertHexText; set => SetField(ref _insertHexText, value); }
@@ -257,11 +281,30 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         void BuildCommandCatalog()
         {
             AvailableCommands.Clear();
-            if (_es?.Scripts == null) return;
+            if (_es?.Scripts == null) { ApplyCommandFilter(); return; }
             foreach (var sc in _es.Scripts)
             {
                 if (sc == null) continue;
                 AvailableCommands.Add(EventScript.makeCommandComboText(sc, false));
+            }
+            ApplyCommandFilter();
+        }
+
+        /// <summary>Rebuild <see cref="FilteredCommands"/> from <see cref="AvailableCommands"/>,
+        /// keeping (with their ORIGINAL indices) the entries whose text contains
+        /// <see cref="CommandFilterText"/> — case-insensitive; an empty filter keeps all.
+        /// The preserved index is the position in <see cref="AvailableCommands"/>, i.e. the
+        /// same value the un-filtered ComboBox's SelectedIndex fed to
+        /// <see cref="SelectedCommandCatalogIndex"/>, so insertion is byte-for-byte unchanged (#1736).</summary>
+        void ApplyCommandFilter()
+        {
+            _filteredCommands.Clear();
+            string f = _commandFilterText;
+            for (int i = 0; i < _availableCommands.Count; i++)
+            {
+                string text = _availableCommands[i] ?? "";
+                if (f.Length == 0 || text.IndexOf(f, StringComparison.OrdinalIgnoreCase) >= 0)
+                    _filteredCommands.Add(new CommandCatalogEntry(i, text));
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/EventScriptView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EventScriptView.axaml
@@ -21,6 +21,10 @@
       <StackPanel Spacing="6">
         <StackPanel Orientation="Horizontal" Spacing="6">
           <TextBlock Text="Insert command:" VerticalAlignment="Center" />
+          <TextBox AutomationProperties.AutomationId="EventScript_CatalogFilter_Input" Name="CatalogFilterBox"
+                   Width="150" Watermark="Filter..." VerticalAlignment="Center"
+                   TextChanged="CatalogFilter_TextChanged"
+                   ToolTip.Tip="Type to filter the command list (case-insensitive substring)." />
           <ComboBox AutomationProperties.AutomationId="EventScript_Catalog_Combo" Name="CatalogCombo" Width="260">
             <ComboBox.Styles>
               <Style Selector="ComboBoxItem">
@@ -30,7 +34,7 @@
             </ComboBox.Styles>
             <ComboBox.ItemTemplate>
               <DataTemplate>
-                <TextBlock Text="{Binding}" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding}" />
+                <TextBlock Text="{Binding Text}" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Text}" />
               </DataTemplate>
             </ComboBox.ItemTemplate>
           </ComboBox>

--- a/FEBuilderGBA.Avalonia/Views/EventScriptView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventScriptView.axaml.cs
@@ -17,7 +17,9 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             InitializeComponent();
             CommandsList.ItemsSource = _vm.Commands;
-            CatalogCombo.ItemsSource = _vm.AvailableCommands;
+            // #1736: the picker shows the FILTERED catalog; each entry keeps its
+            // original catalog index so insertion is unaffected by filtering.
+            CatalogCombo.ItemsSource = _vm.FilteredCommands;
         }
 
         void Disassemble_Click(object? sender, RoutedEventArgs e)
@@ -51,11 +53,20 @@ namespace FEBuilderGBA.Avalonia.Views
             _vm.SelectedCommandIndex = CommandsList.SelectedIndex;
         }
 
+        void CatalogFilter_TextChanged(object? sender, TextChangedEventArgs e)
+        {
+            // #1736: live case-insensitive substring filter of the Insert-command catalog.
+            _vm.CommandFilterText = CatalogFilterBox.Text ?? "";
+        }
+
         // ── structural-edit handlers ───────────────────────────────────
 
         void Insert_Click(object? sender, RoutedEventArgs e)
         {
-            _vm.SelectedCommandCatalogIndex = CatalogCombo.SelectedIndex;
+            // #1736: map the selected FILTERED entry back to its ORIGINAL catalog index
+            // (the filtered list's position differs from the full catalog).
+            _vm.SelectedCommandCatalogIndex =
+                (CatalogCombo.SelectedItem as EventScriptViewModel.CommandCatalogEntry)?.Index ?? -1;
             _vm.InsertSelectedCatalogCommand();
             AfterEdit();
         }

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -14147,3 +14147,9 @@ ROM（.gba）は絶対に添付しないでください。
 
 :Couldn't open your browser automatically. Please file the bug at this URL:
 ブラウザーを自動で開けませんでした。次のURLからバグを報告してください:
+
+:Filter...
+フィルター...
+
+:Type to filter the command list (case-insensitive substring).
+コマンド一覧を絞り込む文字列を入力します（大文字小文字を区別しない部分一致）。

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -27977,3 +27977,9 @@ ROM 重建需要桌面文件系统访问权限，本设备不可用。
 
 :Couldn't open your browser automatically. Please file the bug at this URL:
 无法自动打开浏览器。请通过以下网址报告错误:
+
+:Filter...
+筛选...
+
+:Type to filter the command list (case-insensitive substring).
+输入以筛选命令列表（不区分大小写的子串匹配）。


### PR DESCRIPTION
## Summary

The Avalonia **Event Script Editor**'s "Insert command" picker was a flat, unfiltered `ComboBox` over the full event-command catalog, so finding a specific command (e.g. a reinforcement / `LOAD` / unit-spawn) was slow and error-prone for newcomers (user report in discussion #1712). This adds a live **search filter** in front of the picker.

- **`EventScriptViewModel`**: adds `record CommandCatalogEntry(int Index, string Text)`, an `ObservableCollection<CommandCatalogEntry> FilteredCommands`, and a `CommandFilterText` property. `ApplyCommandFilter()` rebuilds `FilteredCommands` from `AvailableCommands`, keeping — with each entry's **original catalog index** — the entries whose text contains the filter (case-insensitive substring; empty = all). `AvailableCommands` and `SelectedCommandCatalogIndex` are unchanged.
- **`EventScriptView`**: a `Filter...` `TextBox` (its `TextChanged` sets `CommandFilterText`) is placed before the `ComboBox`; the `ComboBox` now shows `FilteredCommands` (its `ItemTemplate` binds `Text`); `Insert` maps the selected entry's **original `Index`** into `SelectedCommandCatalogIndex`, so insertion is byte-for-byte identical to before. The `ComboBox` (and its #1716 fixed-width dropdown style) is kept — **not** swapped for an `AutoCompleteBox` — so the existing layout guard stays valid.
- **ja/zh translations** for the new `Filter...` watermark and its tooltip.

Preserving the original index (rather than mapping by display string) is required because command display strings are not guaranteed unique.

## Plan & review

Plan: https://github.com/laqieer/FEBuilderGBA/issues/1736#issuecomment-4850040958 — cross-model board approved: https://github.com/laqieer/FEBuilderGBA/issues/1736#issuecomment-4850073693

## Scope

Closes #1736

The identical picker in `ProcsScriptView` is a natural fast-follow but is **out of scope** for this issue's acceptance criteria (Event Script Editor). The VM change leaves `ProcsScriptView` (which still binds `AvailableCommands`) unaffected.

## Test plan

- [x] **6 new `EventScriptViewModelEditTests` (all pass):** empty filter mirrors the full catalog with original indices; a substring filter narrows the list while **preserving the original index**; filtering is case-insensitive; a no-match filter yields empty and clearing restores all; inserting via a filtered entry's `Index` inserts the **same** command as the unfiltered path; a no-selection (`-1`) insert is rejected.
- [x] **Existing guards stay green:** `EventScriptViewModelEditTests` (`AvailableCommands.Count`, direct `SelectedCommandCatalogIndex` insert) and #1716 `ButtonOverlapLayoutTests.EventScriptView_CatalogCombo_HasFixedWidthDropdownStyle` / `ProcsScriptView_...` (ComboBox + fixed-width dropdown preserved).
- [x] **L10n:** `L10nCoverageTest.AvaloniaViews_HaveJaAndZhTranslations` green (new watermark + tooltip translated to ja/zh).
- [x] **Full Avalonia suite:** `dotnet test FEBuilderGBA.Avalonia.Tests` → **9267 passed, 0 failed, 7 skipped**.
- [x] **Core + WinForms suites:** `dotnet test FEBuilderGBA.Core.Tests` and `FEBuilderGBA.Tests` → green (translate-file additions only; no code impact).

## GUI Test Report

| Area | Behaviour | Result |
|---|---|---|
| Event Script Editor toolbar | New `Filter...` box renders before the Insert-command picker | ✅ PASS (screenshot) |
| Insert-command filter | Typing narrows the catalog live by case-insensitive substring | ✅ PASS (`CommandFilterText_NarrowsCatalog_PreservingOriginalIndex`, `CommandFilterText_IsCaseInsensitive`) |
| Insert after filtering | Selecting a filtered entry inserts the same command as before | ✅ PASS (`InsertSelectedCatalogCommand_FromFilteredEntryIndex_InsertsSameCommand`) |
| Empty / no-match filter | Empty shows all; no-match shows none; clearing restores all | ✅ PASS (`FilteredCommands_EmptyFilter_...`, `CommandFilterText_NoMatch_...`) |
| #1716 layout | ComboBox + fixed-width dropdown style unchanged | ✅ PASS (`ButtonOverlapLayoutTests`) |

## Screenshots

**Event Script Editor (FE8U)** — after disassembling a real event (30 commands), the new `Filter...` box is set to **`MOVE`** and the "Insert command" picker has narrowed the full command catalog to the MOVE-matching commands, with a `ManualMove` command selected in the picker. Running-app WinCapture; the searchable-filter behaviour is additionally covered by the 6 unit tests above.

![Event Script Editor filter](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr1736-eventscript-filter.png)

---
Copilot CLI: 1.0.66
Model: Claude Opus 4.8 (claude-opus-4.8)
