### PR TITLE
fix: correct the app version/release-metadata class (#1805, #1803, #1797)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/VersionMenuItemTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/VersionMenuItemTests.cs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1797 — the Avalonia Tools menu exposes a "Version Information" item (opening
+// VersionView, which shows U.getAppVersion()). This is the fix for the reported
+// "Tools -> Version doesn't exist" gap (VersionView already existed but was
+// unreachable from the UI). Placement matches .github/ISSUE_TEMPLATE/gui_bug.yml,
+// which directs users to "Help → About, or Tools → Version Information".
+using System.Linq;
+using global::Avalonia.Controls;
+using global::Avalonia.Headless.XUnit;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    [Collection("SharedState")]
+    public class VersionMenuItemTests
+    {
+        [AvaloniaFact]
+        public void ToolsMenu_ContainsVersionInformationItem()
+        {
+            var window = new MainWindow();
+
+            var version = window.FindControl<MenuItem>("VersionMenuItem");
+            Assert.NotNull(version);
+            Assert.Contains("Version", version!.Header?.ToString() ?? "");
+
+            var toolsMenu = window.FindControl<MenuItem>("ToolsMenu");
+            Assert.NotNull(toolsMenu);
+            var children = toolsMenu!.Items.OfType<MenuItem>().ToList();
+            int versionIdx = children.FindIndex(m => m.Name == "VersionMenuItem");
+            int optionsIdx = children.FindIndex(m => m.Name == "OptionsMenuItem");
+            Assert.True(versionIdx >= 0, "VersionMenuItem must be a child of the Tools menu");
+            Assert.True(optionsIdx >= 0 && optionsIdx < versionIdx,
+                "Version Information should sit after Options in the Tools menu");
+        }
+    }
+}
+

--- a/FEBuilderGBA.Avalonia/ViewModels/VersionViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/VersionViewModel.cs
@@ -24,7 +24,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 #if DEBUG
             ver = "-Debug Build-";
 #else
-            ver = U.getVersion();
+            ver = U.getAppVersion();
 #endif
             var sb = new StringBuilder();
             string asmName = typeof(U).Assembly.GetName().Name ?? "FEBuilderGBA";

--- a/FEBuilderGBA.Avalonia/ViewModels/WelcomeViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/WelcomeViewModel.cs
@@ -19,7 +19,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 #if DEBUG
                 VersionInfo = "Version: Debug Build";
 #else
-                VersionInfo = $"Version: {U.getVersion()}";
+                VersionInfo = $"Version: {U.getAppVersion()}";
 #endif
             }
             catch

--- a/FEBuilderGBA.Avalonia/Views/MainWindow.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MainWindow.axaml
@@ -47,6 +47,7 @@
         </MenuItem>
         <Separator />
         <MenuItem AutomationProperties.AutomationId="Main_OptionsMenuItem_Button" Header="_Options..." Click="Options_Click" Name="OptionsMenuItem" />
+        <MenuItem AutomationProperties.AutomationId="Main_VersionMenuItem_Button" Header="_Version Information" Click="Version_Click" Name="VersionMenuItem" />
       </MenuItem>
       <MenuItem AutomationProperties.AutomationId="Main_HelpMenu_Button" Header="_Help" Name="HelpMenu">
         <MenuItem AutomationProperties.AutomationId="Main_OnlineManualMenuItem_Button" Header="_Online Manual" Click="OnlineManual_Click" Name="OnlineManualMenuItem" />

--- a/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
@@ -3370,10 +3370,17 @@ namespace FEBuilderGBA.Avalonia.Views
             TryStartAutoSave(currentTarget);
         }
 
+        private void Version_Click(object? sender, RoutedEventArgs e)
+        {
+            WindowManager.Instance.Open<VersionView>();
+        }
+
         private async void About_Click(object? sender, RoutedEventArgs e)
         {
             await MessageBoxWindow.Show(this,
-                R._("FEBuilderGBA") + "\n" + R._("Avalonia Cross-Platform Preview") + "\n" + R._("Copyright 2017- GPLv3"),
+                R._("FEBuilderGBA") + "\n" + R._("Avalonia Cross-Platform Preview") + "\n"
+                    + R._("Version") + ": " + U.getAppVersion() + "\n"
+                    + R._("Copyright 2017- GPLv3"),
                 R._("About"), MessageBoxMode.Ok);
         }
 

