### PR TITLE
fix: handle empty/uninitialized config/patch2 gracefully (#1811)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/AndroidResourceEmptyStateTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/AndroidResourceEmptyStateTests.cs
@@ -32,6 +32,21 @@ namespace FEBuilderGBA.Avalonia.Tests
             ((List<PatchEntry>)field.GetValue(vm)).Clear();
         }
 
+        // Add one dummy patch so the "list populated" clear-path can be exercised deterministically.
+        static void AddDummyPatch(PatchManagerViewModel vm)
+        {
+            var field = typeof(PatchManagerViewModel)
+                .GetField("_allPatches", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(field);
+            ((List<PatchEntry>)field.GetValue(vm))
+                .Add(PatchEntry.FromPatchInfo(new PatchMetadataCore.PatchInfo { Name = "dummy" }));
+        }
+
+        // A guaranteed-nonexistent patch dir so PatchMetadataCore.IsPatchLibraryEmpty() returns true
+        // (the fresh-install "not initialized" state) deterministically, matching the cleared list.
+        static readonly string EmptyPatchDir =
+            Path.Combine(Path.GetTempPath(), "fe_empty_patch2_" + Guid.NewGuid().ToString("N"));
+
         [Fact]
         public void PatchManager_OnAndroid_WithNoPatches_ShowsLimitationNotice()
         {
@@ -42,7 +57,7 @@ namespace FEBuilderGBA.Avalonia.Tests
 
                 var vm = new PatchManagerViewModel();
                 ClearAllPatches(vm);          // simulate the on-device empty patch list
-                vm.ApplyAndroidEmptyStateNotice();
+                vm.ApplyEmptyStateNotice(EmptyPatchDir);
 
                 Assert.Equal(AndroidResourceNoticeCore.PatchLibraryUnavailableMessage, vm.StatusMessage);
             }
@@ -53,7 +68,7 @@ namespace FEBuilderGBA.Avalonia.Tests
         }
 
         [Fact]
-        public void PatchManager_AndroidNotice_IsClearedWhenConditionNoLongerHolds()
+        public void PatchManager_EmptyStateNotice_ClearedWhenListPopulated()
         {
             var savedSeam = AndroidResourceNoticeCore.IsAndroidOverride;
             try
@@ -62,13 +77,13 @@ namespace FEBuilderGBA.Avalonia.Tests
                 ClearAllPatches(vm);
 
                 AndroidResourceNoticeCore.IsAndroidOverride = () => true;  // Android + empty
-                vm.ApplyAndroidEmptyStateNotice();
+                vm.ApplyEmptyStateNotice(EmptyPatchDir);
                 Assert.Equal(AndroidResourceNoticeCore.PatchLibraryUnavailableMessage, vm.StatusMessage);
 
-                // Condition flips false (e.g. VM reuse on desktop / future on-device delivery):
-                // the stale Android notice must be cleared, not stick around.
-                AndroidResourceNoticeCore.IsAndroidOverride = () => false;
-                vm.ApplyAndroidEmptyStateNotice();
+                // The list becomes populated (e.g. patch2 downloaded, or VM reused): the stale
+                // empty-state notice must be cleared, not stick around.
+                AddDummyPatch(vm);
+                vm.ApplyEmptyStateNotice(EmptyPatchDir);
                 Assert.Equal("", vm.StatusMessage);
             }
             finally
@@ -78,7 +93,7 @@ namespace FEBuilderGBA.Avalonia.Tests
         }
 
         [Fact]
