### PR TITLE
feat(decomp): export FE8J text to texts/jp_texts.txt (#1774)

### DIFF
--- a/FEBuilderGBA.Core.Tests/DecompAssetExportCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/DecompAssetExportCoreTests.cs
@@ -1671,6 +1671,40 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Contains("#define MSG_0x00FF 255", defs);
         }
 
+        // ---- FormatTextsJp (#1774, FE8J texts/jp_texts.txt format) ----
+
+        [Fact]
+        public void FormatTextsJp_SingleEntry_HashHexHeader_NoMsgPrefix()
+        {
+            var entries = new System.Collections.Generic.List<(uint, string)> { (1, "ＦＥ３ダミーＴＸＴ") };
+            string s = DecompAssetExportCore.FormatTextsJp(entries);
+
+            Assert.Equal("#0x0001\nＦＥ３ダミーＴＸＴ\n", s);
+            Assert.DoesNotContain("# msg", s);   // not the fe8u header
+            Assert.DoesNotContain("#define", s); // no textdefs macros
+        }
+
+        [Fact]
+        public void FormatTextsJp_MultipleEntries_NoBlankSeparator()
+        {
+            var entries = new System.Collections.Generic.List<(uint, string)>
+            {
+                (0, "A"),
+                (1, "B"),
+                (0xFF, "C"),
+            };
+            string s = DecompAssetExportCore.FormatTextsJp(entries);
+            // Header + text lines back-to-back, no blank separator between entries.
+            Assert.Equal("#0x0000\nA\n#0x0001\nB\n#0x00FF\nC\n", s);
+        }
+
+        [Fact]
+        public void FormatTextsJp_NullOrEmpty_ReturnsEmpty()
+        {
+            Assert.Equal("", DecompAssetExportCore.FormatTextsJp(null));
+            Assert.Equal("", DecompAssetExportCore.FormatTextsJp(new System.Collections.Generic.List<(uint, string)>()));
+        }
+
         // ---- ExportText ----
 
         [Fact]
@@ -1679,6 +1713,32 @@ namespace FEBuilderGBA.Core.Tests
             var result = DecompAssetExportCore.ExportText(null, "/tmp/textdir");
             Assert.False(result.Ok);
             Assert.Equal(DecompAssetStatus.BadArgs, result.Status);
+        }
+
+        [Fact]
+        public void ExportText_FE8J_WritesJpTextsTxt_NotTextsAndTextdefs()
+        {
+            var rom = new ROM();
+            rom.LoadLow("synth-fe8j.gba", new byte[0x0100_0000], "BE8J01");
+            Assert.True(rom.RomInfo != null && rom.RomInfo.is_multibyte);
+
+            string dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(),
+                "fe8j-text-" + System.Guid.NewGuid().ToString("N"));
+            try
+            {
+                var r = DecompAssetExportCore.ExportText(rom, dir);
+                Assert.True(r.Ok, r.Message);
+                // JP tree: texts/jp_texts.txt is written; the fe8u files are NOT.
+                Assert.Contains(r.WrittenPaths, p => p.Replace('\\', '/').EndsWith("texts/jp_texts.txt"));
+                Assert.True(System.IO.File.Exists(System.IO.Path.Combine(dir, "texts", "jp_texts.txt")));
+                Assert.False(System.IO.File.Exists(System.IO.Path.Combine(dir, "texts.txt")));
+                Assert.False(System.IO.File.Exists(System.IO.Path.Combine(dir, "textdefs.txt")));
+                Assert.Contains("jp_texts.txt", r.Message);
+            }
+            finally
+            {
+                if (System.IO.Directory.Exists(dir)) System.IO.Directory.Delete(dir, true);
+            }
         }
 
         // ---- ExportGraphics (null IImageService) ----