--- a/FEBuilderGBA.CLI/Program.cs
+++ b/FEBuilderGBA.CLI/Program.cs
@@ -439,7 +439,7 @@ namespace FEBuilderGBA.CLI
 
         static void PrintVersion()
         {
-            string version = U.getVersion();
+            string version = U.getAppVersion();
             Console.WriteLine($"FEBuilderGBA Version:{version}");
             Console.WriteLine("Copyright: 2017-");
             Console.WriteLine("License: GPLv3");

--- a/FEBuilderGBA.Core/ProblemReportCore.cs
+++ b/FEBuilderGBA.Core/ProblemReportCore.cs
@@ -150,7 +150,7 @@ namespace FEBuilderGBA
             sb.Append(Log.LogToString(1024));
             sb.Append("\r\n------\r\n");
 
-            sb.AppendLine(typeof(U).Assembly.GetName().Name + ":" + U.getVersion());
+            sb.AppendLine(typeof(U).Assembly.GetName().Name + ":" + U.getAppVersion());
 
             if (rom != null && rom.RomInfo != null && rom.Data != null)
             {

--- a/FEBuilderGBA.Core/UpdateInfo.cs
+++ b/FEBuilderGBA.Core/UpdateInfo.cs
@@ -34,17 +34,33 @@ namespace FEBuilderGBA
         /// </summary>
         public UpdateInfo()
         {
-            VERSION_CORE = U.getVersion();
+            VERSION_CORE = U.getAppVersion();
+        }
+
+        /// <summary>
+        /// Parses a version string to a comparable number, tolerating an optional
+        /// <c>ver_</c> release-tag prefix (e.g. <c>ver_20260704.04</c> → 20260704.04).
+        /// <see cref="FEBuilderGBA.U.getAppVersion"/> returns the tag WITH the prefix, so a
+        /// raw <see cref="FEBuilderGBA.U.atof"/> would yield 0 and make every remote look newer.
+        /// </summary>
+        public static double ParseVersion(string version)
+        {
+            if (string.IsNullOrEmpty(version)) return 0;
+            string v = version.Trim();
+            if (v.StartsWith("ver_", StringComparison.Ordinal))
+                v = v.Substring(4);
+            return U.atof(v);
         }
 
         /// <summary>
         /// Compares two version strings and returns which is newer.
-        /// Returns: &lt;0 if v1 &lt; v2, 0 if equal, &gt;0 if v1 &gt; v2
+        /// Returns: &lt;0 if v1 &lt; v2, 0 if equal, &gt;0 if v1 &gt; v2.
+        /// Tolerates an optional <c>ver_</c> prefix on either side (see <see cref="ParseVersion"/>).
         /// </summary>
         public static int CompareVersions(string v1, string v2)
         {
-            double version1 = U.atof(v1);
-            double version2 = U.atof(v2);
+            double version1 = ParseVersion(v1);
+            double version2 = ParseVersion(v2);
 
             if (version1 < version2) return -1;
             if (version1 > version2) return 1;
@@ -99,7 +115,7 @@ namespace FEBuilderGBA
             if (string.IsNullOrEmpty(version))
                 return false;
 
-            return System.Text.RegularExpressions.Regex.IsMatch(version, @"^\d{8}\.\d{2}$");
+            return System.Text.RegularExpressions.Regex.IsMatch(version, @"^(?:ver_)?\d{8}\.\d{2}$");
         }
     }
 }

--- a/FEBuilderGBA.Tests/UpdateCheckSplitPackageTests.cs
+++ b/FEBuilderGBA.Tests/UpdateCheckSplitPackageTests.cs
@@ -8,6 +8,8 @@ namespace FEBuilderGBA.Tests
         [Theory]
         [InlineData("https://example.com/FEBuilderGBA_20260226.15.7z",  "20260226.15")]
         [InlineData("https://example.com/FEBuilderGBA_20260226.15.zip", "20260226.15")]
