### PR TITLE
test(decomp): add FE8J decomp validation coverage (#1777)

### DIFF
--- a/FEBuilderGBA.Core.Tests/DecompBuildCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/DecompBuildCoreTests.cs
@@ -415,7 +415,7 @@ namespace FEBuilderGBA.Core.Tests
                 Assert.Equal("FE8J", project!.ForceVersion);
                 project.NeedsRebuild = true;
 
-                string seenForceVersion = null;
+                string? seenForceVersion = null;
                 var status = DecompBuildCore.ReloadBuiltRom(project, (p, fv) =>
                 {
                     seenForceVersion = fv;

--- a/FEBuilderGBA.Core.Tests/DecompBuildCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/DecompBuildCoreTests.cs
@@ -398,5 +398,34 @@ namespace FEBuilderGBA.Core.Tests
             }
             finally { Directory.Delete(dir, true); }
         }
+
+        [Fact]
+        public void ReloadBuiltRom_PassesForceVersionFE8J_ToLoadSeam()
+        {
+            // #1777: the JP (FE8J) manifest forceVersion must reach the reload seam so
+            // the Avalonia/CLI loaders pin the FE8J variant (parity with the FE8U test).
+            string dir = NewTempDir();
+            try
+            {
+                WriteManifest(dir,
+                    "{\"schemaVersion\":1,\"builtRom\":\"out.gba\",\"forceVersion\":\"FE8J\"}");
+                CopyTinyGba(dir); // create out.gba
+                var project = DecompProjectDetector.Detect(dir);
+                Assert.NotNull(project);
+                Assert.Equal("FE8J", project!.ForceVersion);
+                project.NeedsRebuild = true;
+
+                string seenForceVersion = null;
+                var status = DecompBuildCore.ReloadBuiltRom(project, (p, fv) =>
+                {
+                    seenForceVersion = fv;
+                    return true;
+                });
+
+                Assert.Equal(DecompResolveStatus.Ok, status);
+                Assert.Equal("FE8J", seenForceVersion);
+            }
+            finally { Directory.Delete(dir, true); }
+        }
     }
 }

--- a/FEBuilderGBA.E2ETests/Tests/DecompProjectOpenTests.cs
+++ b/FEBuilderGBA.E2ETests/Tests/DecompProjectOpenTests.cs
@@ -84,6 +84,32 @@ namespace FEBuilderGBA.E2ETests.Tests
         }
 
         [SkippableFact]
+        public void Project_FE8J_RomInfo_ReportsDecompModeAndFE8JVersion()
+        {
+            // #1777: exercise the decomp --project --rom-info path against a JP (FE8J) ROM
+            // wrapped in a synthetic decomp tree. Runs in e2e-fe8j.yml (which provides
+            // FE8J.gba), giving CI decomp coverage for the JP open/rom-info seam.
+            Skip.If(RomLocator.FE8J == null, "FE8J ROM not available");
+
+            string dir = MakeBuiltProject(RomLocator.FE8J!);
+            try
+            {
+                var (code, stdout, stderr) = RunWithRetry($"--project=\"{dir}\" --rom-info");
+
+                Assert.True(code == 0,
+                    $"--project --rom-info exited with {code}\nStdout: {stdout}\nStderr: {stderr}");
+                Assert.Contains("Mode: Decomp", stdout);
+                Assert.Contains("synth.gba", stdout);
+                // FE8J-specific: version 8 + multibyte → VersionToFilename "FE8J".
+                Assert.Contains("version=FE8J", stdout);
+            }
+            finally
+            {
+                try { Directory.Delete(dir, true); } catch { }
+            }
+        }
+
+        [SkippableFact]
         public void Project_Unbuilt_FailsWithRunTheBuildFirst()
         {
             // No ROM needed — the failure happens before any ROM load.


### PR DESCRIPTION
## Summary

Closes #1777. Nothing in CI or the test suite exercised the decomp CLI against a **JP** ROM, and `forceVersion:"FE8J"` was never threaded through a test — so every FE8J decomp fix (#1773/#1774/#1775/#1776/#1778) had no end-to-end gate. This adds the two acceptance tests the sibling issues cite.

## Tests added

- **`DecompProjectOpenTests.Project_FE8J_RomInfo_ReportsDecompModeAndFE8JVersion`** (E2E, `[SkippableFact]`): wraps the real **FE8J** ROM (`RomLocator.FE8J`) in a synthetic decomp tree (`MakeBuiltProject`) and asserts `FEBuilderGBA.CLI --project=<dir> --rom-info` reports `Mode: Decomp`, the preview ROM, and **`version=FE8J`** (FE8J = version 8 + multibyte → `VersionToFilename "FE8J"`). It runs inside **`e2e-fe8j.yml`** (which forwards `rom-name: FE8J` to `e2e-run.yml`, filtering `roms.zip` to keep `FE8J.gba`), so this is the **CI decomp validation** for the JP open/rom-info seam — Part 1 #1–#2.
- **`DecompBuildCoreTests.ReloadBuiltRom_PassesForceVersionFE8J_ToLoadSeam`** (unit): a manifest `forceVersion:"FE8J"` reaches the reload seam (parity with the existing FE8U test) — Part 2 #6.

## Scope note

`--build-project` against a *real* `fireemblem8j` tree with `make`/`make compare` (Part 1 #4) needs the actual JP decomp repo + a GBA toolchain in CI (a large infra lift) and is left as a documented follow-up. This PR delivers the reusable **open / `--rom-info` + `forceVersion` gates** the other FE8J issues reference.

## Test plan

- [x] `ReloadBuiltRom_PassesForceVersionFE8J_ToLoadSeam` — `Passed` (with the FE8U test, `Passed: 2`).
- [x] `Project_FE8J_RomInfo_ReportsDecompModeAndFE8JVersion` — ran locally with `ROMS_DIR` pointing at the FE8J ROM: **`Passed: 1`** (asserts `Mode: Decomp` + `version=FE8J`); skips cleanly when the ROM is absent.
- [x] Verified `e2e-fe8j.yml` → `e2e-run.yml` runs `FEBuilderGBA.E2ETests` with `FE8J.gba`, so the E2E test executes (not skipped) in CI.

Test-only change (no runtime code).

---
Copilot CLI: 1.0.69-0
Model: Claude Opus 4.8 (claude-opus-4.8)
