### PR TITLE
fix(avalonia,cli): persist Options settings on a fresh install (#1799)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/OptionsConfigPersistenceTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/OptionsConfigPersistenceTests.cs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1799: on a fresh install (no config/config.xml yet) CoreState.Config was left
+// null by a File.Exists guard in App.axaml.cs / RomLoader.cs, so OptionsViewModel
+// .Save() silently discarded every setting (tool paths, theme, submodule URLs).
+// With Config.LoadOrCreate wired into startup, a first-run Options save must now
+// persist and a fresh reopen must read the values back. This test reproduces the
+// exact user scenario (@Chrixcalibur) end-to-end through the real ViewModel.
+using System;
+using System.IO;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+[Collection("SharedState")]
+public class OptionsConfigPersistenceTests : IDisposable
+{
+    readonly Config? _savedConfig;
+    readonly string? _savedBaseDir;
+    readonly string? _savedLanguage;
+    readonly string _baseDir;
+
+    public OptionsConfigPersistenceTests()
+    {
+        _savedConfig = CoreState.Config;
+        _savedBaseDir = CoreState.BaseDirectory;
+        _savedLanguage = CoreState.Language;
+
+        // Isolated temp base dir OUTSIDE the repo (and not a git repo) so Save()'s
+        // ApplySubmoduleRemotes() cannot touch the real config/patch2 submodule.
+        _baseDir = Path.Combine(Path.GetTempPath(), $"opt_persist_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(_baseDir, "config"));
+        CoreState.BaseDirectory = _baseDir;
+    }
+
+    public void Dispose()
+    {
+        CoreState.Config = _savedConfig;
+        CoreState.BaseDirectory = _savedBaseDir;
+        CoreState.Language = _savedLanguage;
+        try { if (Directory.Exists(_baseDir)) Directory.Delete(_baseDir, true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void FreshInstall_OptionsSave_PersistsToolPaths_AcrossReopen()
+    {
+        string configPath = Path.Combine(_baseDir, "config", "config.xml");
+        Assert.False(File.Exists(configPath)); // fresh install: no prefs file yet
+
+        // Startup wiring (mirrors the fixed App.axaml.cs / RomLoader.cs).
+        CoreState.Config = Config.LoadOrCreate(configPath);
+        Assert.NotNull(CoreState.Config);
+
+        // User browses for tools and presses OK.
+        var vm = new OptionsViewModel();
+        vm.Load();
+        vm.Emulator = @"C:\emu\vba.exe";
+        vm.Sappy = @"C:\tools\sappy.exe";
+        vm.EventAssembler = @"C:\ea\ColorzCore.dll";
+        vm.Save();
+
+        Assert.True(File.Exists(configPath)); // config.xml created on the first save
+
+        // Reopen Options: a fresh VM over a freshly-loaded config must read them back.
+        CoreState.Config = Config.LoadOrCreate(configPath);
+        var vm2 = new OptionsViewModel();
+        vm2.Load();
+        Assert.Equal(@"C:\emu\vba.exe", vm2.Emulator);
+        Assert.Equal(@"C:\tools\sappy.exe", vm2.Sappy);
+        Assert.Equal(@"C:\ea\ColorzCore.dll", vm2.EventAssembler);
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/OptionsConfigPersistenceTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/OptionsConfigPersistenceTests.cs
@@ -42,6 +42,11 @@ public class OptionsConfigPersistenceTests : IDisposable
         CoreState.BaseDirectory = _savedBaseDir;
         CoreState.Language = _savedLanguage;
         CoreState.GitPath = _savedGitPath;
+        // OptionsViewModel.Save() reloads the *global* MyTranslateResource for the temp
+        // BaseDirectory (clearing it here). Restore it for the saved language/base dir so
+        // it doesn't leak into other [Collection("SharedState")] tests (matches the L10n
+        // restore convention). Best-effort; never fail Dispose over it.
+        try { OptionsViewModel.ReloadTranslations(); } catch { /* best effort */ }
         try { if (Directory.Exists(_baseDir)) Directory.Delete(_baseDir, true); } catch { /* best effort */ }
     }
 

--- a/FEBuilderGBA.Avalonia.Tests/OptionsConfigPersistenceTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/OptionsConfigPersistenceTests.cs
@@ -19,6 +19,7 @@ public class OptionsConfigPersistenceTests : IDisposable
     readonly Config? _savedConfig;
     readonly string? _savedBaseDir;
     readonly string? _savedLanguage;
+    readonly string _savedGitPath;
     readonly string _baseDir;
 
     public OptionsConfigPersistenceTests()
@@ -26,6 +27,7 @@ public class OptionsConfigPersistenceTests : IDisposable
         _savedConfig = CoreState.Config;
         _savedBaseDir = CoreState.BaseDirectory;
         _savedLanguage = CoreState.Language;
+        _savedGitPath = CoreState.GitPath;
 
         // Isolated temp base dir OUTSIDE the repo (and not a git repo) so Save()'s
         // ApplySubmoduleRemotes() cannot touch the real config/patch2 submodule.
@@ -39,6 +41,7 @@ public class OptionsConfigPersistenceTests : IDisposable
         CoreState.Config = _savedConfig;
         CoreState.BaseDirectory = _savedBaseDir;
         CoreState.Language = _savedLanguage;
+        CoreState.GitPath = _savedGitPath;
         try { if (Directory.Exists(_baseDir)) Directory.Delete(_baseDir, true); } catch { /* best effort */ }
     }
 

--- a/FEBuilderGBA.Avalonia.Tests/OptionsConfigPersistenceTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/OptionsConfigPersistenceTests.cs
@@ -42,11 +42,6 @@ public class OptionsConfigPersistenceTests : IDisposable
         CoreState.BaseDirectory = _savedBaseDir;
         CoreState.Language = _savedLanguage;
         CoreState.GitPath = _savedGitPath;
-        // OptionsViewModel.Save() reloads the *global* MyTranslateResource for the temp
-        // BaseDirectory (clearing it here). Restore it for the saved language/base dir so
-        // it doesn't leak into other [Collection("SharedState")] tests (matches the L10n
-        // restore convention). Best-effort; never fail Dispose over it.
-        try { OptionsViewModel.ReloadTranslations(); } catch { /* best effort */ }
         try { if (Directory.Exists(_baseDir)) Directory.Delete(_baseDir, true); } catch { /* best effort */ }
     }
 

--- a/FEBuilderGBA.Avalonia/App.axaml.cs
+++ b/FEBuilderGBA.Avalonia/App.axaml.cs
@@ -217,13 +217,12 @@ namespace FEBuilderGBA.Avalonia
 
             // Load config
             // #1124: baseDir is the exe dir on desktop and Context.FilesDir (app-private) on Android (#1123), so config.xml is already redirected to app-private storage on Android.
+            // #1799: always create the Config (even when config.xml doesn't exist yet on a
+            // fresh install) so CoreState.Config is never null and the Options dialog can
+            // persist settings. Previously the File.Exists guard left it null on first run,
+            // silently discarding tool paths, theme, recent files, etc.
             string configPath = Path.Combine(baseDir, "config", "config.xml");
-            if (File.Exists(configPath))
-            {
-                var config = new Config();
-                config.Load(configPath);
-                CoreState.Config = config;
-            }
+            CoreState.Config = Config.LoadOrCreate(configPath);
 
             // Initialize language from config (backward-compatible: try "Language", then "func_lang")
             if (CoreState.Config != null)

--- a/FEBuilderGBA.CLI/RomLoader.cs
+++ b/FEBuilderGBA.CLI/RomLoader.cs
@@ -24,13 +24,11 @@ namespace FEBuilderGBA.CLI
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 
             // Load config
+            // #1799: always create the Config so CoreState.Config is never null on a
+            // fresh install (shared with the Avalonia GUI via Config.LoadOrCreate) —
+            // otherwise config writers like --lastrom persistence silently no-op.
             string configPath = Path.Combine(baseDir, "config", "config.xml");
-            if (File.Exists(configPath))
-            {
-                var config = new Config();
-                config.Load(configPath);
-                CoreState.Config = config;
-            }
+            CoreState.Config = Config.LoadOrCreate(configPath);
         }
 
         /// <summary>

--- a/FEBuilderGBA.Core.Tests/ConfigLoadOrCreateTests.cs
+++ b/FEBuilderGBA.Core.Tests/ConfigLoadOrCreateTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    /// <summary>
+    /// #1799: <see cref="Config.LoadOrCreate(string)"/> must yield a usable, persistable
+    /// <see cref="Config"/> even when the file does not exist yet (fresh install), so
+    /// <c>CoreState.Config</c> is never null and the Options dialog can save. Previously
+    /// App.axaml.cs / RomLoader.cs guarded the assignment behind <c>File.Exists</c>, leaving
+    /// <c>CoreState.Config</c> null on first run and silently discarding all settings.
+    /// </summary>
+    public class ConfigLoadOrCreateTests : IDisposable
+    {
+        readonly string _dir;
+        readonly string _configPath;
+
+        public ConfigLoadOrCreateTests()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), $"cfg_loadorcreate_{Guid.NewGuid():N}");
+            _configPath = Path.Combine(_dir, "config", "config.xml");
+        }
+
+        public void Dispose()
+        {
+            try { if (Directory.Exists(_dir)) Directory.Delete(_dir, true); } catch { /* best effort */ }
+        }
+
+        [Fact]
+        public void LoadOrCreate_MissingFile_ReturnsUsableConfig_AndCreatesDirectory()
+        {
+            Assert.False(File.Exists(_configPath));
+            Assert.False(Directory.Exists(Path.GetDirectoryName(_configPath)!));
+
+            var cfg = Config.LoadOrCreate(_configPath);
+
+            Assert.NotNull(cfg);                                              // never null on a fresh install
+            Assert.Equal(_configPath, cfg.ConfigFilename);                   // Save() has a concrete target
+            Assert.True(Directory.Exists(Path.GetDirectoryName(_configPath)!)); // parent dir ensured
+            Assert.Equal("", cfg.at("emulator", ""));                        // empty, not crashed
+        }
+
+        [Fact]
+        public void LoadOrCreate_SaveThenReload_RoundTripsToolPaths()
+        {
+            var cfg = Config.LoadOrCreate(_configPath);
+            cfg["emulator"] = @"C:\tools\vba.exe";
+            cfg["sappy"] = @"C:\tools\sappy.exe";
+            cfg.Save();
+
+            Assert.True(File.Exists(_configPath));                           // first-run config.xml created
+
+            var reloaded = Config.LoadOrCreate(_configPath);
+            Assert.Equal(@"C:\tools\vba.exe", reloaded.at("emulator", ""));
+            Assert.Equal(@"C:\tools\sappy.exe", reloaded.at("sappy", ""));
+        }
+    }
+}