+        [InlineData("https://example.com/FEBuilderGBA_ver_20260704.04.7z",  "20260704.04")]
+        [InlineData("https://example.com/FEBuilderGBA_ver_20260704.04.zip", "20260704.04")]
         [InlineData("",                                                   "00000000.00")]
         [InlineData(null,                                                 "00000000.00")]
         [InlineData("https://example.com/invalid.7z",                    "00000000.00")]
@@ -15,6 +17,43 @@ namespace FEBuilderGBA.Tests
         {
             string result = UpdateCheckSplitPackage.ExtractVersionFromUrl(url);
             Assert.Equal(expected, result);
+        }
+
+        // #1803: a real release lists FEBuilderGBA-android-apk.zip (and the avalonia/cli
+        // bundles) BEFORE the WinForms desktop package. The legacy updater grabbed the
+        // FIRST browser_download_url (the APK). SelectCoreAssetUrl must pick the desktop
+        // FEBuilderGBA_ asset (underscore separator), never a platform bundle (hyphen).
+        const string ReleaseJson = @"{
+  ""assets"": [
+    { ""browser_download_url"": ""https://github.com/laqieer/FEBuilderGBA/releases/download/ver_20260704.04/FEBuilderGBA-android-apk.zip"" },
+    { ""browser_download_url"": ""https://github.com/laqieer/FEBuilderGBA/releases/download/ver_20260704.04/FEBuilderGBA-avalonia-win-x64.zip"" },
+    { ""browser_download_url"": ""https://github.com/laqieer/FEBuilderGBA/releases/download/ver_20260704.04/FEBuilderGBA-cli-win-x64.zip"" },
+    { ""browser_download_url"": ""https://github.com/laqieer/FEBuilderGBA/releases/download/ver_20260704.04/FEBuilderGBA_ver_20260704.04.zip"" }
+  ]
+}";
+
+        [Fact]
+        public void SelectCoreAssetUrl_PicksDesktopAsset_NotAndroidApk()
+        {
+            string url = UpdateCheckSplitPackage.SelectCoreAssetUrl(ReleaseJson);
+            Assert.EndsWith("FEBuilderGBA_ver_20260704.04.zip", url);
+            Assert.DoesNotContain("android", url);
+            Assert.DoesNotContain("avalonia", url);
+            Assert.DoesNotContain("-cli-", url);
+        }
+
+        [Fact]
+        public void SelectCoreAssetUrl_NumericAsset_Matches()
+        {
+            string json = @"{ ""assets"": [ { ""browser_download_url"": ""https://x/FEBuilderGBA_20260226.00.7z"" } ] }";
+            Assert.EndsWith("FEBuilderGBA_20260226.00.7z", UpdateCheckSplitPackage.SelectCoreAssetUrl(json));
+        }
+
+        [Fact]
+        public void SelectCoreAssetUrl_OnlyPlatformBundles_ReturnsEmpty()
+        {
+            string json = @"{ ""assets"": [ { ""browser_download_url"": ""https://x/FEBuilderGBA-android-apk.zip"" } ] }";
+            Assert.Equal("", UpdateCheckSplitPackage.SelectCoreAssetUrl(json));
         }
 
         [Fact]

--- a/FEBuilderGBA.Tests/UpdateInfoTests.cs
+++ b/FEBuilderGBA.Tests/UpdateInfoTests.cs
@@ -117,5 +117,56 @@ namespace FEBuilderGBA.Tests
             Assert.Contains("20260226.00", display);
             Assert.Contains("Core:", display);
         }
+
+        // ---- #1805 / #1803: ver_ release-tag prefix handling ----
+        // getAppVersion() returns the stamped release tag "ver_YYYYMMDD.NN"; the raw
+        // U.atof would parse a leading 'v' as 0 and make every remote look newer.
+
+        [Theory]
+        [InlineData("ver_20260704.04", "20260704.04", 0)]   // local tag == remote numeric → up to date (no false positive)
+        [InlineData("ver_20260704.04", "20260704.05", -1)]  // genuinely older
+        [InlineData("ver_20260704.05", "20260704.04", 1)]   // genuinely newer
+        [InlineData("ver_20260704.04", "ver_20260704.04", 0)]
+        [InlineData("20260704.04", "ver_20260704.05", -1)]
+        public void CompareVersions_TolerantOfVerPrefix(string v1, string v2, int expected)
+        {
+            int result = UpdateInfo.CompareVersions(v1, v2);
+            if (expected < 0) Assert.True(result < 0, $"Expected {v1} < {v2}");
+            else if (expected > 0) Assert.True(result > 0, $"Expected {v1} > {v2}");
+            else Assert.Equal(0, result);
+        }
+
+        [Theory]
+        [InlineData("ver_20260704.04", 20260704.04)]
+        [InlineData("20260704.04", 20260704.04)]
+        [InlineData("  ver_20260704.04  ", 20260704.04)]
+        [InlineData("", 0)]
+        [InlineData(null, 0)]
+        public void ParseVersion_StripsVerPrefix(string version, double expected)
+        {
+            Assert.Equal(expected, UpdateInfo.ParseVersion(version), 3);
+        }
+
+        [Theory]
+        [InlineData("ver_20260226.00", true)]
+        [InlineData("20260226.00", true)]
+        [InlineData("ver_20260226.0", false)]   // missing hour digit even with prefix
+        [InlineData("ver_2026.00", false)]       // wrong width
+        public void IsValidVersion_AcceptsOptionalVerPrefix(string version, bool expected)
+        {
+            Assert.Equal(expected, UpdateInfo.IsValidVersion(version));
+        }
+
+        [Fact]
+        public void DetermineUpdateType_VerPrefixedLocal_NotFalsePositive()
+        {
+            // #1805: the installed WinForms build is stamped with the release tag; the
+            // latest GitHub release exposes the numeric version. Must NOT claim an update.
+            var updateInfo = new UpdateInfo();
+            typeof(UpdateInfo).GetProperty("VERSION_CORE").SetValue(updateInfo, "ver_20260704.04");
+            Assert.Equal(UpdateInfo.PackageType.None, updateInfo.DetermineUpdateType("20260704.04"));
+            // A genuinely newer remote is still detected.
+            Assert.Equal(UpdateInfo.PackageType.CoreOnly, updateInfo.DetermineUpdateType("20260704.05"));
+        }
     }
 }

