### PR TITLE
feat(decomp): resolve FE8J sym_jp.txt symbols (#1773)

### DIFF
--- a/FEBuilderGBA.Core.Tests/DecompMapFileTests.cs
+++ b/FEBuilderGBA.Core.Tests/DecompMapFileTests.cs
@@ -234,6 +234,65 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Empty(DecompSymParser.Parse("\x00\x01\xff garbage"));
         }
 
+        // #1773: FE8J sym_jp.txt linker-assignment form ("Name = 0x08XXXXXX;").
+
+        [Fact]
+        public void Sym_LinkerAssign_FE8J_ParsesNameEqualsHex()
+        {
+            string sym = string.Join("\n", new[]
+            {
+                "ColorFadeTick = 0x08000234;",
+                "ApplyColorAddition_ClampMax = 0x080014C4;",
+                "ProcCmd_DELETE = 0x08003A48;",
+            });
+
+            List<DecompSymbol> syms = DecompSymParser.Parse(sym);
+            var byName = syms.ToDictionary(s => s.Name, s => s.Addr);
+
+            Assert.Equal(0x08000234u, byName["ColorFadeTick"]);
+            Assert.Equal(0x080014C4u, byName["ApplyColorAddition_ClampMax"]);
+            Assert.Equal(0x08003A48u, byName["ProcCmd_DELETE"]);
+        }
+
+        [Fact]
+        public void Sym_LinkerAssign_TolerantOfCommentsWhitespaceAndSkipsNonSymbols()
+        {
+            string sym = string.Join("\n", new[]
+            {
+                "  spaced_symbol   =   0x08001000 ;",              // extra whitespace + space before ;
+                "commented = 0x08002000; /* trailing comment */",  // trailing block comment
+                "/* block */ inline_before = 0x08003000;",         // leading block comment
+                "valid_symbol = 0x08004000;",
+                ". = 0x08005000;",                                 // linker location counter -> skipped
+                "low_skipped = 0x00000050;",                       // addr <= 0x100 -> skipped
+            });
+
+            List<DecompSymbol> syms = DecompSymParser.Parse(sym);
+            var byName = syms.ToDictionary(s => s.Name, s => s.Addr);
+
+            Assert.Equal(0x08001000u, byName["spaced_symbol"]);
+            Assert.Equal(0x08002000u, byName["commented"]);
+            Assert.Equal(0x08003000u, byName["inline_before"]);
+            Assert.Equal(0x08004000u, byName["valid_symbol"]);
+            Assert.False(byName.ContainsKey("."));            // location counter is not a symbol
+            Assert.False(byName.ContainsKey("low_skipped"));  // addr <= 0x100
+            Assert.All(syms, s => Assert.InRange(s.Addr, 0x08000000u, 0x09FFFFFFu));
+        }
+
+        [Fact]
+        public void Sym_MixedLinkerAssignAndNoGba_BothParsed()
+        {
+            string sym = string.Join("\n", new[]
+            {
+                "0800D07C event_engine_main",   // no$gba form
+                "ColorFadeTick = 0x08000234;",  // linker-assign form
+            });
+            List<DecompSymbol> syms = DecompSymParser.Parse(sym);
+            var byName = syms.ToDictionary(s => s.Name, s => s.Addr);
+            Assert.Equal(0x0800D07Cu, byName["event_engine_main"]);
+            Assert.Equal(0x08000234u, byName["ColorFadeTick"]);
+        }
+
         [Fact]
         public void Json_ArrayForm_HexAndNumericAddr()
         {

--- a/FEBuilderGBA.Core.Tests/DecompMapFileTests.cs
+++ b/FEBuilderGBA.Core.Tests/DecompMapFileTests.cs
@@ -294,6 +294,18 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void Sym_LinkerAssign_MultiLineComment_DoesNotMergeLines()
+        {
+            // #1789: a /* ... */ comment spanning a newline with content after the closing
+            // */ must not merge the two logical lines (which would drop both symbols).
+            string sym = "foo = 0x08000010; /* uh\noh */ bar = 0x08000020;";
+            List<DecompSymbol> syms = DecompSymParser.Parse(sym);
+            var byName = syms.ToDictionary(s => s.Name, s => s.Addr);
+            Assert.Equal(0x08000010u, byName["foo"]);
+            Assert.Equal(0x08000020u, byName["bar"]);
+        }
+
+        [Fact]
         public void Json_ArrayForm_HexAndNumericAddr()
         {
             string json = @"[

--- a/FEBuilderGBA.Core.Tests/DecompSymbolResolverTests.cs
+++ b/FEBuilderGBA.Core.Tests/DecompSymbolResolverTests.cs
@@ -190,6 +190,40 @@ namespace FEBuilderGBA.Core.Tests
             finally { try { Directory.Delete(dir, true); } catch { } }
         }
 
+        // #1773: an FE8J project ships sym_jp.txt (linker-assign format), NOT a
+        // <stem>.sym — the resolver must auto-discover it and resolve its symbols.
+        [Fact]
+        public void SymJpTxt_AutoDiscovered_ForFE8JProject_ResolvesNames()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), $"decompsymjp_{Guid.NewGuid():N}");
+            Directory.CreateDirectory(dir);
+            try
+            {
+                // stem = "fireemblem8"; there is NO fireemblem8.sym, only sym_jp.txt.
+                File.WriteAllText(Path.Combine(dir, "fireemblem8.gba"), "x");
+                File.WriteAllText(Path.Combine(dir, "sym_jp.txt"), string.Join("\n", new[]
+                {
+                    "ApplyColorAddition_ClampMax = 0x080014C4;",
+                    "ProcCmd_DELETE = 0x08003A48;",
+                }));
+                var project = new DecompProject { ProjectRoot = dir, BuiltRomPath = Path.Combine(dir, "fireemblem8.gba") };
+                var resolver = DecompSymbolResolver.Load(project);
+
+                // sym_jp.txt was auto-discovered and its linker-assign lines parsed.
+                Assert.True(resolver.CountSym >= 2);
+                Assert.Contains(resolver.Symbols.Values, v => v.Name == "ApplyColorAddition_ClampMax");
+                Assert.Contains(resolver.Symbols.Values, v => v.Name == "ProcCmd_DELETE");
+
+                // Resolve-by-address through the merged view (acceptance #3).
+                var shipped = new AsmMapSymbolFile(new ROM());
+                shipped.LoadFromLines(MakeFe8uRom(), new string[0]);
+                var merged = new MergedAsmMapFile(shipped, resolver);
+                Assert.Equal("ApplyColorAddition_ClampMax", merged.GetName(0x080014C4u));
+                Assert.Equal("ProcCmd_DELETE", merged.GetName(0x08003A48u));
+            }
+            finally { try { Directory.Delete(dir, true); } catch { } }
+        }
+
         [Fact]
         public void Merged_Precedence_ProjectWinsAtSameAddr()
         {

--- a/FEBuilderGBA.Core/DecompMapFile.cs
+++ b/FEBuilderGBA.Core/DecompMapFile.cs
@@ -312,7 +312,15 @@ namespace FEBuilderGBA
                     return result;
 
                 // Strip /* ... */ block comments (sym_jp.txt annotates some assignments).
-                symText = BlockCommentRx.Replace(symText, " ");
+                // Preserve any newlines the comment spanned so two logical lines can't be
+                // merged (which would silently drop the symbols on the merged line, #1789).
+                symText = BlockCommentRx.Replace(symText, m =>
+                {
+                    int nl = 0;
+                    for (int i = 0; i < m.Value.Length; i++)
+                        if (m.Value[i] == '\n') nl++;
+                    return nl > 0 ? new string('\n', nl) : " ";
+                });
 
                 string[] lines = symText.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
                 var seen = new HashSet<uint>();

--- a/FEBuilderGBA.Core/DecompMapFile.cs
+++ b/FEBuilderGBA.Core/DecompMapFile.cs
@@ -281,12 +281,28 @@ namespace FEBuilderGBA
     }
 
     /// <summary>