-        public void PatchManager_OnDesktop_WithNoPatches_DoesNotShowAndroidNotice()
+        public void PatchManager_OnDesktop_WithNoPatches_ShowsNotInitializedNotice()
         {
             var savedSeam = AndroidResourceNoticeCore.IsAndroidOverride;
             try
@@ -87,9 +102,11 @@ namespace FEBuilderGBA.Avalonia.Tests
 
                 var vm = new PatchManagerViewModel();
                 ClearAllPatches(vm);
-                vm.ApplyAndroidEmptyStateNotice();
+                vm.ApplyEmptyStateNotice(EmptyPatchDir);
 
-                // Desktop keeps the existing (blank) status — no Android notice even with an empty list.
+                // #1811: desktop with an empty/uninitialized patch2 now surfaces the
+                // not-downloaded-yet notice (not the Android limitation, and not a silent blank).
+                Assert.Equal(PatchMetadataCore.NotInitializedMessage, vm.StatusMessage);
                 Assert.NotEqual(AndroidResourceNoticeCore.PatchLibraryUnavailableMessage, vm.StatusMessage);
             }
             finally

--- a/FEBuilderGBA.Avalonia/ViewModels/PatchManagerViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/PatchManagerViewModel.cs
@@ -156,33 +156,45 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             TotalCount = _allPatches.Count;
             InstalledCount = _allPatches.Count(p => p.Status == PatchMetadataCore.PatchStatus.Installed);
 
-            ApplyAndroidEmptyStateNotice();
+            ApplyEmptyStateNotice(patchDir);
 
             ApplyFilter();
             IsLoaded = true;
         }
 
         /// <summary>
-        /// Android empty-state notice (#1641): patch2 is not delivered on-device, so the patch list
-        /// resolves empty there. Surface the canonical limitation instead of a silent blank list.
-        /// Desktop (resource delivery supported) keeps its existing behaviour untouched. Extracted so
-        /// the platform-gated branch is directly unit-testable via the
+        /// Empty-state notice for the Patch Manager. When the patch list resolves empty, explain WHY
+        /// instead of showing a silent blank list: on desktop (#1811) <c>config/patch2</c> has not
+        /// been downloaded yet (git-delivered since #1766) → <see cref="PatchMetadataCore.NotInitializedMessage"/>;
+        /// on Android (#1641) patch2 is not delivered on-device → <see cref="AndroidResourceNoticeCore.PatchLibraryUnavailableMessage"/>.
+        /// When the list is populated, any stale empty-state notice we set is cleared (never clobbers
+        /// an unrelated status). Platform is routed through the test-injectable
         /// <see cref="AndroidResourceNoticeCore.IsAndroidOverride"/> seam.
         /// </summary>
-        public void ApplyAndroidEmptyStateNotice()
+        public void ApplyEmptyStateNotice(string patchDir)
         {
-            bool shouldShow = !AndroidResourceNoticeCore.IsResourceDeliverySupported && _allPatches.Count == 0;
-            if (shouldShow)
+            if (_allPatches.Count != 0)
             {
-                StatusMessage = AndroidResourceNoticeCore.PatchLibraryUnavailableMessage;
+                // Populated: clear our own stale empty-state notice (VM reuse / list refilled).
+                if (StatusMessage == AndroidResourceNoticeCore.PatchLibraryUnavailableMessage ||
+                    StatusMessage == PatchMetadataCore.NotInitializedMessage)
+                {
+                    StatusMessage = "";
+                }
+                return;
             }
-            else if (StatusMessage == AndroidResourceNoticeCore.PatchLibraryUnavailableMessage)
+
+            // Only claim "not initialized" when the library is genuinely empty/missing (#1811) — an
+            // empty list from an enumeration failure (files present but unreadable) must not be
+            // mislabelled as not-downloaded-yet.
+            if (!PatchMetadataCore.IsPatchLibraryEmpty(patchDir))
             {
-                // Idempotent: if the condition no longer holds (e.g. the VM is reused, or a future
-                // on-device delivery populates the list), clear our own stale notice so it cannot
-                // stick around. Only clears the Android notice — never clobbers an unrelated status.
-                StatusMessage = "";
+                return;
             }
+
+            StatusMessage = AndroidResourceNoticeCore.IsResourceDeliverySupported
+                ? PatchMetadataCore.NotInitializedMessage                    // desktop: patch2 not downloaded yet (#1811)
+                : AndroidResourceNoticeCore.PatchLibraryUnavailableMessage;  // Android: not available on-device (#1641)
         }
 
         /// <summary>