--- a/FEBuilderGBA.Core/Config.cs
+++ b/FEBuilderGBA.Core/Config.cs
@@ -116,10 +116,12 @@ namespace FEBuilderGBA
                     Directory.CreateDirectory(dir);
                 }
             }
-            catch
+            catch (Exception ex)
             {
                 // Non-fatal: Save() is itself exception-safe and surfaces a clear error
-                // if the location is genuinely unwritable.
+                // if the location is genuinely unwritable. Log once so a first-run
+                // directory-creation failure is diagnosable from the logs.
+                Log.Error("Config.LoadOrCreate: could not ensure config directory for", fullfilename, ex.ToString());
             }
 
             var config = new Config();

--- a/FEBuilderGBA.Core/Config.cs
+++ b/FEBuilderGBA.Core/Config.cs
@@ -96,5 +96,35 @@ namespace FEBuilderGBA
             //設定されていないっぽい
             return def;
         }
+
+        /// <summary>
+        /// #1799: create a usable <see cref="Config"/> for <paramref name="fullfilename"/>
+        /// whether or not the file exists yet. Ensures the parent directory exists (so a
+        /// first-run <see cref="Save()"/> can create it) and sets <see cref="ConfigFilename"/>
+        /// via <see cref="Load(string)"/>. Both the Avalonia GUI (App.axaml.cs) and the CLI
+        /// (RomLoader) startup use this so <c>CoreState.Config</c> is never null on a fresh
+        /// install — previously a <c>File.Exists</c> guard left it null, and every config
+        /// writer (Options dialog, theme, recent files, init wizard) silently no-op'd.
+        /// </summary>
+        public static Config LoadOrCreate(string fullfilename)
+        {
+            try
+            {
+                string dir = Path.GetDirectoryName(fullfilename);
+                if (!string.IsNullOrEmpty(dir))
+                {
+                    Directory.CreateDirectory(dir);
+                }
+            }
+            catch
+            {
+                // Non-fatal: Save() is itself exception-safe and surfaces a clear error
+                // if the location is genuinely unwritable.
+            }
+
+            var config = new Config();
+            config.Load(fullfilename); // sets ConfigFilename; no-op when the file is absent
+            return config;
+        }
     }
 }