--- a/FEBuilderGBA.Core.Tests/DecompAssetExportCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/DecompAssetExportCoreTests.cs
@@ -1720,7 +1720,7 @@ namespace FEBuilderGBA.Core.Tests
         {
             var rom = new ROM();
             rom.LoadLow("synth-fe8j.gba", new byte[0x0100_0000], "BE8J01");
-            Assert.True(rom.RomInfo != null && rom.RomInfo.is_multibyte);
+            Assert.True(rom.RomInfo != null && rom.RomInfo.version == 8 && rom.RomInfo.is_multibyte);
 
             string dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(),
                 "fe8j-text-" + System.Guid.NewGuid().ToString("N"));

--- a/FEBuilderGBA.Core/DecompAssetExportCore.cs
+++ b/FEBuilderGBA.Core/DecompAssetExportCore.cs
@@ -1060,8 +1060,10 @@ namespace FEBuilderGBA
                 // texts.txt/textdefs.txt "# msg" migration format. jp_textdefs.txt
                 // (control-token table) and jp_huffman_tiebreaks.txt (ROM-derived) are
                 // hand/ROM-maintained and must NOT be overwritten by a text dump.
-                bool isJp = rom.RomInfo?.is_multibyte ?? false;
-                if (isJp)
+                // Gate on FE8J specifically (version 8 + multibyte): is_multibyte alone is
+                // also true for FE6J/FE7J, whose decomp trees use a different text format.
+                bool isFe8j = rom.RomInfo != null && rom.RomInfo.version == 8 && rom.RomInfo.is_multibyte;
+                if (isFe8j)
                 {
                     string textsDir = Path.Combine(absOutDir, "texts");
                     Directory.CreateDirectory(textsDir);
@@ -1351,8 +1353,8 @@ namespace FEBuilderGBA
             {
                 foreach (var (id, text) in entries)
                 {
-                    texts.Append("#0x" + id.ToString("X4") + "\n");
-                    texts.Append((text ?? "") + "\n");
+                    texts.Append("#0x").Append(id.ToString("X4")).Append('\n');
+                    texts.Append(text ?? "").Append('\n');
                 }
             }
             return texts.ToString();

--- a/FEBuilderGBA.Core/DecompAssetExportCore.cs
+++ b/FEBuilderGBA.Core/DecompAssetExportCore.cs
@@ -1053,9 +1053,32 @@ namespace FEBuilderGBA
                 if (entries == null)
                     entries = new List<(uint, string)>();
 
-                var (textsTxt, textdefsTxt) = FormatTexts(entries);
-
                 Directory.CreateDirectory(absOutDir);
+
+                // #1774: the FE8J (JP) decomp tree consumes text from texts/jp_texts.txt
+                // (header "#0xNNNN", no blank separator) via msg_jp.py — NOT the fe8u
+                // texts.txt/textdefs.txt "# msg" migration format. jp_textdefs.txt
+                // (control-token table) and jp_huffman_tiebreaks.txt (ROM-derived) are
+                // hand/ROM-maintained and must NOT be overwritten by a text dump.
+                bool isJp = rom.RomInfo?.is_multibyte ?? false;
+                if (isJp)
+                {
+                    string textsDir = Path.Combine(absOutDir, "texts");
+                    Directory.CreateDirectory(textsDir);
+                    string jpTextsPath = Path.Combine(textsDir, "jp_texts.txt");
+                    File.WriteAllText(jpTextsPath, FormatTextsJp(entries), new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+                    var jpResult = new DecompAssetResult
+                    {
+                        Status = DecompAssetStatus.Ok,
+                        Message = $"Exported {entries.Count} JP text entries to texts/jp_texts.txt " +
+                                  "(jp_textdefs.txt and jp_huffman_tiebreaks.txt are hand/ROM-maintained and were left untouched)"
+                    };
+                    jpResult.WrittenPaths.Add(jpTextsPath);
+                    return jpResult;
+                }
+
+                var (textsTxt, textdefsTxt) = FormatTexts(entries);
                 string textsPath = Path.Combine(absOutDir, "texts.txt");
                 string textdefsPath = Path.Combine(absOutDir, "textdefs.txt");
                 File.WriteAllText(textsPath, textsTxt, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
@@ -1312,6 +1335,27 @@ namespace FEBuilderGBA
             }
 
             return (texts.ToString(), defs.ToString());
+        }
+
+        /// <summary>
+        /// #1774: format text entries for the FE8J (JP) decomp tree's
+        /// <c>texts/jp_texts.txt</c>, which <c>msg_jp.py</c> consumes: a
+        /// <c>#0xNNNN</c> header line followed by the decoded text line, with NO
+        /// <c># msg</c> prefix and NO blank separator between entries. LF line
+        /// endings (decomp convention). ROM-free so it is unit-tested directly.
+        /// </summary>
+        internal static string FormatTextsJp(List<(uint textId, string text)> entries)
+        {
+            var texts = new StringBuilder();
+            if (entries != null)
+            {
+                foreach (var (id, text) in entries)
+                {
+                    texts.Append("#0x" + id.ToString("X4") + "\n");
+                    texts.Append((text ?? "") + "\n");
+                }
+            }
+            return texts.ToString();
         }
 
         // ---- Private helpers ----


### PR DESCRIPTION
## Summary

Closes #1774. `DecompAssetExportCore.ExportText` (the `--export-asset --kind=text` sink) unconditionally wrote **`texts.txt` + `textdefs.txt`** in the fe8u migration format (`# msg 0x%04X` headers + `#define MSG_*`) with **no `is_multibyte` branch**. The **FE8J** (JP) decomp tree instead consumes text from **`texts/jp_texts.txt`** (header `#0xNNNN`, no blank separator) via `msg_jp.py`, so on a JP ROM the exporter wrote the wrong filenames in a format the JP encoder cannot parse (→ `src/msg_data.c` never regenerated).

## Fix

- Add **`FormatTextsJp`** (ROM-free, unit-tested) emitting the FE8J format: `#0x{id:X4}\n{text}\n` per entry — **no** `# msg` prefix, **no** blank separator, LF endings.
- Branch `ExportText` on `rom.RomInfo?.is_multibyte`: when JP, write **`texts/jp_texts.txt`** and report it in `WrittenPaths`.
- **Do NOT emit or overwrite** `jp_textdefs.txt` (a hand-maintained control-token table) or `jp_huffman_tiebreaks.txt` (ROM-derived) — the result `Message` states they were left untouched. fe8u output is unchanged.

## Scope note

Acceptance criterion #3 (reflecting `jp_texts.txt` in the `--decomp-audit` coverage matrix / `DecompRoundTripAuditCore.cs:232`) is the dedicated subject of **#1776** (region-blind matrix) and is intentionally left to that PR to avoid overlapping edits. This PR is the exporter half (criteria 1, 2, 4).

## Test plan

- [x] `FormatTextsJp_SingleEntry_HashHexHeader_NoMsgPrefix` — exact `#0x0001\n<text>\n`; no `# msg`/`#define`.
- [x] `FormatTextsJp_MultipleEntries_NoBlankSeparator` — headers/text back-to-back, no blank line.
- [x] `FormatTextsJp_NullOrEmpty_ReturnsEmpty`.
- [x] `ExportText_FE8J_WritesJpTextsTxt_NotTextsAndTextdefs` — on a synthetic `BE8J01` (`is_multibyte`) ROM, `ExportText` writes `texts/jp_texts.txt` and does **not** create `texts.txt`/`textdefs.txt`; `Message` mentions `jp_texts.txt`.
- [x] `ExportText_NullRom_ReturnsBadArgs` and the fe8u `FormatTexts` tests stay green.

Core-only change (no GUI).

---
Copilot CLI: 1.0.69-0
Model: Claude Opus 4.8 (claude-opus-4.8)