--- a/FEBuilderGBA/ErrorReportForm.cs
+++ b/FEBuilderGBA/ErrorReportForm.cs
@@ -63,7 +63,7 @@ namespace FEBuilderGBA
             }
 
             string errorMessage = "ErrorMessage:" + ex.GetType().ToString() + " " + ex.Message + "\r\n"
-              + typeof(U).Assembly.GetName().Name + ":" + U.getVersion() + "\r\n"
+              + typeof(U).Assembly.GetName().Name + ":" + U.getAppVersion() + "\r\n"
               + "FEVersion:" + FEVersion + "\r\n"
               + inputformref_debuginfo
               + "MessageName:" + threadname + "\r\n"

--- a/FEBuilderGBA/FEBuilderGBA.csproj
+++ b/FEBuilderGBA/FEBuilderGBA.csproj
@@ -245,6 +245,24 @@
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
+  <!-- #1805: Stamp the release tag into AssemblyInformationalVersion so U.getAppVersion()
+       returns the user-facing ver_YYYYMMDD.NN. GenerateAssemblyInfo is false here (this
+       project uses a hand-written AssemblyInfo.cs), so the SDK will NOT emit the attribute
+       from /p:InformationalVersion=<tag>; we generate the one attribute ourselves when the
+       property is supplied (release.yml passes github.ref_name). Local/dev builds omit
+       InformationalVersion, so getAppVersion() keeps falling back to the build-stamp. -->
+  <Target Name="StampInformationalVersion" BeforeTargets="CoreCompile" Condition="'$(InformationalVersion)' != ''">
+    <PropertyGroup>
+      <_InfoVerFile>$(IntermediateOutputPath)InformationalVersion.g.cs</_InfoVerFile>
+    </PropertyGroup>
+    <WriteLinesToFile File="$(_InfoVerFile)"
+                      Lines="[assembly: System.Reflection.AssemblyInformationalVersion(&quot;$(InformationalVersion)&quot;)]"
+                      Overwrite="true" />
+    <ItemGroup>
+      <Compile Include="$(_InfoVerFile)" />
+    </ItemGroup>
+  </Target>
+
   <!-- Copy config directories to build output directory -->
   <Target Name="CopyConfigDirectories" AfterTargets="Build">
     <Message Text="========================================" Importance="high" />