### PR DESCRIPTION
## Summary
Fixes @Chrixcalibur's report: in the Avalonia GUI, the **Help → Options** dialog didn't persist tool paths — Browse a tool, press **OK**, reopen Options → gone.

**Root cause.** `FEBuilderGBA.Avalonia/App.axaml.cs` (and `FEBuilderGBA.CLI/RomLoader.cs`) assigned `CoreState.Config` **only inside** `if (File.Exists(configPath))`. On a fresh install (no `config/config.xml` yet) `CoreState.Config` stayed **null**, and `OptionsViewModel.Save()`/`Load()` are both guarded by `if (cfg != null)` — so OK silently discarded everything and reopening showed empty fields. WinForms never had this bug (`Program.cs` loads config unconditionally).

**Fix.** Add `Config.LoadOrCreate(path)` in `FEBuilderGBA.Core` — ensures the parent dir exists and `Load()`s the file (`ConfigFilename` is set even when the file is absent, so a first-run `Save()` creates it), returning a **never-null** `Config`. Both the Avalonia GUI **and** the CLI now use it (the board found the identical guard in both entry points, so this fixes the whole class). Bonus: the same null-guard also silently broke theme persistence, recent files, and the init wizard on fresh installs — all fixed too.

Closes #1799.

## Scope
Avalonia GUI **bug fix** + shared Core helper + CLI parity. **WinForms untouched** (in scope under the [dual-GUI policy](https://github.com/laqieer/FEBuilderGBA/blob/master/docs/GUI-STRATEGY.md) — Avalonia bug fix).

## Before / After
Real desktop-Skia render of the **Options** dialog. Before = fresh install (no config.xml, defaults); After = a persisted config.xml loads back (auto-save now **checked**, interval **10**):

| Before (fresh — nothing persisted) | After (settings persist & reload) |
|---|---|
| ![before](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/1799/before.png) | ![after](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/1799/after.png) |

## GUI Test Report
| Check | Result |
|---|---|
| Options dialog renders (headless Skia) | ✅ before/after PNG |
| Persisted settings load on reopen (auto-save on/10) | ✅ visible in After |
| Fresh-install `OptionsViewModel.Save()` persists Emulator/Sappy/EventAssembler across reopen | ✅ `OptionsConfigPersistenceTests` pass |
| `Config.LoadOrCreate` round-trip (missing file → usable → Save → reload) | ✅ `ConfigLoadOrCreateTests` pass |
| Full `FEBuilderGBA.Core.Tests` | ✅ **6451 passed / 0 failed** (submodule initialized) |
| Full `FEBuilderGBA.Avalonia.Tests` | ✅ **9325 passed / 0 failed** |
| CLI builds with the `RomLoader` change | ✅ |

## Test plan
- [x] `ConfigLoadOrCreateTests` (Core) — missing file → non-null + `ConfigFilename` set + dir created; Save→reload round-trips tool paths
- [x] `OptionsConfigPersistenceTests` (Avalonia) — end-to-end fresh-install `OptionsViewModel.Save()` persists across reopen; isolated temp `BaseDirectory` (non-git) + `CoreState` snapshot/restore + `[Collection("SharedState")]`
- [x] Full Core.Tests green with `config/patch2` initialized (6451/0; the 10 `SkillSystemsAnime` failures reproduce only without the submodule)
- [x] Full Avalonia.Tests green (9325/0)
- [x] CLI project builds
- [x] Before/after Options render committed to `pr-screenshots/1799/`

---
Copilot CLI: 1.0.69-0
Model: Claude Opus 4.8 (claude-opus-4.8)