### PR TITLE
fix(avalonia): hide version-mismatched editor buttons in localized UI (#1798)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GetVersionVisibilityByNameTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GetVersionVisibilityByNameTests.cs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1798: version gating must key off the STABLE, version-encoding button Name, not the
+// translatable Content. In Japanese, config/translate/ja.txt renders "Unit (FE6)" as
+// "ユニット（FE6）" with FULL-WIDTH parens （ ）, so the old ASCII "(FE6)" Content check
+// returned null (no tag) and left FE6/FE7/FE7U/FE8U buttons visible on FE8J.
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    public class GetVersionVisibilityByNameTests
+    {
+        // Representative version-encoding names vs every ROM version (ver, isMultibyte):
+        // FE6 (6,true JP-only), FE7J (7,true), FE7U (7,false), FE8J (8,true), FE8U (8,false).
+        [Theory]
+        // FE6 button — visible only on FE6
+        [InlineData("UnitFE6Button", 6, true, true)]
+        [InlineData("UnitFE6Button", 7, false, false)]
+        [InlineData("UnitFE6Button", 8, true, false)]   // FE8J — hidden (the reported bug)
+        [InlineData("UnitFE6Button", 8, false, false)]  // FE8U — hidden
+        // FE7 (generic) button — visible on both FE7J and FE7U, hidden elsewhere
+        [InlineData("SupTalkFE7Button", 7, true, true)]
+        [InlineData("SupTalkFE7Button", 7, false, true)]
+        [InlineData("SupTalkFE7Button", 8, true, false)]
+        // FE7U (region) button — visible ONLY on FE7U (ver==7 && !isMultibyte)
+        [InlineData("MapSettingsFE7UButton", 7, false, true)]
+        [InlineData("MapSettingsFE7UButton", 7, true, false)]  // FE7J — hidden
+        [InlineData("MapSettingsFE7UButton", 8, false, false)]
+        // FE8U (region) button — visible ONLY on FE8U (ver==8 && !isMultibyte)
+        [InlineData("OPDemoFE8UButton", 8, false, true)]
+        [InlineData("OPDemoFE8UButton", 8, true, false)]       // FE8J — hidden
+        [InlineData("ExtraFE8UButton", 8, false, true)]
+        [InlineData("ExtraFE8UButton", 8, true, false)]
+        public void GetVersionVisibilityByName_GatesByStableName(string name, int ver, bool isMultibyte, bool expectedVisible)
+        {
+            bool? actual = MainWindow.GetVersionVisibilityByName(name, ver, isMultibyte);
+            Assert.True(actual.HasValue, $"{name} should carry a version tag");
+            Assert.Equal(expectedVisible, actual!.Value);
+        }
+
+        // False-positive guard: skill-system "FE8N" buttons contain "FE8" but are NOT
+        // FE8/FE8U region-version buttons — they must NOT be gated by this rule (return
+        // null so the caller's section/Content handling applies), or they'd be wrongly
+        // hidden. Likewise a generic (untagged) name returns null.
+        [Theory]
+        [InlineData("UnitFE8NButton")]      // skill-system (FE8N), NOT ROM-version FE8
+        [InlineData("ConfigFE8NButton")]
+        [InlineData("ConfigFE8Nv2Button")]
+        [InlineData("ConfigFE8Nv3Button")]
+        [InlineData("UnitCSkillSysButton")] // skill-system, gated by patch presence
+        [InlineData("ConfigCSkill09xButton")]
+        [InlineData("UnitsButton")]
+        [InlineData("ClassesButton")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void GetVersionVisibilityByName_NoVersionSuffix_ReturnsNull(string? name)
+        {
+            Assert.Null(MainWindow.GetVersionVisibilityByName(name, 8, true));
+        }
+
+        // Documents WHY name-based gating is required: the Japanese full-width-paren
+        // Content defeats the ASCII-paren Content check (this is the #1798 root cause).
+        [Fact]
+        public void GetVersionVisibility_FullWidthParens_ReturnsNull_MotivatesNameGating()
+        {
+            // ASCII parens → recognized and gated.
+            Assert.Equal(false, MainWindow.GetVersionVisibility("Unit (FE6)", 8, true));
+            // Full-width parens (ja.txt "ユニット（FE6）") → NOT recognized → always shown.
+            Assert.Null(MainWindow.GetVersionVisibility("ユニット\uFF08FE6\uFF09", 8, true));
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/GetVersionVisibilityByNameTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GetVersionVisibilityByNameTests.cs
@@ -58,15 +58,23 @@ namespace FEBuilderGBA.Avalonia.Tests
             Assert.Null(MainWindow.GetVersionVisibilityByName(name, 8, true));
         }
 
-        // Documents WHY name-based gating is required: the Japanese full-width-paren
-        // Content defeats the ASCII-paren Content check (this is the #1798 root cause).
+        // Documents the #1798 root cause AND why the fix is robust: version gating must
+        // not depend on the (localized) Content. The Name-based gate hides the FE6 button
+        // on FE8J regardless of whether Content uses ASCII "(FE6)" or Japanese full-width
+        // "（FE6）" — it never reads Content at all. The old Content-based check only
+        // recognizes ASCII parens (asserted here as the stable contract); a future
+        // improvement could teach it full-width parens, but the Name-based gate — the
+        // actual fix — does not depend on that, so this test won't regress if it does.
         [Fact]
-        public void GetVersionVisibility_FullWidthParens_ReturnsNull_MotivatesNameGating()
+        public void NameGating_IsContentIndependent_UnlikeContentGating()
         {
-            // ASCII parens → recognized and gated.
+            // Name-based gate (the fix): FE6 button hidden on FE8J for ANY Content shape.
+            Assert.Equal(false, MainWindow.GetVersionVisibilityByName("UnitFE6Button", 8, true));
+
+            // Content-based gate recognizes ASCII parens (stable, asserted contract)...
             Assert.Equal(false, MainWindow.GetVersionVisibility("Unit (FE6)", 8, true));
-            // Full-width parens (ja.txt "ユニット（FE6）") → NOT recognized → always shown.
-            Assert.Null(MainWindow.GetVersionVisibility("ユニット\uFF08FE6\uFF09", 8, true));
+            // ...but the Name-based gate is what guarantees correctness in localized UIs,
+            // where Content becomes "ユニット（FE6）" with full-width parens.
         }
     }
 }

--- a/FEBuilderGBA.Avalonia.Tests/MainMenuVersionVisibilityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/MainMenuVersionVisibilityTests.cs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1798 reproduction: on an FE8J ROM the main menu must HIDE editor buttons that
+// are specific to other versions (FE6 / FE7 / FE7U / FE8U). This loads a real
+// FE8J ROM into a headless MainWindow, runs the production UpdateEditorVisibility,
+// and asserts the version-mismatched buttons are hidden while FE8-generic ones stay.
+using System.IO;
+using System.Reflection;
+using System.Text;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Views;
+using global::Avalonia.Controls;
+using global::Avalonia.Headless.XUnit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    [Collection("SharedState")]
+    public class MainMenuVersionVisibilityTests : System.IDisposable
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly bool _available;
+        private readonly ROM? _prevRom;
+        private readonly IEtcCache? _prevComment, _prevLint, _prevWork;
+        private readonly ISystemTextEncoder? _prevEncoder;
+        private readonly string? _prevBaseDir;
+
+        public MainMenuVersionVisibilityTests(ITestOutputHelper output)
+        {
+            _output = output;
+            _prevRom = CoreState.ROM;
+            _prevComment = CoreState.CommentCache;
+            _prevLint = CoreState.LintCache;
+            _prevWork = CoreState.WorkSupportCache;
+            _prevEncoder = CoreState.SystemTextEncoder;
+            _prevBaseDir = CoreState.BaseDirectory;
+
+            string? path = TestRomLocator.FindRom("FE8J");
+            if (path == null) { _available = false; return; }
+            try
+            {
+                string dir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? ".";
+                CoreState.BaseDirectory = dir;
+                Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+                string cfg = Path.Combine(dir, "config", "config.xml");
+                CoreState.Config = Config.LoadOrCreate(cfg);
+
+                var rom = new ROM();
+                if (!rom.Load(path, out string _)) { _available = false; return; }
+                CoreState.ROM = rom;
+                CoreState.CommentCache = new HeadlessEtcCache();
+                CoreState.LintCache = new HeadlessEtcCache();
+                CoreState.WorkSupportCache = new HeadlessEtcCache();
+                try { CoreState.SystemTextEncoder = new SystemTextEncoder(CoreState.TextEncoding, rom); }
+                catch { CoreState.SystemTextEncoder = new HeadlessSystemTextEncoder(rom); }
+                CoreState.TextEscape ??= new TextEscape();
+                CoreState.Undo ??= new Undo();
+                _available = true;
+            }
+            catch { _available = false; }
+        }
+
+        public void Dispose()
+        {
+            CoreState.ROM = _prevRom;
+            CoreState.CommentCache = _prevComment;
+            CoreState.LintCache = _prevLint;
+            CoreState.WorkSupportCache = _prevWork;
+            CoreState.SystemTextEncoder = _prevEncoder;
+            if (_prevBaseDir != null) CoreState.BaseDirectory = _prevBaseDir;
+        }
+
+        [AvaloniaFact]
+        public void FE8J_HidesOtherVersionSpecificEditorButtons()
+        {
+            if (!_available) { _output.WriteLine("SKIP: FE8J.gba unavailable"); return; }
+
+            var rom = CoreState.ROM!;
+            Assert.Equal(8, rom.RomInfo.version);
+            Assert.True(rom.RomInfo.is_multibyte); // FE8J
+
+            var window = new MainWindow();
+
+            // Version-specific buttons that must be HIDDEN on FE8J (FE6/FE7/FE7U/FE8U).
+            string[] mustHide =
+            {
+                "UnitFE6Button", "ClassFE6Button", "ItemsFE6Button", "MoveCostFE6Button",
+                "SupportFE6Button", "SupTalkFE6Button", "SupTalkFE7Button", "UnitsFE7Button",
+                "EventUnitFE6Button", "EventUnitFE7Button", "BattleTalkFE6Button", "BattleTalkFE7Button",
+                "MapSettingsFE6Button", "MapSettingsFE7Button", "MapSettingsFE7UButton",
+                "OPDemoFE7Button", "OPDemoFE7UButton", "OPDemoFE8UButton", "OPFontFE8UButton",
+                "AlphaFE6Button", "SoundRoomFE6Button", "CGFE7UButton", "ExtraFE8UButton",
+                "EDFE6Button", "EDFE7Button", "PortraitFE6Button",
+            };
+
+            // Simulate RefreshEditorButtons() in Japanese: the version-specific buttons'
+            // Content gets full-width parens (e.g. "Unit （FE6）"), which DEFEATS the old
+            // ASCII "(FE6)" Content check. The Name-based gate (#1798 fix) must still hide
+            // them. Converting ASCII parens -> full-width reproduces the exact ja.txt shape.
+            foreach (string name in mustHide)
+            {
+                var b = window.FindControl<Button>(name);
+                if (b == null) continue;
+                string c = b.Content?.ToString() ?? "";
+                b.Content = c.Replace('(', '\uFF08').Replace(')', '\uFF09');
+            }
+
+            // Run the production version-gating exactly as the ROM-load path does.
+            typeof(MainWindow)
+                .GetMethod("UpdateEditorVisibility", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .Invoke(window, null);
+
+            // With full-width (localized) Content, gating must still hide them by Name.
+            var stillVisible = new System.Collections.Generic.List<string>();
+            foreach (string name in mustHide)
+            {
+                var btn = window.FindControl<Button>(name);
+                if (btn != null && btn.IsVisible) stillVisible.Add(name);
+            }
+            Assert.True(stillVisible.Count == 0,
+                "These version-mismatched buttons are still visible on FE8J (#1798): " +
+                string.Join(", ", stillVisible));
+
+            // Sanity: an FE8-applicable button stays visible (nothing over-hidden).
+            var fe8Extra = window.FindControl<Button>("ExtraUnitButton"); // no version tag → always shown
+            Assert.True(fe8Extra == null || fe8Extra.IsVisible);
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/MainMenuVersionVisibilityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/MainMenuVersionVisibilityTests.cs
@@ -24,6 +24,7 @@ namespace FEBuilderGBA.Avalonia.Tests
         private readonly IEtcCache? _prevComment, _prevLint, _prevWork;
         private readonly ISystemTextEncoder? _prevEncoder;
         private readonly string? _prevBaseDir;
+        private readonly Config? _prevConfig;
 
         public MainMenuVersionVisibilityTests(ITestOutputHelper output)
         {
@@ -34,6 +35,7 @@ namespace FEBuilderGBA.Avalonia.Tests
             _prevWork = CoreState.WorkSupportCache;
             _prevEncoder = CoreState.SystemTextEncoder;
             _prevBaseDir = CoreState.BaseDirectory;
+            _prevConfig = CoreState.Config;
 
             string? path = TestRomLocator.FindRom("FE8J");
             if (path == null) { _available = false; return; }
@@ -67,7 +69,8 @@ namespace FEBuilderGBA.Avalonia.Tests
             CoreState.LintCache = _prevLint;
             CoreState.WorkSupportCache = _prevWork;
             CoreState.SystemTextEncoder = _prevEncoder;
-            if (_prevBaseDir != null) CoreState.BaseDirectory = _prevBaseDir;
+            CoreState.BaseDirectory = _prevBaseDir;
+            CoreState.Config = _prevConfig;
         }
 
         [AvaloniaFact]

--- a/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
@@ -3873,8 +3873,14 @@ namespace FEBuilderGBA.Avalonia.Views
                 foreach (var item in wp.Children)
                 {
                     if (item is not Button btn) continue;
-                    string content = btn.Content?.ToString() ?? "";
-                    bool? visible = GetVersionVisibility(content, ver, isMultibyte);
+                    // #1798: gate by the STABLE, version-encoding button Name (never
+                    // localized) — NOT the translatable Content. In Japanese,
+                    // RefreshEditorButtons sets Content to full-width parens (e.g.
+                    // "ユニット（FE6）"), so the ASCII "(FE6)" check in GetVersionVisibility
+                    // silently failed and left FE6/FE7/FE7U/FE8U buttons visible on FE8J.
+                    // Fall back to the Content check only when the Name carries no tag.
+                    bool? visible = GetVersionVisibilityByName(btn.Name, ver, isMultibyte)
+                        ?? GetVersionVisibility(btn.Content?.ToString() ?? "", ver, isMultibyte);
                     if (visible.HasValue)
                     {
                         btn.IsVisible = visible.Value;
@@ -3903,6 +3909,33 @@ namespace FEBuilderGBA.Avalonia.Views
             if (content.Contains("(FE8)"))
                 return ver == 8;
             return null; // no tag — always show
+        }
+
+        /// <summary>
+        /// #1798: translation-independent version gating. Version-specific editor buttons
+        /// are named "&lt;Editor&gt;FE&lt;n&gt;[U]Button" (e.g. UnitFE6Button,
+        /// MapSettingsFE7UButton, OPDemoFE8UButton) — a stable identifier that is never
+        /// localized, unlike Content (which becomes full-width "（FE6）" in Japanese and
+        /// defeats GetVersionVisibility's ASCII "(FE6)" check). Matches the version token
+        /// immediately before the "Button" suffix so a generic name can't be misread.
+        /// Returns null when the name has no version suffix (caller falls back to Content).
+        /// Order matters: region-specific (FE7U, FE8U) before generic (FE7, FE8).
+        /// </summary>
+        internal static bool? GetVersionVisibilityByName(string? name, int ver, bool isMultibyte)
+        {
+            if (string.IsNullOrEmpty(name))
+                return null;
+            if (name.EndsWith("FE7UButton"))
+                return ver == 7 && !isMultibyte;
+            if (name.EndsWith("FE8UButton"))
+                return ver == 8 && !isMultibyte;
+            if (name.EndsWith("FE6Button"))
+                return ver == 6;
+            if (name.EndsWith("FE7Button"))
+                return ver == 7;
+            if (name.EndsWith("FE8Button"))
+                return ver == 8;
+            return null; // no version suffix in the name
         }
 
         // ===================== #1411 Portrait Editor version gating =====================

--- a/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
@@ -3925,15 +3925,15 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             if (string.IsNullOrEmpty(name))
                 return null;
-            if (name.EndsWith("FE7UButton"))
+            if (name.EndsWith("FE7UButton", StringComparison.Ordinal))
                 return ver == 7 && !isMultibyte;
-            if (name.EndsWith("FE8UButton"))
+            if (name.EndsWith("FE8UButton", StringComparison.Ordinal))
                 return ver == 8 && !isMultibyte;
-            if (name.EndsWith("FE6Button"))
+            if (name.EndsWith("FE6Button", StringComparison.Ordinal))
                 return ver == 6;
-            if (name.EndsWith("FE7Button"))
+            if (name.EndsWith("FE7Button", StringComparison.Ordinal))
                 return ver == 7;
-            if (name.EndsWith("FE8Button"))
+            if (name.EndsWith("FE8Button", StringComparison.Ordinal))
                 return ver == 8;
             return null; // no version suffix in the name
         }


### PR DESCRIPTION
## Summary
Fixes the reported bug: on an **FE8J** ROM with a **Japanese** UI, the main menu showed editor buttons meant only for other versions (FE6/FE7/FE7U/FE8U), e.g. `Unit (FE6)`.

**Root cause.** `MainWindow.HideVersionMismatchedButtons` → `GetVersionVisibility` gated on the button's **translatable `Content`**, matching an ASCII tag `(FE6)`. `RefreshEditorButtons` sets `Content = R._("Unit (FE6)")`; `config/translate/ja.txt` (and `zh.txt`) render this as **`ユニット（FE6）`** with **full-width** parens `（ ）` — so the ASCII `Contains("(FE6)")` missed, `GetVersionVisibility` returned `null` (no tag → always show), and the buttons stayed visible. English passes through untranslated, so it only reproduced in a CJK-localized UI.

**Fix.** Gate by the **stable, version-encoding button `Name`** (`UnitFE6Button`, `MapSettingsFE7UButton`, `OPDemoFE8UButton` …), which is never localized, via `GetVersionVisibilityByName`. It matches the version token as an exact **suffix** before `Button` (`EndsWith`), so skill-system `FE8N` buttons (`UnitFE8NButton`, `ConfigFE8Nv2/v3Button`) are **not** misclassified as ROM-version FE8. The existing `Content` check is kept as a fallback, and `GetVersionVisibility` is unchanged (its source-order test still passes).

Closes #1798.

## Scope
Avalonia GUI **bug fix** — `MainWindow.axaml.cs` gating + tests only. **WinForms untouched** (in scope under the [dual-GUI policy](https://github.com/laqieer/FEBuilderGBA/blob/master/docs/GUI-STRATEGY.md)).

## Before / After
Real desktop capture — FE8J main menu (Japanese), filtering for **"FE6"**:

| Before — 16 FE6 editors wrongly shown | After — 0 match (hidden) |
|---|---|
| ![before](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/1798/before.png) | ![after](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/1798/after.png) |

## GUI Test Report
| Check | Result |
|---|---|
| FE8J main menu renders (real desktop, Japanese) | ✅ before/after |
| Filter "FE6" on FE8J | ✅ 16 → **0** editors after fix |
| Real-ROM integration: all FE6/FE7/FE7U/FE8U buttons hidden on FE8J w/ full-width Content | ✅ `MainMenuVersionVisibilityTests` (fails on old Content-only logic) |
| `GetVersionVisibilityByName` FE6/FE7/FE7U/FE8/FE8U × version matrix | ✅ `GetVersionVisibilityByNameTests` |
| FE8N/CSkill/generic names → null (no false hide) | ✅ |
| `GetVersionVisibility` source-order test (`FEBuilderGBA.Tests`) | ✅ still passes |
| Full `FEBuilderGBA.Avalonia.Tests` (CI-equivalent, no ROMS_DIR) | ✅ **9351 passed / 0 failed / 9 skipped** |

## Test plan
- [x] `GetVersionVisibilityByNameTests` — version matrix + FE8N/CSkill/generic negatives + full-width-paren documentation
- [x] `MainMenuVersionVisibilityTests` — real FE8J ROM in a headless `MainWindow`, full-width Content, asserts every FE6/FE7/FE7U/FE8U button hidden (fail-before/pass-after verified on a clean build)
- [x] Full Avalonia suite green CI-equivalently (9351/0/9); the ROM-dependent integration test runs locally with `ROMS_DIR` and skips in CI like the other real-ROM tests
- [x] `FEBuilderGBA.Tests` version-order guard still passes
- [x] Before/after real captures committed to `pr-screenshots/1798/`

---
Copilot CLI: 1.0.69-0
Model: Claude Opus 4.8 (claude-opus-4.8)