--- a/FEBuilderGBA.Core.Tests/PatchMetadataCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/PatchMetadataCoreTests.cs
@@ -1246,5 +1246,54 @@ namespace FEBuilderGBA.Core.Tests
                 Directory.Delete(tempDir, true);
             }
         }
+
+        // ---- #1811: empty/uninitialized patch2 detection ----
+
+        [Fact]
+        public void IsPatchLibraryEmpty_MissingOrNullDirectory_ReturnsTrue()
+        {
+            string missing = Path.Combine(Path.GetTempPath(), "fe_no_patch2_" + System.Guid.NewGuid().ToString("N"));
+            Assert.True(PatchMetadataCore.IsPatchLibraryEmpty(missing));
+            Assert.True(PatchMetadataCore.IsPatchLibraryEmpty(null));
+            Assert.True(PatchMetadataCore.IsPatchLibraryEmpty(""));
+        }
+
+        [Fact]
+        public void IsPatchLibraryEmpty_ExistingEmptyDirectory_ReturnsTrue()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), "fe_empty_patch2_" + System.Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try { Assert.True(PatchMetadataCore.IsPatchLibraryEmpty(dir)); }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void IsPatchLibraryEmpty_DirectoryWithOnlyNonPatchFiles_ReturnsTrue()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), "fe_nonpatch_" + System.Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(Path.Combine(dir, "README.txt"), "x");
+            try { Assert.True(PatchMetadataCore.IsPatchLibraryEmpty(dir)); }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void IsPatchLibraryEmpty_DirectoryWithNestedPatch_ReturnsFalse()
+        {
+            // Matches EnumeratePatches' recursive PATCH_*.txt scan (e.g. FE8U/SYSTEM/PATCH_*.txt).
+            string dir = Path.Combine(Path.GetTempPath(), "fe_patch2_" + System.Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path.Combine(dir, "SYSTEM"));
+            File.WriteAllText(Path.Combine(dir, "SYSTEM", "PATCH_Test.txt"), "NAME:Test");
+            try { Assert.False(PatchMetadataCore.IsPatchLibraryEmpty(dir)); }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void NotInitializedMessage_IsNonEmpty_MentionsDownload_AndDistinctFromAndroidNotice()
+        {
+            Assert.False(string.IsNullOrWhiteSpace(PatchMetadataCore.NotInitializedMessage));
+            Assert.Contains("download", PatchMetadataCore.NotInitializedMessage, System.StringComparison.OrdinalIgnoreCase);
+            Assert.NotEqual(AndroidResourceNoticeCore.PatchLibraryUnavailableMessage, PatchMetadataCore.NotInitializedMessage);
+        }
     }
 }

--- a/FEBuilderGBA.Core/PatchMetadataCore.cs
+++ b/FEBuilderGBA.Core/PatchMetadataCore.cs
@@ -65,17 +65,24 @@ namespace FEBuilderGBA
         /// <param name="patchBaseDir">The <c>config/patch2/{version}</c> directory.</param>
         public static bool IsPatchLibraryEmpty(string patchBaseDir)
         {
-            if (string.IsNullOrEmpty(patchBaseDir) || !Directory.Exists(patchBaseDir))
+            if (string.IsNullOrEmpty(patchBaseDir))
                 return true;
             try
             {
                 return Directory.GetFiles(patchBaseDir, "PATCH_*.txt", SearchOption.AllDirectories).Length == 0;
             }
+            catch (DirectoryNotFoundException)
+            {
+                // Genuinely missing directory -> the fresh-install / not-initialized state.
+                return true;
+            }
             catch
             {
                 // An existing directory that fails to enumerate (permission / path-too-long) is a real
-                // error, not the fresh-install "not initialized" state — return false so callers do NOT
-                // mislead the user with the not-downloaded-yet notice and mask the actual failure.
+                // error, not the fresh-install state — return false so callers do NOT mislead the user
+                // with the not-downloaded-yet notice and mask the actual failure. (Directory.Exists is
+                // deliberately NOT used to gate this: it also returns false on an existence-probe error,
+                // which would misclassify an inaccessible dir as "not initialized".)
                 return false;
             }
         }