-    /// Tolerant no$gba <c>.sym</c> parser: each line is <c>HEXADDR&lt;space&gt;name</c>
-    /// (mirrors <see cref="SymbolUtil"/>'s RegistSymbolByNoDoll split). Addresses
-    /// &lt;= 0x100 are skipped. NEVER throws.
+    /// Tolerant symbol-table parser. Handles BOTH:
+    /// <list type="bullet">
+    /// <item>no$gba <c>.sym</c>: <c>HEXADDR&lt;space&gt;name</c> (mirrors
+    /// <see cref="SymbolUtil"/>'s RegistSymbolByNoDoll split).</item>
+    /// <item>linker-assignment (#1773, FE8J <c>sym_jp.txt</c>):
+    /// <c>Name = 0x08XXXXXX;</c> — tolerant of a trailing <c>;</c> and
+    /// <c>/* … */</c> block comments.</item>
+    /// </list>
+    /// Format is auto-detected per line. Addresses &lt;= 0x100 are skipped. NEVER throws.
     /// </summary>
     public static class DecompSymParser
     {
+        // #1773: FE8J sym_jp.txt linker assignment, e.g. "ColorFadeTick = 0x08000234;".
+        // Name must start with a letter/underscore (so the linker location counter "."
+        // and no$gba "HEXADDR name" lines never match and fall through to the no$gba path).
+        static readonly Regex LinkerAssignRx = new Regex(
+            @"^\s*([A-Za-z_][A-Za-z0-9_.$]*)\s*=\s*0[xX]([0-9A-Fa-f]+)\s*;?\s*$",
+            RegexOptions.Compiled);
+
+        static readonly Regex BlockCommentRx = new Regex(@"/\*.*?\*/",
+            RegexOptions.Compiled | RegexOptions.Singleline);
+
         public static List<DecompSymbol> Parse(string symText)
         {
             var result = new List<DecompSymbol>();
@@ -295,6 +311,9 @@ namespace FEBuilderGBA
                 if (string.IsNullOrEmpty(symText))
                     return result;
 
+                // Strip /* ... */ block comments (sym_jp.txt annotates some assignments).
+                symText = BlockCommentRx.Replace(symText, " ");
+
                 string[] lines = symText.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
                 var seen = new HashSet<uint>();
                 foreach (string line in lines)
@@ -302,14 +321,28 @@ namespace FEBuilderGBA
                     if (line == null) continue;
                     string trimmed = line.Trim();
                     if (trimmed.Length == 0) continue;
-                    // no$gba line: "100109C MMBDrawInventoryObjs". Column-aligned dumps
-                    // use repeated spaces/tabs between addr and name, so split on any
-                    // run of whitespace and take the first two tokens (Copilot PR #1138).
-                    string[] sp = trimmed.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-                    if (sp.Length < 2) continue;
 
-                    uint addr = U.atoh(sp[0]);
-                    string name = sp[1];
+                    string name;
+                    uint addr;
+
+                    Match la = LinkerAssignRx.Match(trimmed);
+                    if (la.Success)
+                    {
+                        // FE8J sym_jp.txt: "Name = 0xADDR;"
+                        name = la.Groups[1].Value;
+                        addr = ParseHexU(la.Groups[2].Value);
+                    }
+                    else
+                    {
+                        // no$gba line: "100109C MMBDrawInventoryObjs". Column-aligned dumps
+                        // use repeated spaces/tabs between addr and name, so split on any
+                        // run of whitespace and take the first two tokens (Copilot PR #1138).
+                        string[] sp = trimmed.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                        if (sp.Length < 2) continue;
+                        addr = U.atoh(sp[0]);
+                        name = sp[1];
+                    }
+
                     if (string.IsNullOrEmpty(name)) continue;
                     if (name[0] == '$') continue;
                     if (addr <= 0x100) continue;
@@ -324,6 +357,16 @@ namespace FEBuilderGBA
                 return result;
             }
             return result;
+        }
+
+        // Parse a bare hex string (no 0x prefix) to u32; clamps a 64-bit value to low 32.
+        static uint ParseHexU(string hex)
+        {
+            if (uint.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out uint v))
+                return v;
+            if (ulong.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out ulong lv))
+                return unchecked((uint)lv);
+            return 0;
         }
     }
 