--- a/FEBuilderGBA/Program.cs
+++ b/FEBuilderGBA/Program.cs
@@ -577,7 +577,7 @@ namespace FEBuilderGBA
         //ROM読みこみに伴うシステムの初期化.
         static void InitSystem(string fullfilename)
         {
-            Log.Notify("InitSystem:", Path.GetFileName(ROM.Filename), "ver:", ROM.RomInfo.VersionToFilename, "length:", ROM.Data.Length.ToString("X"), "FEBuilderGBA:", U.getVersion());
+            Log.Notify("InitSystem:", Path.GetFileName(ROM.Filename), "ver:", ROM.RomInfo.VersionToFilename, "length:", ROM.Data.Length.ToString("X"), "FEBuilderGBA:", U.getAppVersion());
 
             //Undoバッファの準備
             Undo = new Undo();

--- a/FEBuilderGBA/ToolProblemReportForm.cs
+++ b/FEBuilderGBA/ToolProblemReportForm.cs
@@ -484,7 +484,7 @@ namespace FEBuilderGBA
                 FEVersion += " @CRC32: " + U.ToHexString8(crc32.Calc(Program.ROM.Data));
             }
 
-            sb.AppendLine(typeof(U).Assembly.GetName().Name + ":" + U.getVersion());
+            sb.AppendLine(typeof(U).Assembly.GetName().Name + ":" + U.getAppVersion());
             sb.AppendLine("FEVersion:" + FEVersion);
             sb.AppendLine("Emu:" + OptionForm.GetEmulatorName() + " Ver:" + OptionForm.GetEmulatorVersion());
 
@@ -590,7 +590,7 @@ namespace FEBuilderGBA
                 }
                 catch (Exception ex) { Log.Error(ex.ToString()); }
 
-                string? appVersion = U.getVersion();
+                string? appVersion = U.getAppVersion();
                 string? romTag = null;
                 try { romTag = Program.ROM?.RomInfo?.VersionToFilename; } catch { }
                 string editorTitle = targetForm?.Text ?? "FEBuilderGBA";

--- a/FEBuilderGBA/ToolWorkSupportForm.cs
+++ b/FEBuilderGBA/ToolWorkSupportForm.cs
@@ -960,7 +960,7 @@ namespace FEBuilderGBA
             FEVersion = Program.ROM.RomInfo.VersionToFilename;
             FEVersion += " @ROMSize: " + Program.ROM.Data.Length;
 
-            sb.AppendLine(typeof(U).Assembly.GetName().Name + ":" + U.getVersion());
+            sb.AppendLine(typeof(U).Assembly.GetName().Name + ":" + U.getAppVersion());
             sb.AppendLine("FEVersion:" + FEVersion);
             sb.AppendLine("Emu:" + OptionForm.GetEmulatorName() + " Ver:" + OptionForm.GetEmulatorVersion());
 

--- a/FEBuilderGBA/U.cs
+++ b/FEBuilderGBA/U.cs
@@ -4124,6 +4124,32 @@ namespace FEBuilderGBA
 
             return baseDate.AddDays(build).AddSeconds(revision * 2).ToString("yyyyMMdd.HH");
         }
