### PR TITLE
feat(decomp): emit FE8J voicegroup named section + .align 4 (#1775)

### DIFF
--- a/FEBuilderGBA.Core.Tests/VoicegroupAsmExportCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/VoicegroupAsmExportCoreTests.cs
@@ -306,6 +306,25 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Contains("voicegroup003:", r.Text);
         }
 
+        // #1775: prove Export() forwards is_multibyte into the FE8J section directives.
+        [Fact]
+        public void Export_FE8J_RomInfoMultibyte_EmitsNamedSectionAndWordAlign()
+        {
+            var rom = new ROM();
+            rom.LoadLow("synth-fe8j.gba", new byte[0x0100_0000], "BE8J01");
+            Assert.True(rom.RomInfo != null && rom.RomInfo.is_multibyte);
+
+            uint a = 0x3000;
+            WriteDirectSound(rom, a, key: 60, panByte: 0, samplePtr: 0x08005000, adsr: new byte[] { 1, 2, 3, 4 });
+            WriteTerminator(rom, a + 12);
+
+            var r = VoicegroupAsmExportCore.Export(rom, a, 5);
+            Assert.True(r.Ok, string.Join("; ", r.Diagnostics));
+            Assert.Contains(".section .rodata.voicegroup005, \"a\", %progbits", r.Text);
+            Assert.Contains("\t.align 4\n", r.Text);
+            Assert.DoesNotContain("\t.section .rodata\n", r.Text); // not the generic fe8u section
+        }
+
         // ---- raw ROM writers ----------------------------------------------
 
         static void WriteBytes(ROM rom, uint addr, byte[] bytes)

--- a/FEBuilderGBA.Core.Tests/VoicegroupAsmExportCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/VoicegroupAsmExportCoreTests.cs
@@ -62,6 +62,46 @@ namespace FEBuilderGBA.Core.Tests
             Assert.DoesNotContain("0x08123456 @", s); // no inline comment after the arg
         }
 
+        // #1775: FE8J voicegroup section directives ---------------------------
+
+        [Fact]
+        public void Format_FE8J_Multibyte_EmitsNamedSectionAndWordAlign()
+        {
+            var v = Rec(0x01, VoicegroupAsmExportCore.VoiceKind.Square1);
+            string s = VoicegroupAsmExportCore.FormatVoicegroup(
+                new List<VoicegroupAsmExportCore.VoiceRecord> { v }, 0, 0x08207470, isMultibyte: true, out _);
+
+            // FE8J: named .rodata.voicegroupNNN sub-section with SHF_ALLOC + word align.
+            Assert.Contains(".section .rodata.voicegroup000, \"a\", %progbits", s);
+            Assert.Contains("\t.align 4\n", s);
+            Assert.Contains("voicegroup000:", s);
+            // Must NOT emit the generic fe8u directives.
+            Assert.DoesNotContain("\t.section .rodata\n", s);
+            Assert.DoesNotContain("\t.align 2\n", s);
+        }
+
+        [Fact]
+        public void Format_FE8U_Default_KeepsGenericSectionAndHalfwordAlign()
+        {
+            var v = Rec(0x01, VoicegroupAsmExportCore.VoiceKind.Square1);
+            string s = VoicegroupAsmExportCore.FormatVoicegroup(
+                new List<VoicegroupAsmExportCore.VoiceRecord> { v }, 43, 0x500, isMultibyte: false, out _);
+
+            Assert.Contains("\t.section .rodata\n", s);
+            Assert.Contains("\t.align 2\n", s);
+            Assert.DoesNotContain(".rodata.voicegroup", s);   // no FE8J named section
+        }
+
+        [Fact]
+        public void Format_FourArgOverload_DefaultsToFe8u()
+        {
+            var v = Rec(0x01, VoicegroupAsmExportCore.VoiceKind.Square1);
+            string s = VoicegroupAsmExportCore.FormatVoicegroup(
+                new List<VoicegroupAsmExportCore.VoiceRecord> { v }, 0, 0x500, out _);
+            Assert.Contains("\t.section .rodata\n", s);
+            Assert.DoesNotContain(".rodata.voicegroup", s);
+        }
+
         [Fact]
         public void Format_DirectSound_NoResample_And_Alt_UseCorrectMacroNames()
         {

--- a/FEBuilderGBA.Core/VoicegroupAsmExportCore.cs
+++ b/FEBuilderGBA.Core/VoicegroupAsmExportCore.cs
@@ -141,7 +141,7 @@ namespace FEBuilderGBA
 
                 result.VoiceCount = voices.Count;
                 List<string> diags;
-                result.Text = FormatVoicegroup(voices, voicegroupNumber, baseOffset, out diags);
+                result.Text = FormatVoicegroup(voices, voicegroupNumber, baseOffset, rom.RomInfo?.is_multibyte ?? false, out diags);
                 result.Diagnostics.AddRange(diags);
                 result.Ok = true;
                 return result;
@@ -191,6 +191,22 @@ namespace FEBuilderGBA
             int voicegroupNumber,
             uint provenanceBaseOffset,
             out List<string> diagnostics)
