### PR TITLE
docs: declare the dual-GUI strategy (WinForms stable / Avalonia features) (#1800)

### DIFF
--- a/.github/ISSUE_TEMPLATE/gui_bug.yml
+++ b/.github/ISSUE_TEMPLATE/gui_bug.yml
@@ -5,6 +5,9 @@ body:
   - type: markdown
     attributes:
       value: "**One bug per issue.** Drag your screenshot straight onto the box below — do not link a Google Doc/Imgur. **Never attach your ROM (.gba).**"
+  - type: markdown
+    attributes:
+      value: "This form is for **bugs**. New **features** go to [Ideas Discussions](https://github.com/laqieer/FEBuilderGBA/discussions/categories/ideas), not here — and the **WinForms GUI is stable (bug fixes only)**, so new GUI features ship to the **Avalonia GUI**. See the [GUI Strategy](https://github.com/laqieer/FEBuilderGBA/blob/master/docs/GUI-STRATEGY.md)."
   - type: dropdown
     id: app
     attributes:

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -2,7 +2,7 @@
 
 - **Bug reports** — Use **Help → Report a Bug…** in the app (see the [Reporting Bugs guide](../docs/REPORTING-BUGS.md)), or [open a bug issue](https://github.com/laqieer/FEBuilderGBA/issues/new/choose) on GitHub.
 - **Usage questions** — Post in [Q&A Discussions](https://github.com/laqieer/FEBuilderGBA/discussions/categories/q-a).
-- **Feature requests** — Post in [Ideas Discussions](https://github.com/laqieer/FEBuilderGBA/discussions/categories/ideas).
+- **Feature requests** — Post in [Ideas Discussions](https://github.com/laqieer/FEBuilderGBA/discussions/categories/ideas). New GUI features target the cross-platform **Avalonia GUI**; the **WinForms GUI is stable (bug fixes only)** — see the [GUI Strategy](../docs/GUI-STRATEGY.md).
 - **Community chat** — Join the [FE hacking Discord](https://discordapp.com/invite/Yzztqqa).
 
 Please do **not** attach your ROM file (.gba) to any issue or discussion.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -82,9 +82,9 @@ FEBuilderGBA\bin\Release\FEBuilderGBA.exe --rom roms\FE8U.gba --lint
 ## High-level architecture
 
 - `FEBuilderGBA.Core` is the canonical shared domain layer. It contains ROM loading and version detection (`Rom.cs`, `ROMFE*.cs`), undo (`Undo.cs`), text encoding, event scripts, export/import, patch detection, lint scanning, rebuild logic, and platform abstraction points exposed through `CoreState`.
-- `FEBuilderGBA` is the WinForms host. `FEBuilderGBA\Program.cs` does early command-line detection so `--version` and other non-GUI flows can run before WinForms or GDI initialization.
+- `FEBuilderGBA` is the WinForms host. `FEBuilderGBA\Program.cs` does early command-line detection so `--version` and other non-GUI flows can run before WinForms or GDI initialization. **The WinForms GUI is in stable mode: bug fixes only — do NOT add new features here** (see [docs/GUI-STRATEGY.md](../docs/GUI-STRATEGY.md)).
 - `FEBuilderGBA.CLI` is a separate cross-platform host. Its `Program.cs` sets `CoreState.Services` to headless services, sets `CoreState.ImageService` to the SkiaSharp implementation, and routes the CLI commands.
-- `FEBuilderGBA.Avalonia` is the newer cross-platform GUI. It reuses `FEBuilderGBA.Core` and adds its own lightweight editor auto-binding via `FEBuilderGBA.Core\EditorFormRef.cs`.
+- `FEBuilderGBA.Avalonia` is the newer cross-platform GUI. It reuses `FEBuilderGBA.Core` and adds its own lightweight editor auto-binding via `FEBuilderGBA.Core\EditorFormRef.cs`. **The Avalonia GUI is in preview and is where all new GUI features ship** (`FEBuilderGBA.Core`/`FEBuilderGBA.CLI` are shared and not restricted by this policy).
 - `FEBuilderGBA.SkiaSharp` supplies the image service implementation used by CLI and Avalonia code paths.
 - `FEBuilderGBA.Tests`, `FEBuilderGBA.Core.Tests`, and `FEBuilderGBA.E2ETests` split coverage across Windows-host behavior, pure Core behavior, and black-box executable behavior.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -563,8 +563,8 @@ Avalonia portrait import supports FE-Repo Standard Hackboxes (128×112) and FE8 
 
 ### Adding Form/Feature
 > **GUI policy:** new **features** target the **Avalonia GUI** (`FEBuilderGBA.Avalonia`).
-> The WinForms GUI is in **stable mode — bug fixes only**; add a WinForms form only
-> when fixing a bug or porting existing behaviour, never for a new feature. See
+> The WinForms GUI is in **stable mode — bug fixes only**; touch a WinForms form only
+> to fix a bug/regression, never to add a new feature. See
 > [docs/GUI-STRATEGY.md](docs/GUI-STRATEGY.md).
 1. Create Form class (inherit from `Form`)
 2. Use Designer for UI layout

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -562,6 +562,10 @@ The FE-Repo submodule (`resources/FE-Repo/`) contains public GBA Fire Emblem gra
 Avalonia portrait import supports FE-Repo Standard Hackboxes (128×112) and FE8 HALFBODY Halfbody Hackboxes (160×160, requires the HALFBODY portrait-extension patch). Twoparter Hackboxes (144×304) are intentionally rejected until a verified PART1/PART2 slicing layout exists.
 
 ### Adding Form/Feature
+> **GUI policy:** new **features** target the **Avalonia GUI** (`FEBuilderGBA.Avalonia`).
+> The WinForms GUI is in **stable mode — bug fixes only**; add a WinForms form only
+> when fixing a bug or porting existing behaviour, never for a new feature. See
+> [docs/GUI-STRATEGY.md](docs/GUI-STRATEGY.md).
 1. Create Form class (inherit from `Form`)
 2. Use Designer for UI layout
 3. Call `InputFormRef.MakeLinkEvent(this)` in constructor

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,19 @@ Every PR reviewer (human or automated) should verify:
 3. For large doc restructuring, open a dedicated docs PR
 4. For wiki updates, edit via the web UI or clone and push
 
+## GUI Strategy & Feature Policy
+
+FEBuilderGBA has **two GUIs held to different standards** (full policy:
+[docs/GUI-STRATEGY.md](docs/GUI-STRATEGY.md)):
+
+- **WinForms GUI (`FEBuilderGBA`)** — stable and widely used → **bug fixes only, no new features.**
+- **Avalonia GUI (`FEBuilderGBA.Avalonia`)** — cross-platform **preview** → **all new GUI features ship here.**
+
+So: build/propose a **new GUI feature against Avalonia**; a WinForms change is in
+scope only when it fixes a bug/regression. `FEBuilderGBA.Core` / `FEBuilderGBA.CLI`
+are shared and cross-platform and are **not** restricted by this policy. Reviewers
+should reject or redirect new-feature PRs that target the WinForms GUI.
+
 ## Code Contribution Guidelines
 
 See [DEVELOPMENT-WORKFLOW.md](DEVELOPMENT-WORKFLOW.md) for the mandatory development workflow including plan review, implementation, and PR review gates.

--- a/DEVELOPMENT-WORKFLOW.md
+++ b/DEVELOPMENT-WORKFLOW.md
@@ -212,6 +212,7 @@ Never work directly on master — always create a feature branch.
 **Scope discipline:**
 - Follow the accepted plan exactly
 - No bonus refactoring, no extra features, no "while I'm here" changes
+- **New GUI features target the Avalonia GUI (`FEBuilderGBA.Avalonia`).** The WinForms GUI (`FEBuilderGBA`) is in stable mode — bug fixes only; do not implement or accept new features there (see [docs/GUI-STRATEGY.md](docs/GUI-STRATEGY.md)). Core/CLI are shared and unaffected.
 - If you discover something that needs fixing, file a new issue — don't scope-creep
 
 **Test requirements:**

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ README
 | Project | Target | Description |
 |---------|--------|-------------|
 | `FEBuilderGBA.Core` | net9.0 | Cross-platform core library: ROM manipulation, undo, LZ77, Huffman/text encoding, patch detection, translation, caching, git/archive, event ASM/disassembler, struct export, and ~100 other per-class seams. See [docs/CORE-SEAMS.md](docs/CORE-SEAMS.md) for the full catalog. |
-| `FEBuilderGBA` | net9.0-windows | WinForms GUI application |
+| `FEBuilderGBA` | net9.0-windows | WinForms GUI application — **stable; bug fixes only** (see [GUI strategy](docs/GUI-STRATEGY.md)) |
 | `FEBuilderGBA.CLI` | net9.0 | Cross-platform command-line tool (67 commands<sup>[†](#cli-command-count)</sup> — UPS/patch, lint, rebuild, disasm, translate, struct/data export-import, portrait/MIDI/battle-anime/palette, decomp project mode, and more). Full reference: [docs/cli-reference.md](docs/cli-reference.md) · arg table: [docs/cli-args.md](docs/cli-args.md). |
 | `FEBuilderGBA.SkiaSharp` | net9.0 | SkiaSharp `IImageService` (GBA 4bpp/8bpp tiles, palette conversion) + `SkiaFontRasterizer` (cross-platform GDI-parity glyph rendering for translation-font auto-generation). |
 | `FEBuilderGBA.Avalonia` | net9.0 | Cross-platform Avalonia GUI: 324 editors (unit/item/class/map/event/AI/text/audio/graphics/portrait/world-map/support/arena/monster/summon/menu/credits) with read/write + undo, image PNG import, hex editor, pointer/free-space tools, cross-editor jump/pick navigation, and decomp-project mode. Full editor inventory: [docs/avalonia-forms.md](docs/avalonia-forms.md) · gap analysis: [docs/avalonia-gap-analysis.md](docs/avalonia-gap-analysis.md). |
@@ -34,6 +34,14 @@ README
 | `FEBuilderGBA.E2ETests` | net9.0-windows | End-to-end GUI/CLI tests |
 
 <a id="cli-command-count">†</a> **CLI command count = 67**: distinct top-level command branches in the `FEBuilderGBA.CLI/Program.cs` dispatch table, collapsing the two documented aliases (`--help`/`-h`, `--test`/`--testonly`); `--project` and `--resolve-addr` are counted as separate user-facing commands. The canonical full list is [docs/cli-reference.md](docs/cli-reference.md).
+
+> **🧭 GUI strategy — two front-ends, two standards.** The **WinForms GUI**
+> (`FEBuilderGBA`) is the mature, widely-used desktop app; its goal is
+> **stability**, so it accepts **bug fixes only — no new features**. The
+> **Avalonia GUI** (`FEBuilderGBA.Avalonia`) is a cross-platform **preview**,
+> so **all new GUI features ship there**. `FEBuilderGBA.Core` / `FEBuilderGBA.CLI`
+> are shared and cross-platform and are **not** restricted by this policy. See
+> **[docs/GUI-STRATEGY.md](docs/GUI-STRATEGY.md)**.
 
 ### Cloning the Repository
 

--- a/docs/GUI-STRATEGY.md
+++ b/docs/GUI-STRATEGY.md
@@ -47,8 +47,8 @@ When triaging an issue or scoping a PR:
 2. **Is it a WinForms bug/regression?** → fixing it is in scope.
 3. **Is it Core/CLI/SkiaSharp?** → not covered by this policy; scope normally.
 
-This policy is also recorded in
+This policy is also recorded across the repository's contributor docs:
 [`README.md`](../README.md), [`CONTRIBUTING.md`](../CONTRIBUTING.md),
 [`DEVELOPMENT-WORKFLOW.md`](../DEVELOPMENT-WORKFLOW.md),
-[`.github/SUPPORT.md`](../.github/SUPPORT.md), `CLAUDE.md`,
-`.github/copilot-instructions.md`, and the project wiki.
+[`.github/SUPPORT.md`](../.github/SUPPORT.md), `CLAUDE.md`, and
+`.github/copilot-instructions.md`.

--- a/docs/GUI-STRATEGY.md
+++ b/docs/GUI-STRATEGY.md
@@ -1,0 +1,54 @@
+# GUI Strategy
+
+FEBuilderGBA ships **two** graphical front-ends over the same shared engine
+(`FEBuilderGBA.Core` + `FEBuilderGBA.CLI` + `FEBuilderGBA.SkiaSharp`). They are
+held to **different standards** on purpose.
+
+## Policy
+
+| GUI | Project | Status | What it accepts |
+|-----|---------|--------|-----------------|
+| **WinForms GUI** | `FEBuilderGBA` (`net9.0-windows`) | **Stable** — used widely for years | **Bug fixes only. No new features.** |
+| **Avalonia GUI** | `FEBuilderGBA.Avalonia` (`net9.0`, cross-platform) | **Preview** — not yet widely relied upon | **All new GUI features ship here.** Bug fixes too. |
+
+## Why
+
+- **WinForms is the production workhorse.** A huge existing user base depends on
+  it every day, and its behaviour is deeply name-driven (designer control names
+  wire editor logic via `InputFormRef.MakeLinkEvent`), which makes changes
+  disproportionately regression-prone. Its goal is therefore **stability**: we
+  change it only to fix bugs, never to add features.
+- **Avalonia is still in preview.** It is cross-platform (Windows/Linux/macOS,
+  plus an Android head) and not yet the primary tool for most users, so a
+  regression there has a **limited blast radius**. That makes it the right place
+  to build and iterate on **new features**.
+
+## What this means in practice
+
+- **A new feature request → the Avalonia GUI.** Implement it in
+  `FEBuilderGBA.Avalonia` (backed by `FEBuilderGBA.Core` where logic is shared).
+  Do **not** add it to the WinForms GUI.
+- **A WinForms issue is actioned only when it is a bug/regression** — restoring
+  or correcting existing behaviour. Feature requests targeting WinForms are
+  declined (redirect the requester to the Avalonia GUI and/or
+  [Ideas Discussions](https://github.com/laqieer/FEBuilderGBA/discussions/categories/ideas)).
+- **Core / CLI are not restricted by this policy.** `FEBuilderGBA.Core`,
+  `FEBuilderGBA.CLI`, and `FEBuilderGBA.SkiaSharp` are shared, cross-platform,
+  and back *both* GUIs — they continue to accept new capabilities. This policy
+  is specifically about **GUI feature work**, i.e. new editors/screens/UI
+  behaviour, which belongs in Avalonia.
+
+## For reviewers & AI agents
+
+When triaging an issue or scoping a PR:
+
+1. **Is it a new GUI feature?** → target `FEBuilderGBA.Avalonia`. Reject/redirect
+   if it proposes adding the feature to `FEBuilderGBA` (WinForms).
+2. **Is it a WinForms bug/regression?** → fixing it is in scope.
+3. **Is it Core/CLI/SkiaSharp?** → not covered by this policy; scope normally.
+
+This policy is also recorded in
+[`README.md`](../README.md), [`CONTRIBUTING.md`](../CONTRIBUTING.md),
+[`DEVELOPMENT-WORKFLOW.md`](../DEVELOPMENT-WORKFLOW.md),
+[`.github/SUPPORT.md`](../.github/SUPPORT.md), `CLAUDE.md`,
+`.github/copilot-instructions.md`, and the project wiki.

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ overview and quick start; the documents below go into depth on specific areas.
 | Doc | What it covers |
 |-----|----------------|
 | [CORE-SEAMS.md](CORE-SEAMS.md) | Full per-class catalog of the cross-platform `FEBuilderGBA.Core` seams (one paragraph each). |
+| [GUI-STRATEGY.md](GUI-STRATEGY.md) | **Dual-GUI policy** — WinForms (`FEBuilderGBA`) is stable/bug-fixes-only; the Avalonia GUI (`FEBuilderGBA.Avalonia`) is preview and receives all new GUI features. |
 | [ENGINEERING-NOTES.md](ENGINEERING-NOTES.md) | Cross-cutting engineering gotchas, recurring failure modes, working conventions (the "why"), and campaign history. |
 | [avalonia-forms.md](avalonia-forms.md) | Avalonia editor/form inventory. |
 | [avalonia-gui-forms.md](avalonia-gui-forms.md) | Avalonia GUI form mapping details. |


### PR DESCRIPTION
## Summary
Declares the project's **dual-GUI strategy** (owner directive) across every contributor / user / AI-agent surface.

- **WinForms GUI (`FEBuilderGBA`)** — widely used for years → **stability first: bug fixes only, no new features.**
- **Avalonia GUI (`FEBuilderGBA.Avalonia`)** — cross-platform **preview**, limited blast radius → **all new GUI features ship there.**
- **`FEBuilderGBA.Core` / `FEBuilderGBA.CLI`** are shared/cross-platform and **not** restricted by this policy (they back both GUIs).

Closes #1800.

## Changes (docs-only, 9 files)
| File | What |
|---|---|
| `docs/GUI-STRATEGY.md` | **New canonical policy doc** (table + rationale + triage rules for reviewers/agents) |
| `README.md` | WinForms table row tagged "stable; bug fixes only" + a GUI-strategy callout |
| `docs/README.md` | index row for the new doc |
| `CONTRIBUTING.md` | new "GUI Strategy & Feature Policy" section |
| `DEVELOPMENT-WORKFLOW.md` | scope-discipline bullet |
| `.github/SUPPORT.md` | feature-request routing note |
| `.github/ISSUE_TEMPLATE/gui_bug.yml` | note by the **App** dropdown (features → Ideas/Avalonia) |
| `CLAUDE.md` | caveat on the WinForms-specific "Adding Form/Feature" section |
| `.github/copilot-instructions.md` | policy under High-level architecture (so AI agents triage correctly) |

## Review gate
Cross-model board (claude-sonnet-5 / gpt-5.5 / gemini-3.5-flash) reviewed the plan: tightened wording to **"new GUI features"** (Core/CLI unaffected) and added the CLAUDE.md / copilot-instructions.md / DEVELOPMENT-WORKFLOW.md / SUPPORT.md surfaces per their feedback. The wiki `Home.md` "request features" line + an Announcements discussion are handled **post-merge** (out-of-repo).

## Test plan
- [x] `gui_bug.yml` + `config.yml` validate as YAML (`yaml.safe_load` OK)
- [x] `CLAUDE.md` stays under the ~40 000-char harness truncation limit (28 599 bytes)
- [x] All new relative doc links resolve (`docs/GUI-STRATEGY.md` ↔ README/CONTRIBUTING/etc.)
- [x] Docs-only — no code/behaviour change, no build/test impact; `docs/README.md` index kept complete (ENGINEERING-NOTES row preserved)

---
Copilot CLI: 1.0.69-0
Model: Claude Opus 4.8 (claude-opus-4.8)