+
+        /// <summary>
+        /// The user-facing application version. For release builds this is the exact
+        /// <c>ver_YYYYMMDD.NN</c> tag stamped into the entry assembly's
+        /// <c>AssemblyInformationalVersion</c> by <c>release.yml</c>; for local/dev
+        /// builds (no such stamp) it falls back to <see cref="getVersion"/>. This is
+        /// what should be shown to users, because <see cref="getVersion"/> reflects the
+        /// Core assembly's per-build wildcard timestamp, which does not match the
+        /// release the user downloaded (#1805).
+        /// </summary>
+        public static string getAppVersion()
+        {
+            string fallback = getVersion();
+            try
+            {
+                var entry = System.Reflection.Assembly.GetEntryAssembly();
+                if (entry == null) return fallback;
+                var attr = (System.Reflection.AssemblyInformationalVersionAttribute?)
+                    System.Attribute.GetCustomAttribute(entry, typeof(System.Reflection.AssemblyInformationalVersionAttribute));
+                return BugReportCore.SelectVersion(attr?.InformationalVersion, fallback);
+            }
+            catch
+            {
+                return fallback;
+            }
+        }
         //NumUpDownControlの範囲を安全に再設定します
         public static void SelectedIndexSafety(NumericUpDown nud, int value)
         {

--- a/FEBuilderGBA/UpdateCheck.cs
+++ b/FEBuilderGBA/UpdateCheck.cs
@@ -195,8 +195,8 @@ namespace FEBuilderGBA
             out_url = "";
             out_version = "";
 
-            string versionString = U.getVersion();
-            double version = U.atof(versionString);
+            string versionString = U.getAppVersion();
+            double version = UpdateInfo.ParseVersion(versionString);
 
             string url = "https://api.github.com/repos/laqieer/FEBuilderGBA/releases/latest";
             string contents;
@@ -215,19 +215,12 @@ namespace FEBuilderGBA
             }
 
 
-            string downloadurl;
+            string downloadurl = UpdateCheckSplitPackage.SelectCoreAssetUrl(contents);
+            if (string.IsNullOrEmpty(downloadurl))
             {
-                System.Text.RegularExpressions.Match match = RegexCache.Match(contents
-                , "\"browser_download_url\": \"(.+)\""
-                );
-                if (match.Groups.Count < 2)
-                {
-                    return R._("サイトの結果が期待外でした。\r\n{0}", url) + "\r\n\r\n" 
-                        + "browser_download_url not found" + "\r\n"
-                        + "contents:\r\n" +  contents + "\r\n"
-                        + "match.Groups:\r\n" +  U.var_dump(match.Groups);
-                }
-                downloadurl = match.Groups[1].Value;
+                return R._("サイトの結果が期待外でした。\r\n{0}", url) + "\r\n\r\n"
+                    + "FEBuilderGBA desktop asset not found" + "\r\n"
+                    + "contents:\r\n" + contents;
             }
 
             {
@@ -271,8 +264,8 @@ namespace FEBuilderGBA
             out_url = "";
             out_version = "";
 
-            string versionString = U.getVersion();
-            double version = U.atof(versionString);
+            string versionString = U.getAppVersion();
+            double version = UpdateInfo.ParseVersion(versionString);
 
             string url = "https://nightly.link/laqieer/FEBuilderGBA/workflows/msbuild/master";
             string contents;
@@ -326,8 +319,8 @@ namespace FEBuilderGBA
             out_url = "";
             out_version = "";
 
-            string versionString = U.getVersion();
-            double version = U.atof(versionString);
+            string versionString = U.getAppVersion();
+            double version = UpdateInfo.ParseVersion(versionString);
 
             string url = "https://ux.getuploader.com/FE4/";
             string contents;

--- a/FEBuilderGBA/UpdateCheckSplitPackage.cs
+++ b/FEBuilderGBA/UpdateCheckSplitPackage.cs
@@ -38,7 +38,8 @@ namespace FEBuilderGBA
             }
 
             string escapedBase = Regex.Escape(baseUrl);
-            string corePattern = escapedBase + @"/FEBuilderGBA_(\d{8}\.\d{2})\.zip";
+            // Accept the optional "ver_" release-tag prefix (asset is FEBuilderGBA_ver_YYYYMMDD.NN.zip). #1803
+            string corePattern = escapedBase + @"/(FEBuilderGBA_(?:ver_)?\d{8}\.\d{2}\.zip)";
 
             Match coreMatch = RegexCache.Match(contents, corePattern);
 
