### PR TITLE
fix: migrate dead dw.ngmansion.xyz DokuWiki links to static mirror (#1780)

### DIFF
--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassCSkillSysView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassCSkillSysView.axaml.cs
@@ -496,7 +496,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void OnLearnInfo(object? sender, RoutedEventArgs e)
         {
-            const string url = "https://dw.ngmansion.xyz/doku.php?id=en:guide_febuildergba_learnskillinfo";
+            const string url = "https://laqieer.github.io/dw.ngmansion.xyz/wiki/en/guide_febuildergba_learnskillinfo.html";
             try
             {
                 Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });

--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassSkillSystemView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassSkillSystemView.axaml.cs
@@ -443,7 +443,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 var psi = new System.Diagnostics.ProcessStartInfo
                 {
-                    FileName = "https://dw.ngmansion.xyz/doku.php?id=en:guide_febuildergba_learnskillinfo",
+                    FileName = "https://laqieer.github.io/dw.ngmansion.xyz/wiki/en/guide_febuildergba_learnskillinfo.html",
                     UseShellExecute = true,
                 };
                 System.Diagnostics.Process.Start(psi);

--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentUnitCSkillSysView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentUnitCSkillSysView.axaml.cs
@@ -395,7 +395,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void OnLearnInfo(object? sender, RoutedEventArgs e)
         {
-            const string url = "https://dw.ngmansion.xyz/doku.php?id=en:guide_febuildergba_learnskillinfo";
+            const string url = "https://laqieer.github.io/dw.ngmansion.xyz/wiki/en/guide_febuildergba_learnskillinfo.html";
             try
             {
                 Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });

--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentUnitSkillSystemView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentUnitSkillSystemView.axaml.cs
@@ -460,7 +460,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 var psi = new System.Diagnostics.ProcessStartInfo
                 {
-                    FileName = "https://dw.ngmansion.xyz/doku.php?id=en:guide_febuildergba_learnskillinfo",
+                    FileName = "https://laqieer.github.io/dw.ngmansion.xyz/wiki/en/guide_febuildergba_learnskillinfo.html",
                     UseShellExecute = true,
                 };
                 System.Diagnostics.Process.Start(psi);

--- a/FEBuilderGBA.Core.Tests/DeadWikiLinkTests.cs
+++ b/FEBuilderGBA.Core.Tests/DeadWikiLinkTests.cs
@@ -24,16 +24,20 @@ namespace FEBuilderGBA.Core.Tests
         private const string DeadDispatcher = "/doku.php";
         private static readonly string DeadLinkPattern = DeadHost + DeadDispatcher;
 
-        // Directories to skip: git-ignored build output, submodules, and bundled
-        // third-party/resource trees that are not part of this repo's source.
+        // Directories to skip: git-ignored build output, generated data, and git
+        // submodules (separate repos, out of scope for this repo's dead-link guard).
+        // Note: tools/ and resources/ are NOT blanket-skipped — only their submodule
+        // subpaths are — so first-party tools (tools/WinCapture, tools/TextToPng,
+        // tools/capture-window.cs, etc.) remain guarded against dead-link reintroduction.
         private static readonly string[] SkipSegments =
         {
             Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar,
             Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar,
             Path.DirectorySeparatorChar + ".git" + Path.DirectorySeparatorChar,
-            Path.DirectorySeparatorChar + "config" + Path.DirectorySeparatorChar,   // config/patch2 submodule + generated data
-            Path.DirectorySeparatorChar + "tools" + Path.DirectorySeparatorChar,     // bundled EA/ColorzCore submodules
-            Path.DirectorySeparatorChar + "resources" + Path.DirectorySeparatorChar, // FE-Repo submodule
+            Path.DirectorySeparatorChar + "config" + Path.DirectorySeparatorChar,              // generated game data + config/patch2 submodule
+            Path.DirectorySeparatorChar + "tools" + Path.DirectorySeparatorChar + "Event-Assembler" + Path.DirectorySeparatorChar, // submodule
+            Path.DirectorySeparatorChar + "tools" + Path.DirectorySeparatorChar + "ColorzCore" + Path.DirectorySeparatorChar,       // submodule
+            Path.DirectorySeparatorChar + "resources" + Path.DirectorySeparatorChar + "FE-Repo",  // FE-Repo + FE-Repo-Music-No-Preview submodules
         };
 
         private static readonly string[] ScanExtensions =

--- a/FEBuilderGBA.Core.Tests/DeadWikiLinkTests.cs
+++ b/FEBuilderGBA.Core.Tests/DeadWikiLinkTests.cs
@@ -124,7 +124,13 @@ namespace FEBuilderGBA.Core.Tests
 
                 string content;
                 try { content = File.ReadAllText(file); }
-                catch { continue; }
+                catch (Exception ex)
+                {
+                    // A first-party source/doc file we expected to scan is unreadable —
+                    // fail loudly rather than silently skip, which could hide a dead link.
+                    violations.Add(GetRelative(root, file) + " (unreadable: " + ex.GetType().Name + ")");
+                    continue;
+                }
 
                 if (content.IndexOf(DeadLinkPattern, StringComparison.OrdinalIgnoreCase) >= 0)
                 {

--- a/FEBuilderGBA.Core.Tests/DeadWikiLinkTests.cs
+++ b/FEBuilderGBA.Core.Tests/DeadWikiLinkTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    /// <summary>
+    /// Regression guard for issue #1780: the legacy DokuWiki host
+    /// <c>https://dw.ngmansion.xyz/</c> was shut down, and all in-app help links /
+    /// documentation references were migrated to the static mirror
+    /// <c>https://laqieer.github.io/dw.ngmansion.xyz/</c>. This test fails if any
+    /// source or documentation file re-introduces a dead <c>doku.php</c> link, so
+    /// the dead links cannot silently come back.
+    /// </summary>
+    public class DeadWikiLinkTests
+    {
+        // The dead DokuWiki dispatcher pattern = legacy host + the "/doku.php" dispatcher.
+        // Built from two parts so this guard file does not match itself, and so it does
+        // NOT match the valid static mirror (which contains the host as a path segment:
+        // laqieer.github.io/dw.ngmansion.xyz/wiki/...). Any occurrence of the combined
+        // pattern means a help link / doc reference was not migrated to the mirror.
+        private const string DeadHost = "dw.ngmansion.xyz";
+        private const string DeadDispatcher = "/doku.php";
+        private static readonly string DeadLinkPattern = DeadHost + DeadDispatcher;
+
+        // Directories to skip: git-ignored build output, submodules, and bundled
+        // third-party/resource trees that are not part of this repo's source.
+        private static readonly string[] SkipSegments =
+        {
+            Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar,
+            Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar,
+            Path.DirectorySeparatorChar + ".git" + Path.DirectorySeparatorChar,
+            Path.DirectorySeparatorChar + "config" + Path.DirectorySeparatorChar,   // config/patch2 submodule + generated data
+            Path.DirectorySeparatorChar + "tools" + Path.DirectorySeparatorChar,     // bundled EA/ColorzCore submodules
+            Path.DirectorySeparatorChar + "resources" + Path.DirectorySeparatorChar, // FE-Repo submodule
+        };
+
+        private static readonly string[] ScanExtensions =
+        {
+            ".cs", ".md", ".axaml",
+        };
+
+        private static string FindRepoRoot()
+        {
+            var dir = AppContext.BaseDirectory;
+            for (int i = 0; i < 12; i++)
+            {
+                if (File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+                    return dir;
+                dir = Path.GetDirectoryName(dir);
+                if (dir == null) break;
+            }
+            return null;
+        }
+
+        private static bool IsSkipped(string path)
+        {
+            foreach (var seg in SkipSegments)
+            {
+                if (path.IndexOf(seg, StringComparison.OrdinalIgnoreCase) >= 0)
+                    return true;
+            }
+            return false;
+        }
+
+        [Fact]
+        public void NoSourceFile_ReferencesDeadDokuWikiHost()
+        {
+            var root = FindRepoRoot();
+            if (root == null)
+            {
+                // Running without the full repo checkout (e.g. packaged CI) — nothing to scan.
+                return;
+            }
+
+            var violations = new List<string>();
+            foreach (var file in Directory.EnumerateFiles(root, "*.*", SearchOption.AllDirectories))
+            {
+                var ext = Path.GetExtension(file);
+                bool wanted = false;
+                foreach (var e in ScanExtensions)
+                {
+                    if (string.Equals(ext, e, StringComparison.OrdinalIgnoreCase)) { wanted = true; break; }
+                }
+                if (!wanted) continue;
+                if (IsSkipped(file)) continue;
+
+                string content;
+                try { content = File.ReadAllText(file); }
+                catch { continue; }
+
+                if (content.IndexOf(DeadLinkPattern, StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    violations.Add(GetRelative(root, file));
+                }
+            }
+
+            Assert.True(violations.Count == 0,
+                "The dead DokuWiki host '" + DeadLinkPattern + "' must not be referenced " +
+                "(migrate to https://laqieer.github.io/dw.ngmansion.xyz/wiki/<id-with-slashes>.html). " +
+                "Offending files:\n  " + string.Join("\n  ", violations));
+        }
+
+        private static string GetRelative(string root, string file)
+        {
+            if (file.StartsWith(root, StringComparison.OrdinalIgnoreCase))
+                return file.Substring(root.Length).TrimStart(Path.DirectorySeparatorChar);
+            return file;
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/DeadWikiLinkTests.cs
+++ b/FEBuilderGBA.Core.Tests/DeadWikiLinkTests.cs
@@ -24,20 +24,20 @@ namespace FEBuilderGBA.Core.Tests
         private const string DeadDispatcher = "/doku.php";
         private static readonly string DeadLinkPattern = DeadHost + DeadDispatcher;
 
-        // Directories to skip: git-ignored build output, generated data, and git
-        // submodules (separate repos, out of scope for this repo's dead-link guard).
-        // Note: tools/ and resources/ are NOT blanket-skipped — only their submodule
-        // subpaths are — so first-party tools (tools/WinCapture, tools/TextToPng,
+        // Build output and git trees pruned by directory NAME during the walk.
+        private static readonly string[] SkipDirNames = { "bin", "obj", ".git" };
+
+        // Repo-root-relative directories to prune (forward-slash). config/ is generated
+        // game data + the config/patch2 submodule; the rest are git submodules (separate
+        // repos, out of scope). tools/ and resources/ are NOT blanket-pruned — only their
+        // submodule subpaths are — so first-party tools (tools/WinCapture, tools/TextToPng,
         // tools/capture-window.cs, etc.) remain guarded against dead-link reintroduction.
-        private static readonly string[] SkipSegments =
+        private static readonly string[] SkipRelDirs =
         {
-            Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar,
-            Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar,
-            Path.DirectorySeparatorChar + ".git" + Path.DirectorySeparatorChar,
-            Path.DirectorySeparatorChar + "config" + Path.DirectorySeparatorChar,              // generated game data + config/patch2 submodule
-            Path.DirectorySeparatorChar + "tools" + Path.DirectorySeparatorChar + "Event-Assembler" + Path.DirectorySeparatorChar, // submodule
-            Path.DirectorySeparatorChar + "tools" + Path.DirectorySeparatorChar + "ColorzCore" + Path.DirectorySeparatorChar,       // submodule
-            Path.DirectorySeparatorChar + "resources" + Path.DirectorySeparatorChar + "FE-Repo",  // FE-Repo + FE-Repo-Music-No-Preview submodules
+            "config",                 // generated game data + config/patch2 submodule
+            "tools/Event-Assembler",  // submodule
+            "tools/ColorzCore",       // submodule
+            "resources/FE-Repo",      // FE-Repo + FE-Repo-Music-No-Preview submodules
         };
 
         private static readonly string[] ScanExtensions =
@@ -58,14 +58,52 @@ namespace FEBuilderGBA.Core.Tests
             return null;
         }
 
-        private static bool IsSkipped(string path)
+        // Recursive walk that PRUNES skipped directories before descending, so the large
+        // build-output, .git, generated-data, and submodule trees are never enumerated.
+        // Yields only first-party source/doc files with a scanned extension.
+        private static IEnumerable<string> EnumerateSourceFiles(string root)
         {
-            foreach (var seg in SkipSegments)
+            var stack = new Stack<string>();
+            stack.Push(root);
+            while (stack.Count > 0)
             {
-                if (path.IndexOf(seg, StringComparison.OrdinalIgnoreCase) >= 0)
-                    return true;
+                var dir = stack.Pop();
+
+                string[] files;
+                try { files = Directory.GetFiles(dir); }
+                catch { files = Array.Empty<string>(); }
+                foreach (var f in files)
+                {
+                    var ext = Path.GetExtension(f);
+                    foreach (var e in ScanExtensions)
+                    {
+                        if (string.Equals(ext, e, StringComparison.OrdinalIgnoreCase)) { yield return f; break; }
+                    }
+                }
+
+                string[] subdirs;
+                try { subdirs = Directory.GetDirectories(dir); }
+                catch { subdirs = Array.Empty<string>(); }
+                foreach (var sub in subdirs)
+                {
+                    var name = Path.GetFileName(sub);
+                    bool prune = false;
+                    foreach (var d in SkipDirNames)
+                    {
+                        if (string.Equals(d, name, StringComparison.OrdinalIgnoreCase)) { prune = true; break; }
+                    }
+                    if (!prune)
+                    {
+                        var rel = Path.GetRelativePath(root, sub).Replace(Path.DirectorySeparatorChar, '/');
+                        foreach (var s in SkipRelDirs)
+                        {
+                            if (rel.Equals(s, StringComparison.OrdinalIgnoreCase) ||
+                                rel.StartsWith(s + "/", StringComparison.OrdinalIgnoreCase)) { prune = true; break; }
+                        }
+                    }
+                    if (!prune) stack.Push(sub);
+                }
             }
-            return false;
         }
 
         [Fact]
@@ -78,17 +116,11 @@ namespace FEBuilderGBA.Core.Tests
                 return;
             }
 
+            int scanned = 0;
             var violations = new List<string>();
-            foreach (var file in Directory.EnumerateFiles(root, "*.*", SearchOption.AllDirectories))
+            foreach (var file in EnumerateSourceFiles(root))
             {
-                var ext = Path.GetExtension(file);
-                bool wanted = false;
-                foreach (var e in ScanExtensions)
-                {
-                    if (string.Equals(ext, e, StringComparison.OrdinalIgnoreCase)) { wanted = true; break; }
-                }
-                if (!wanted) continue;
-                if (IsSkipped(file)) continue;
+                scanned++;
 
                 string content;
                 try { content = File.ReadAllText(file); }
@@ -99,6 +131,13 @@ namespace FEBuilderGBA.Core.Tests
                     violations.Add(GetRelative(root, file));
                 }
             }
+
+            // When the repo root resolves (the normal dev/CI case), a green pass MUST mean the
+            // tree was actually walked — not a silent no-op. The repo has far more than 200
+            // scanned source/doc files, so this floor proves real coverage occurred.
+            Assert.True(scanned > 200,
+                $"Expected to scan the first-party source tree, but only saw {scanned} files " +
+                "(directory-prune/walk bug?).");
 
             Assert.True(violations.Count == 0,
                 "The dead DokuWiki host '" + DeadLinkPattern + "' must not be referenced " +

--- a/FEBuilderGBA/ImageUtil.cs
+++ b/FEBuilderGBA/ImageUtil.cs
@@ -586,7 +586,7 @@ namespace FEBuilderGBA
                 {
                     continue;
                 }
-                //TSA see https://dw.ngmansion.xyz/doku.php?id=column:tsa
+                //TSA see https://laqieer.github.io/dw.ngmansion.xyz/wiki/column/tsa.html
                 UInt16 tileNumber = (UInt16)(tsatile & 0x03FF);
 
                 //TSAのtileNumberの場所にソースデータがある.
@@ -791,7 +791,7 @@ namespace FEBuilderGBA
                 {
                     continue;
                 }
-                //TSA see https://dw.ngmansion.xyz/doku.php?id=column:tsa
+                //TSA see https://laqieer.github.io/dw.ngmansion.xyz/wiki/column/tsa.html
                 UInt16 tileNumber = (UInt16)(tsatile & 0x03FF);
 
                 //TSAのtileNumberの場所にソースデータがある.
@@ -1199,7 +1199,7 @@ namespace FEBuilderGBA
                 {
                     continue;
                 }
-                //TSA see https://dw.ngmansion.xyz/doku.php?id=column:tsa
+                //TSA see https://laqieer.github.io/dw.ngmansion.xyz/wiki/column/tsa.html
                 UInt16 tileNumber = (UInt16)(tsatile & 0x03FF);
 
                 //TSAのtileNumberの場所にソースデータがある.
@@ -2004,7 +2004,7 @@ namespace FEBuilderGBA
                 {
                     continue;
                 }
-                //TSA see https://dw.ngmansion.xyz/doku.php?id=column:tsa
+                //TSA see https://laqieer.github.io/dw.ngmansion.xyz/wiki/column/tsa.html
                 UInt16 tileNumber = (UInt16)(tsatile & 0x03FF);
 
                 //TSAのtileNumberの場所にソースデータがある.

--- a/FEBuilderGBA/MapStyleEditorFormWarningVanillaTileOverraideForm.cs
+++ b/FEBuilderGBA/MapStyleEditorFormWarningVanillaTileOverraideForm.cs
@@ -16,11 +16,11 @@ namespace FEBuilderGBA
             string lang = OptionForm.lang();
             if (lang == "ja")
             {
-                HelpTextBox.Text = "https://dw.ngmansion.xyz/doku.php?id=guide:febuildergba:%E3%82%BF%E3%82%A4%E3%83%AB%E3%83%91%E3%83%AC%E3%83%83%E3%83%88%E3%81%AE%E5%A4%89%E6%9B%B4";
+                HelpTextBox.Text = "https://laqieer.github.io/dw.ngmansion.xyz/wiki/guide/febuildergba/%E3%82%BF%E3%82%A4%E3%83%AB%E3%83%91%E3%83%AC%E3%83%83%E3%83%88%E3%81%AE%E5%A4%89%E6%9B%B4.html";
             }
             else
             {
-                HelpTextBox.Text = "https://dw.ngmansion.xyz/doku.php?id=en:guide:febuildergba:how_to_change_tile_style_en";
+                HelpTextBox.Text = "https://laqieer.github.io/dw.ngmansion.xyz/wiki/en/guide/febuildergba/how_to_change_tile_style_en.html";
             }
         }
 

--- a/FEBuilderGBA/SkillAssignmentClassCSkillSysForm.cs
+++ b/FEBuilderGBA/SkillAssignmentClassCSkillSysForm.cs
@@ -626,7 +626,7 @@ namespace FEBuilderGBA
 
         private void X_LEARNINFO_Click(object sender, EventArgs e)
         {
-            string url = "https://dw.ngmansion.xyz/doku.php?id=en:guide_febuildergba_learnskillinfo";
+            string url = "https://laqieer.github.io/dw.ngmansion.xyz/wiki/en/guide_febuildergba_learnskillinfo.html";
             U.OpenURLOrFile(url);
         }
 

--- a/FEBuilderGBA/SkillAssignmentClassSkillSystemForm.cs
+++ b/FEBuilderGBA/SkillAssignmentClassSkillSystemForm.cs
@@ -731,7 +731,7 @@ namespace FEBuilderGBA
 
         private void X_LEARNINFO_Click(object sender, EventArgs e)
         {
-            string url = "https://dw.ngmansion.xyz/doku.php?id=en:guide_febuildergba_learnskillinfo";
+            string url = "https://laqieer.github.io/dw.ngmansion.xyz/wiki/en/guide_febuildergba_learnskillinfo.html";
             U.OpenURLOrFile(url);
         }
 

--- a/FEBuilderGBA/SkillAssignmentUnitCSkillSysForm.cs
+++ b/FEBuilderGBA/SkillAssignmentUnitCSkillSysForm.cs
@@ -455,7 +455,7 @@ namespace FEBuilderGBA
 
         private void X_LEARNINFO_Click(object sender, EventArgs e)
         {
-            string url = "https://dw.ngmansion.xyz/doku.php?id=en:guide_febuildergba_learnskillinfo";
+            string url = "https://laqieer.github.io/dw.ngmansion.xyz/wiki/en/guide_febuildergba_learnskillinfo.html";
             U.OpenURLOrFile(url);
         }
 

--- a/FEBuilderGBA/SkillAssignmentUnitSkillSystemForm.cs
+++ b/FEBuilderGBA/SkillAssignmentUnitSkillSystemForm.cs
@@ -696,7 +696,7 @@ namespace FEBuilderGBA
 
         private void X_LEARNINFO_Click(object sender, EventArgs e)
         {
-            string url = "https://dw.ngmansion.xyz/doku.php?id=en:guide_febuildergba_learnskillinfo";
+            string url = "https://laqieer.github.io/dw.ngmansion.xyz/wiki/en/guide_febuildergba_learnskillinfo.html";
             U.OpenURLOrFile(url);
         }
 

--- a/FEBuilderGBA/ToolWorkSupportForm.cs
+++ b/FEBuilderGBA/ToolWorkSupportForm.cs
@@ -159,11 +159,11 @@ namespace FEBuilderGBA
             string url;
             if (lang == "ja")
             {
-                url = "https://dw.ngmansion.xyz/doku.php?id=guide:febuildergba:%E4%BD%9C%E5%93%81%E6%94%AF%E6%8F%B4";
+                url = "https://laqieer.github.io/dw.ngmansion.xyz/wiki/guide/febuildergba/%E4%BD%9C%E5%93%81%E6%94%AF%E6%8F%B4.html";
             }
             else
             {
-                url = "https://dw.ngmansion.xyz/doku.php?id=en:guid:febuildergba:work_support";
+                url = "https://laqieer.github.io/dw.ngmansion.xyz/wiki/en/guid/febuildergba/work_support.html";
             }
             return url;
         }

--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ Much of this project's functions are thanks to the data collected by various com
 We would like to thank our hacking predecessors who have publicly shared any analyzed data.
 
 Details (There is a commentary at the bottom of the page, and the wiki provides other instructions)
-https://dw.ngmansion.xyz/doku.php?id=en:guide:febuildergba:index
+https://laqieer.github.io/dw.ngmansion.xyz/wiki/en/guide/febuildergba/index.html
 
 ### FE8 Skill Systems
 
@@ -588,7 +588,7 @@ C#でありますが、特にパフォーマンスに注意しているので、
 
 
 詳細 (ページ下部に解説集があるよ)
-https://dw.ngmansion.xyz/doku.php?id=guide:febuildergba:index
+https://laqieer.github.io/dw.ngmansion.xyz/wiki/guide/febuildergba/index.html
 
 一部の出来の悪いアンチウイルスソフトが、FEBuilderGBAをウイルスと誤認することがあるようです。
 これは、FEBuilderGBAがエミュレータと通信するためにWindowsDebugAPIを利用しているからだと思います。
@@ -640,7 +640,7 @@ FE_Builder_GBA
 
 
 详细信息（页面底部有评论）
-https://dw.ngmansion.xyz/doku.php?id=zh:guide:febuildergba:index
+https://laqieer.github.io/dw.ngmansion.xyz/wiki/zh/guide/febuildergba/index.html
 
 Some poorly designed anti-virus software may misidentify FEBuilderGBA as a virus.
 This is because FEBuilderGBA uses the WindowsDebugAPI to communicate with the emulator.

--- a/docs/UPDATE-GUIDE.md
+++ b/docs/UPDATE-GUIDE.md
@@ -242,7 +242,7 @@ cat config/patch2/version.txt
 
 - **Bug Reports:** [GitHub Issues](https://github.com/laqieer/FEBuilderGBA/issues)
 - **Community Support:** [Discord Server](https://discordapp.com/invite/Yzztqqa)
-- **Documentation:** [Wiki](https://dw.ngmansion.xyz/doku.php?id=en:guide:febuildergba:index)
+- **Documentation:** [Wiki](https://laqieer.github.io/dw.ngmansion.xyz/wiki/en/guide/febuildergba/index.html)
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #1780. The legacy DokuWiki host `https://dw.ngmansion.xyz/` was shut down, leaving every in-app help link and documentation reference pointing at a dead page. This migrates all **20 references** to the static mirror at `https://laqieer.github.io/dw.ngmansion.xyz/`.

## Transform (verified)

`https://dw.ngmansion.xyz/doku.php?id=a:b:c` → `https://laqieer.github.io/dw.ngmansion.xyz/wiki/a/b/c.html`
(DokuWiki id colons → path slashes; add `wiki/` prefix + `.html` suffix.)

The mirror mirrors DokuWiki ids **verbatim**, so URL-encoding and even the legacy `guid` typo are preserved — the "corrected" `.../guide/febuildergba/work_support.html` actually **404s**, while `.../guid/febuildergba/work_support.html` returns 200. I checked this rather than blindly normalizing.

## Files changed

- **In-app help links (functional):** 4 Avalonia SkillAssignment views, 4 WinForms SkillAssignment forms, `MapStyleEditorFormWarningVanillaTileOverraideForm.cs`, `ToolWorkSupportForm.cs`.
- **Code comments:** `FEBuilderGBA/ImageUtil.cs` (4 TSA-reference comments).
- **Docs:** `README.md` (en/ja/zh wiki links), `docs/UPDATE-GUIDE.md`.
- **New test:** `FEBuilderGBA.Core.Tests/DeadWikiLinkTests.cs` — regression guard.

## All 9 distinct targets verified `HTTP 200`

| Old `doku.php?id=` | New mirror path | Status |
|---|---|---|
| `en:guide_febuildergba_learnskillinfo` | `wiki/en/guide_febuildergba_learnskillinfo.html` | 200 |
| `column:tsa` | `wiki/column/tsa.html` | 200 |
| `guide:febuildergba:<JP タイルパレットの変更>` | `wiki/guide/febuildergba/%E3%82%BF…%E5%A4%89%E6%9B%B4.html` | 200 |
| `en:guide:febuildergba:how_to_change_tile_style_en` | `wiki/en/guide/febuildergba/how_to_change_tile_style_en.html` | 200 |
| `guide:febuildergba:<JP 作品支援>` | `wiki/guide/febuildergba/%E4%BD%9C%E5%93%81%E6%94%AF%E6%8F%B4.html` | 200 |
| `en:guid:febuildergba:work_support` (typo preserved) | `wiki/en/guid/febuildergba/work_support.html` | 200 |
| `en:guide:febuildergba:index` | `wiki/en/guide/febuildergba/index.html` | 200 |
| `guide:febuildergba:index` | `wiki/guide/febuildergba/index.html` | 200 |
| `zh:guide:febuildergba:index` | `wiki/zh/guide/febuildergba/index.html` | 200 |

## Test plan

- [x] `DeadWikiLinkTests.NoSourceFile_ReferencesDeadDokuWikiHost` passes (scans `.cs`/`.md`/`.axaml`, skipping build output + submodules) — `Passed! Failed: 0, Passed: 1`.
- [x] `0` remaining `dw.ngmansion.xyz/doku.php` references in the main source tree.
- [x] All 9 migrated targets return `HTTP 200` (table above).
- [x] Diff is exactly 20 line substitutions with no BOM/whitespace churn.

## GUI Test Report

This PR changes **string constants only** (help-link URLs) inside existing click handlers, plus one WinForms help-text field and code comments — there is **no visual or layout change** to any editor, so an app before/after screenshot would be pixel-identical and non-probative. Per `CLAUDE.md` Pre-Commit Checklist item 5, CLI/terminal output and test-run output are acceptable proof for non-visual changes; the functional proof is that every migrated destination now resolves:

| GUI surface (in-app help link) | Migrated target | Status |
|---|---|---|
| Skill Assignment editors — "Learn Info" (4 Avalonia views + 4 WinForms forms) | `wiki/en/guide_febuildergba_learnskillinfo.html` | ✅ 200 |
| Map Style vanilla-tile-override warning (WinForms) | `wiki/en/…/how_to_change_tile_style_en.html` + JP | ✅ 200 |
| Work Support tool (WinForms) | `wiki/en/guid/…/work_support.html` + JP | ✅ 200 |

All 9 distinct targets verified HTTP 200 (table above); the `DeadWikiLinkTests` guard passes (`Passed: 1`) and now walks the real source tree (asserts `scanned > 200`). No images are embedded because there is no visual delta.

---
Copilot CLI: 1.0.69-0
Model: Claude Opus 4.8 (claude-opus-4.8)