+            => FormatVoicegroup(voices, voicegroupNumber, provenanceBaseOffset, false, out diagnostics);
+
+        /// <summary>
+        /// #1775: region-aware overload. When <paramref name="isMultibyte"/> is true
+        /// (FE8J / JP decomp tree) the voicegroup is placed in its own named
+        /// <c>.rodata.voicegroupNNN, "a", %progbits</c> sub-section with word (<c>.align 4</c>)
+        /// alignment — matching the FE8J <c>ldscript.txt</c> placement and M4A's fixed-stride
+        /// voice lookup. When false (fe8u) it keeps the generic <c>.section .rodata</c> /
+        /// <c>.align 2</c> output (regression-safe). Still ROM-FREE.
+        /// </summary>
+        public static string FormatVoicegroup(
+            IReadOnlyList<VoiceRecord> voices,
+            int voicegroupNumber,
+            uint provenanceBaseOffset,
+            bool isMultibyte,
+            out List<string> diagnostics)
         {
             diagnostics = new List<string>();
             var sb = new StringBuilder();
@@ -200,8 +216,17 @@ namespace FEBuilderGBA
             sb.Append("@ Exported by FEBuilderGBA (#1362) -- review before building.\n");
             sb.Append("@ Source voicegroup ROM offset: 0x" + provenanceBaseOffset.ToString("X") + "\n");
             sb.Append(".include \"asm/macros/music_voice.inc\"\n\n");
-            sb.Append("\t.section .rodata\n");
-            sb.Append("\t.align 2\n");
+            if (isMultibyte)
+            {
+                // FE8J: named sub-section (SHF_ALLOC) + word alignment, per ldscript.txt.
+                sb.Append("\t.section .rodata." + label + ", \"a\", %progbits\n");
+                sb.Append("\t.align 4\n");
+            }
+            else
+            {
+                sb.Append("\t.section .rodata\n");
+                sb.Append("\t.align 2\n");
+            }
             sb.Append("\t.global " + label + "\n");
             sb.Append(label + ":\n");
 


### PR DESCRIPTION
## Summary

Closes #1775. `VoicegroupAsmExportCore.FormatVoicegroup` (the `--export-asset` voicegroup `.s` writer) hardcoded the **fe8u** section directives — a generic `.section .rodata` and `.align 2` — with no region branch. The **FE8J** (JP) decomp places each voicegroup in its **own named sub-section with SHF_ALLOC flags and word alignment**:

```
    .section .rodata.voicegroup000, "a", %progbits
    .align 4
```

A `.s` exported for FE8J with the generic `.section .rodata`/`.align 2` assembles but is **not placed at the linker-script-expected address**, breaking the voicegroup-table pointer, and the `.align 2` vs `.align 4` mismatch can misalign each voicegroup base and corrupt M4A's fixed-stride voice lookups.

## Fix

- Add a **region-aware overload** `FormatVoicegroup(..., bool isMultibyte, out diagnostics)` — still **ROM-FREE** (unit-tested with hand-built records). When `isMultibyte` is true it emits `\t.section .rodata.voicegroup{NNN}, "a", %progbits\n\t.align 4\n`; when false it keeps the exact fe8u output.
- The existing 4-arg overload delegates to it with `isMultibyte: false`, so all prior callers/tests are unchanged (regression-safe).
- `Export(ROM rom, …)` threads `rom.RomInfo?.is_multibyte ?? false` (null-safe — a synthetic ROM with no `RomInfo` defaults to fe8u).

## Test plan

- [x] `Format_FE8J_Multibyte_EmitsNamedSectionAndWordAlign` — asserts `.section .rodata.voicegroup000, "a", %progbits` + `\t.align 4\n` + `voicegroup000:`, and that the generic fe8u directives are absent.
- [x] `Format_FE8U_Default_KeepsGenericSectionAndHalfwordAlign` — fe8u unchanged (`.section .rodata` + `.align 2`, no named section).
- [x] `Format_FourArgOverload_DefaultsToFe8u` — backward-compat overload defaults to fe8u.
- [x] `Export_DoesNotMutateRom` and the full `VoicegroupAsmExportCoreTests` class stay green (`Passed: 19`).

Core-only change (no GUI); the section name matches the FE8J `ldscript.txt` `.rodata.voicegroupNNN` placement in the issue's evidence.

---
Copilot CLI: 1.0.69-0
Model: Claude Opus 4.8 (claude-opus-4.8)
