### PR TITLE
docs: use claude-sonnet-5 as the Claude-series Review Board alternate

### DIFF
--- a/DEVELOPMENT-WORKFLOW.md
+++ b/DEVELOPMENT-WORKFLOW.md
@@ -42,7 +42,7 @@ Do **not** call `agency cc` / Claude Code. Convene a 3-model board **in-session*
 
 1. **Board roster:** `claude-opus-4.8` (Claude Opus 4.8), `gpt-5.5` (GPT-5.5), `gemini-3.5-flash` (Gemini 3.5 Flash).
    **Independence:** if your own active model is one of these, swap that member for a **named same-tier alternate**
-   (`claude-opus-4.8`→`claude-sonnet-4.6`, `gpt-5.5`→`gpt-5.4`, `gemini-3.5-flash`→`gemini-3.1-pro-preview`) so all
+   (`claude-opus-4.8`→`claude-sonnet-5`, `gpt-5.5`→`gpt-5.4`, `gemini-3.5-flash`→`gemini-3.1-pro-preview`) so all
    three reviewers differ from you; keep ≥2 providers (Anthropic / OpenAI / Google). If a roster/alternate model is
    unavailable, substitute another available model from a different provider and note the substitution.
 2. **Gather the artifact (full source-of-truth context)** and embed it in each reviewer's prompt:


### PR DESCRIPTION
## Summary

Claude Sonnet 5 (`claude-sonnet-5`) is now available. This updates the **Branch B** in-session cross-model Review Board's **Independence** alternate so that when the developer's active model is `claude-opus-4.8`, the Claude-series reviewer swaps to `claude-sonnet-5` (previously `claude-sonnet-4.6`) — selecting a **different, current** Claude model than the working model for review.

## Change

`DEVELOPMENT-WORKFLOW.md` (one line, Branch B → Independence alternate mapping):

- Before: `` `claude-opus-4.8`→`claude-sonnet-4.6` ``
- After: `` `claude-opus-4.8`→`claude-sonnet-5` ``

The base roster (`claude-opus-4.8`, `gpt-5.5`, `gemini-3.5-flash`), the OpenAI/Google alternates, and the `Review Board:` footer example are unchanged. `.claude/skills/dev-flow/SKILL.md` needs no change — it lists only the base roster and defers the alternate mechanism to `DEVELOPMENT-WORKFLOW.md`.

## Plan & review

- Issue: #1770
- Plan comment: https://github.com/laqieer/FEBuilderGBA/issues/1770#issuecomment-4866830654
- Plan-gate Cross-Model Review Board (`claude-sonnet-5` / `gpt-5.5` / `gemini-3.5-flash`): **APPROVED**, no blocking concerns.

## Scope

Closes #1770

## Test plan

- [x] `git diff` shows exactly one changed line (`1 file changed, 1 insertion(+), 1 deletion(-)`)
- [x] `claude-sonnet-4.6` no longer appears anywhere in the repo (grep of `DEVELOPMENT-WORKFLOW.md` + `SKILL.md` returns empty)
- [x] `claude-sonnet-5` present on the Independence line of `DEVELOPMENT-WORKFLOW.md`
- [x] Unicode `→` (U+2192) and `≥` (U+2265) preserved; base roster line and footer example unchanged
- [x] `claude-sonnet-5` confirmed as an available model in the environment's model catalog

Docs-only change — no unit/E2E tests apply; screenshots optional per workflow (not a GUI feat/fix PR).

Copilot CLI: 1.0.69-0
Model: Claude Opus 4.8 (claude-opus-4.8)