@@ -48,8 +49,9 @@ namespace FEBuilderGBA
                     + "Package not found on nightly.link";
             }
 
-            string remoteCoreVersion = coreMatch.Groups[1].Value;
-            updateInfo.URL_CORE = baseUrl + "/FEBuilderGBA_" + remoteCoreVersion + ".zip";
+            string coreFile = coreMatch.Groups[1].Value;
+            string remoteCoreVersion = ExtractVersionFromUrl(coreFile);
+            updateInfo.URL_CORE = baseUrl + "/" + coreFile;
 
             UpdateInfo.PackageType packageType = updateInfo.DetermineUpdateType(remoteCoreVersion);
 
@@ -90,7 +92,7 @@ namespace FEBuilderGBA
 #endif
             }
 
-            string corePattern = @"""browser_download_url"":\s*""([^""]+/FEBuilderGBA_(\d{8}\.\d{2})\.(7z|zip))""";
+            string corePattern = @"""browser_download_url"":\s*""([^""]+/FEBuilderGBA_(?:ver_)?(\d{8}\.\d{2})\.(7z|zip))""";
             Match coreMatch = RegexCache.Match(contents, corePattern);
 
             if (coreMatch.Success && coreMatch.Groups.Count >= 3)
@@ -137,12 +139,30 @@ namespace FEBuilderGBA
             if (string.IsNullOrEmpty(url))
                 return "00000000.00";
 
-            // FEBuilderGBA_20260226.00.(7z|zip)
-            Match coreMatch = RegexCache.Match(url, @"FEBuilderGBA_(\d{8}\.\d{2})\.(7z|zip)");
+            // FEBuilderGBA_[ver_]20260226.00.(7z|zip)
+            Match coreMatch = RegexCache.Match(url, @"FEBuilderGBA_(?:ver_)?(\d{8}\.\d{2})\.(7z|zip)");
             if (coreMatch.Success && coreMatch.Groups.Count >= 2)
                 return coreMatch.Groups[1].Value;
 
             return "00000000.00";
+        }
+
+        /// <summary>
+        /// Selects the WinForms desktop package download URL from a GitHub
+        /// <c>/releases/latest</c> JSON body, ignoring the platform bundles
+        /// (<c>FEBuilderGBA-android-apk.zip</c>, <c>-avalonia-*</c>, <c>-cli-*</c>).
+        /// The desktop asset uses an underscore separator:
+        /// <c>FEBuilderGBA_[ver_]YYYYMMDD.NN.(7z|zip)</c>. Returns "" when none is present.
+        /// This prevents the legacy first-<c>browser_download_url</c> fallback from grabbing
+        /// the Android APK asset (#1803).
+        /// </summary>
+        public static string SelectCoreAssetUrl(string releaseJson)
+        {
+            if (string.IsNullOrEmpty(releaseJson))
+                return "";
+            Match m = RegexCache.Match(releaseJson,
+                @"""browser_download_url"":\s*""([^""]+/FEBuilderGBA_(?:ver_)?\d{8}\.\d{2}\.(?:7z|zip))""");
+            return (m.Success && m.Groups.Count >= 2) ? m.Groups[1].Value : "";
         }
     }
 }

--- a/FEBuilderGBA/VersionForm.cs
+++ b/FEBuilderGBA/VersionForm.cs
@@ -31,7 +31,7 @@ namespace FEBuilderGBA
 #if DEBUG
             ver = "-Debug Build-";
 #else
-            ver = U.getVersion();
+            ver = U.getAppVersion();
 #endif
 
             StringBuilder sb = new StringBuilder();

--- a/FEBuilderGBA/WelcomeForm.cs
+++ b/FEBuilderGBA/WelcomeForm.cs
@@ -30,7 +30,7 @@ namespace FEBuilderGBA
 #if DEBUG
             VersionLabel.Text = "-Debug Build-";
 #else
-            VersionLabel.Text = "Ver:" + U.getVersion();
+            VersionLabel.Text = "Ver:" + U.getAppVersion();
 #endif
             AllowDropFilename();
 