--- a/FEBuilderGBA.Core/DecompSymbolResolver.cs
+++ b/FEBuilderGBA.Core/DecompSymbolResolver.cs
@@ -116,7 +116,7 @@ namespace FEBuilderGBA
 
                 string mapPath  = DiscoverArtifact(project, root, stem, "map", project.MapPath, ".map");
                 string elfPath  = DiscoverArtifact(project, root, stem, "elf", project.ElfPath, ".elf");
-                string symPath  = DiscoverArtifact(project, root, stem, "sym", project.SymPath, ".sym");
+                string symPath  = DiscoverArtifact(project, root, stem, "sym", project.SymPath, ".sym", new[] { "sym_jp.txt" });
                 string jsonPath = DiscoverArtifact(project, root, stem, "symbolJson", null, ".sym.json");
 
                 // .map (primary)
@@ -183,7 +183,8 @@ namespace FEBuilderGBA
         // auto-discover <stem><ext> in root. project-relative + containment guarded.
         static string DiscoverArtifact(
             DecompProject project, string root, string stem,
-            string manifestKey, string topLevelValue, string ext)
+            string manifestKey, string topLevelValue, string ext,
+            string[] knownNames = null)
         {
             try
             {
@@ -202,11 +203,24 @@ namespace FEBuilderGBA
                     if (r != null) return r;
                 }
 
-                // 3. auto-discover <stem><ext> in the project root.
+                // 3. auto-discover <stem><ext> in the project root (must actually exist,
+                //    else fall through to the known-name fallbacks below).
                 if (!string.IsNullOrEmpty(stem))
                 {
                     string r = DecompProjectDetector.ResolveArtifact(root, stem + ext);
-                    if (r != null) return r;
+                    if (r != null && File.Exists(r)) return r;
+                }
+
+                // 4. well-known artifact filenames not derived from the built-ROM stem
+                //    (e.g. the FE8J JP symbol table sym_jp.txt, #1773).
+                if (knownNames != null)
+                {
+                    foreach (string kn in knownNames)
+                    {
+                        if (string.IsNullOrEmpty(kn)) continue;
+                        string r = DecompProjectDetector.ResolveArtifact(root, kn);
+                        if (r != null && File.Exists(r)) return r;
+                    }
                 }
             }
             catch { }