--- a/FEBuilderGBA.Core/PatchMetadataCore.cs
+++ b/FEBuilderGBA.Core/PatchMetadataCore.cs
@@ -41,6 +41,46 @@ namespace FEBuilderGBA
         }
 
         /// <summary>
+        /// Desktop empty-state message for the Patch Manager when <c>config/patch2/{version}</c>
+        /// has not been downloaded yet (#1811). Since #1766 the patch library is delivered over
+        /// git (repo <c>laqieer/FEBuilderGBA-patch2</c>) rather than bundled, so a fresh install
+        /// ships five empty <c>FE6/FE7J/FE7U/FE8J/FE8U</c> stub dirs. Unlike the Android-only
+        /// <see cref="AndroidResourceNoticeCore.PatchLibraryUnavailableMessage"/>, this points the
+        /// user at the in-app Initialize / Check-for-Updates flow. Bilingual (JA+EN) to match the
+        /// startup patch2 prompt.
+        /// </summary>
+        public const string NotInitializedMessage =
+            "パッチデータがまだダウンロードされていません。\r\n" +
+            "「更新の確認」からパッチデータベースをダウンロードしてください。\r\n\r\n" +
+            "The patch database has not been downloaded yet.\r\n" +
+            "Use Check for Updates / Initialize Repository to fetch it.";
+
+        /// <summary>
+        /// True when the patch library for a version has no installable patches — the directory is
+        /// missing, or exists but a successful scan finds no <c>PATCH_*.txt</c> (the fresh-install
+        /// state, #1811). Never throws. An <em>existing</em> directory that fails to enumerate
+        /// (permission / path-too-long) returns <c>false</c>: that is a real error, not the
+        /// not-initialized state, so callers won't mislead the user with the download notice.
+        /// </summary>
+        /// <param name="patchBaseDir">The <c>config/patch2/{version}</c> directory.</param>
+        public static bool IsPatchLibraryEmpty(string patchBaseDir)
+        {
+            if (string.IsNullOrEmpty(patchBaseDir) || !Directory.Exists(patchBaseDir))
+                return true;
+            try
+            {
+                return Directory.GetFiles(patchBaseDir, "PATCH_*.txt", SearchOption.AllDirectories).Length == 0;
+            }
+            catch
+            {
+                // An existing directory that fails to enumerate (permission / path-too-long) is a real
+                // error, not the fresh-install "not initialized" state — return false so callers do NOT
+                // mislead the user with the not-downloaded-yet notice and mask the actual failure.
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Enumerate all patch directories for a given ROM version and parse metadata.
         /// </summary>
         /// <param name="patchBaseDir">The config/patch2/{version} directory.</param>

--- a/FEBuilderGBA/PatchForm.cs
+++ b/FEBuilderGBA/PatchForm.cs
@@ -112,6 +112,14 @@ namespace FEBuilderGBA
                 return patchs;
             }
 
+            // #1811: config/patch2/<version> is delivered via git (since #1766) and is missing on a
+            // fresh install. Treat a missing patch directory as "no patches" rather than raising the
+            // generic "パッチ探索中にエラー" dialog from the DirectoryNotFoundException below.
+            if (!Directory.Exists(path))
+            {
+                return patchs;
+            }
+
             try
             {
                 string[] files = Directory.GetFiles(path, "PATCH_*.txt", SearchOption.AllDirectories);
@@ -5861,6 +5869,22 @@ namespace FEBuilderGBA
 
         private void PatchOpenButton_Click(object sender, EventArgs e)
         {
+            if (string.IsNullOrEmpty(PatchFilename.Text))
+            {
+                // #1811: on a fresh install config/patch2 is empty (delivered via git since
+                // #1766), so no patch is selected and PatchFilename.Text is "". Calling
+                // U.OpenURLOrFile("") -> Process.Start("") throws and dumps a raw exception.
+                // Show a friendly, actionable notice instead.
+                if (PatchMetadataCore.IsPatchLibraryEmpty(GetPatchDirectory()))
+                {
+                    R.ShowOK(PatchMetadataCore.NotInitializedMessage);
+                }
+                else
+                {
+                    R.ShowOK("パッチを選択してください。\r\nPlease select a patch first.");
+                }
+                return;
+            }
             U.OpenURLOrFile(PatchFilename.Text);
         }
 


### PR DESCRIPTION
## Summary
On a fresh standalone release `config/patch2` ships as five empty `FE6/FE7J/FE7U/FE8J/FE8U` stub dirs (the patch library is git-delivered since #1766). In that state the WinForms Patch Manager's **Open Patch File** crashed: nothing is selected → `PatchFilename.Text==""` → `U.OpenURLOrFile("")` → `Process.Start("")` throws → `R.ShowStopError` dumped a **raw exception**. Both GUIs also showed a silent, unexplained empty patch list. Reported in discussion #1808.

## Changes (shipped to both GUIs + Core, infra-exempt per the issue)
**Core `PatchMetadataCore`**
- `NotInitializedMessage` — bilingual (JA+EN) not-downloaded-yet notice pointing at the in-app Check-for-Updates / Initialize flow (distinct from the Android-only `AndroidResourceNoticeCore.PatchLibraryUnavailableMessage`).
- `IsPatchLibraryEmpty(dir)` — true when the dir is missing/null or a **successful** scan finds no `PATCH_*.txt`; an existing dir that fails to enumerate returns **false** (a real error, not the fresh-install state) so callers don't mislabel it.

**WinForms** (bug-fix)
- `PatchOpenButton_Click`: guard empty `PatchFilename.Text` → show `NotInitializedMessage` when the library is empty, else a "select a patch first" hint; never call `Process.Start("")`.
- `ScanPatchs`: return empty for a **missing** patch dir instead of raising the generic `パッチ探索中にエラー` dialog on load/reload (adopted from the review board — the missing-dir path).

**Avalonia**
- Rename `ApplyAndroidEmptyStateNotice` → `ApplyEmptyStateNotice(patchDir)` and generalize: empty + `IsPatchLibraryEmpty(dir)` → desktop shows `NotInitializedMessage` (#1811), Android keeps `PatchLibraryUnavailableMessage` (#1641); populated clears the stale notice.

## Test plan
- [x] Core `IsPatchLibraryEmpty` (missing/null, empty dir, only-non-PATCH files, nested `PATCH_*.txt`) + `NotInitializedMessage` (non-empty, mentions download, distinct from the Android notice) — **5/5**.
- [x] Avalonia `AndroidResourceEmptyStateTests`: desktop-empty → `NotInitializedMessage`; Android-empty → `PatchLibraryUnavailableMessage`; populated → cleared — **5/5**.
- [x] Full suites regression-free: **Core 6456/0/6, Avalonia 9352/0/9, WinForms 1946/0**; WinForms x86 build 0 errors.
- [x] Verified the WinForms FE8 editor **loads cleanly with an empty `config/patch2`** (no raw scan-error dialog) — see `app-empty-patch2.png`.

## Screenshots
The tests directly assert the exact fixed behaviour (below). The friendly `NotInitializedMessage` itself is an edge-case dialog behind the first-run / patch2-download flows and a ROM-dependent view, which resisted reliable automated capture in this locked-down CI-agent environment (foreground-input lock + startup dialogs + UIA limitations); the behaviour is comprehensively covered by the 10 passing tests, and the app is shown loading cleanly in the empty-patch2 repro state.

![#1811 tests passing](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/1811/test-proof.png)
![WinForms FE8 editor with empty patch2 loads without crashing](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/1811/app-empty-patch2.png)

Closes #1811

Copilot CLI: 1.0.69-0
Model: Claude Opus 4.8 (claude-opus-4.8)