### PR DESCRIPTION
## Summary
Per @laqieer's directive to *fix the whole class, not one spot*, **#1805**, **#1803** and **#1797** are one class: the app derived its version from `U.getVersion()` — the **Core assembly's wildcard build stamp** (e.g. `20260703.20`) — for both user-facing display and update comparison, instead of the release tag. `U.getAppVersion()` already returns the correct `ver_YYYYMMDD.NN` tag (from `AssemblyInformationalVersion`).

## Root cause
- `U.getVersion()` = `baseDate(2000-01-01)` + assembly `Build`/`Revision` = the *build machine's* timestamp, **not** the release tag.
- The release WinForms asset is `FEBuilderGBA_ver_YYYYMMDD.NN.zip` (note `ver_`). The split-package updater regex expected `FEBuilderGBA_\d{8}` (no `ver_`) → never matched → fell back to the legacy path, which grabbed the **first** `browser_download_url` = `FEBuilderGBA-android-apk.zip` (**#1803**).
- `FEBuilderGBA.csproj` has `GenerateAssemblyInfo=false`, so `release.yml`'s `/p:InformationalVersion` was **never emitted as an attribute** → `getAppVersion()` fell back to the wildcard on the very app #1805 reports.

## Changes
**Core** — `UpdateInfo` ctor uses `getAppVersion()`; `CompareVersions`/`ParseVersion` strip an optional `ver_` before `atof` (else `atof("ver_…")==0` → perpetual false "update available"); `IsValidVersion` accepts the prefix; `ProblemReportCore` → `getAppVersion()`.
**WinForms** (bug-fix) — version shown/reported via `getAppVersion()` in `WelcomeForm`, `VersionForm`, `ErrorReportForm`, `ToolProblemReportForm` (log + bug-report prefill), `ToolWorkSupportForm`, `InitSystem` log; `getAppVersion()` added to WinForms's own (shadowed) `U.cs`. Updater: accept `ver_` in all three `UpdateCheckSplitPackage` regexes; new `SelectCoreAssetUrl` picks the desktop asset and **never** a platform bundle (used by legacy `UpdateCheck` instead of first-match). New `StampInformationalVersion` MSBuild target emits the attribute from `/p:InformationalVersion` (`GenerateAssemblyInfo=false` otherwise drops it).
**CLI** — `--version` → `getAppVersion()`.
**Avalonia** (feature) — `About` dialog shows the version; new **Tools → Version Information** menu item opens the existing (previously unreachable) `VersionView`; Welcome/Version view-models → `getAppVersion()`.

## GUI Test Report
Launched the **stamped** WinForms Release build (`/p:InformationalVersion=ver_20260704.99`). The Welcome window's version label now reads **`Ver:ver_20260704.99`** (was the wildcard `Ver:20260703.20` per #1805). Verified the built exe's `ProductVersion` == `ver_20260704.99` and the generated `InformationalVersion.g.cs`. Avalonia Tools → Version Information wiring is covered by `VersionMenuItemTests` (headless).

![WinForms Welcome shows ver_ tag](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/1805/winforms-version.png)

## Test plan
- [x] Core builds; WinForms x86 **with stamping** builds (0 errors) and stamps `ver_20260704.99`; Avalonia + CLI build.
- [x] `UpdateInfoTests` — ver_-aware `CompareVersions`/`ParseVersion`/`IsValidVersion` + `DetermineUpdateType` no-false-positive.
- [x] `UpdateCheckSplitPackageTests` — `ExtractVersionFromUrl` accepts `ver_`; `SelectCoreAssetUrl` picks the desktop asset and **rejects the Android APK even when listed first**.
- [x] `VersionMenuItemTests` — Tools → Version Information wired.
- [x] Full suites regression-free: WinForms **1946/0**, Avalonia **9352/0/9** (no `ROMS_DIR` = CI-equivalent).

Closes #1805
Closes #1803
Closes #1797

Copilot CLI: 1.0.69-0
Model: Claude Opus 4.8 (claude-opus-4.8)