### PR DESCRIPTION
## Summary

Closes #1773. The decomp symbol resolver only understood the **no$gba `.sym`** format and only auto-discovered `<built-rom-stem>.sym` (e.g. `fireemblem8u.sym`). The FE8J tree ships its extra symbol table as **`sym_jp.txt`** in **linker-assignment** format (`Name = 0x08XXXXXX;`), so it was (a) never discovered (`fireemblem8.sym` doesn't exist in the JP tree) and (b) never parseable (`U.atoh("ColorFadeTick") = 0 → addr ≤ 0x100 → dropped`). ~1,557 map-absent JP function addresses (e.g. `ApplyColorAddition_ClampMax`, `ProcCmd_DELETE`) resolved to `???`.

## Fix

- **Parser** (`DecompSymParser.Parse`, `DecompMapFile.cs`): auto-detect the format **per line** — a linker-assignment line `Name = 0x08XXXXXX;` (tolerant of a trailing `;` and `/* … */` block comments) is parsed for name+addr; everything else falls back to the existing no$gba `HEXADDR name` split. The linker location counter `.` and `addr ≤ 0x100` are skipped. Names must start with a letter/underscore, so no$gba lines never mis-match the linker-assign regex.
- **Discovery** (`DiscoverArtifact`, `DecompSymbolResolver.cs`): add a known-names fallback (`sym_jp.txt`) **and** require the auto-discovered `<stem><ext>` file to actually **exist** before returning — previously step 3 returned a non-existent `<stem>.sym` path and short-circuited the fallback. (Existence-checking the auto-discovery steps is behaviour-neutral for map/elf/json, which `Load` already existence-checks.)

## Test plan

- [x] `Sym_LinkerAssign_FE8J_ParsesNameEqualsHex` — `ColorFadeTick`/`ApplyColorAddition_ClampMax`/`ProcCmd_DELETE` parse to their `0x08…` addresses.
- [x] `Sym_LinkerAssign_TolerantOfCommentsWhitespaceAndSkipsNonSymbols` — trailing/leading `/* … */`, extra whitespace, trailing `;`; skips the `.` location counter and `addr ≤ 0x100`; all results in `0x08000000–0x09FFFFFF`.
- [x] `Sym_MixedLinkerAssignAndNoGba_BothParsed` — a file mixing both forms parses both.
- [x] `SymJpTxt_AutoDiscovered_ForFE8JProject_ResolvesNames` — an FE8J project (no `<stem>.sym`, has `sym_jp.txt`) auto-discovers it; `CountSym ≥ 2` and the merged view resolves `0x080014C4 → ApplyColorAddition_ClampMax`, `0x08003A48 → ProcCmd_DELETE`.
- [x] Full `DecompSymbolResolverTests` + `DecompMapFileTests` green (24/24) — no no$gba/`.map`/`.elf`/JSON regression.

Core-only change (no GUI).

---
Copilot CLI: 1.0.69-0
Model: Claude Opus 4.8 (claude-opus-4.8)
