### PR TITLE
fix(winforms): Portrait Editor FE-Repo button no longer clipped (#1806)

### DIFF
--- a/FEBuilderGBA.Tests/Unit/FERepoBrowseButtonTests.cs
+++ b/FEBuilderGBA.Tests/Unit/FERepoBrowseButtonTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Drawing;
-using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Windows.Forms;
@@ -34,7 +33,7 @@ namespace FEBuilderGBA.Tests.Unit
                     Button feRepo = FERepoResourceBrowserForm.AddBrowseButton(import, export, (s, e) => { });
 
                     Assert.NotNull(feRepo);
-                    Assert.Contains(feRepo, panel.Controls.Cast<Control>());
+                    Assert.True(panel.Controls.Contains(feRepo), "FE-Repo button must be added to the panel");
                     // The whole button must fit within the (grown) panel — no clipping (#1806).
                     Assert.True(feRepo.Bottom <= panel.Height,
                         $"FE-Repo button Bottom ({feRepo.Bottom}) must fit within panel Height ({panel.Height})");

--- a/FEBuilderGBA.Tests/Unit/FERepoBrowseButtonTests.cs
+++ b/FEBuilderGBA.Tests/Unit/FERepoBrowseButtonTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Drawing;
+using System.Linq;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Windows.Forms;
+using Xunit;
+
+namespace FEBuilderGBA.Tests.Unit
+{
+    // #1806 — the shared FE-Repo browse-button helper must place the button inside the
+    // display range: below the bottom-most control AND growing the fixed-size panel so a
+    // layout pass cannot clip it. (The Portrait editor previously hand-placed the button at
+    // ImportButton.Bottom+2 without growing the panel, so it fell out of the display range.)
+    [Collection("SharedState")]
+    public class FERepoBrowseButtonTests
+    {
+        [Fact]
+        public void AddBrowseButton_GrowsPanel_SoButtonIsNotClipped()
+        {
+            ExceptionDispatchInfo edi = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    // A fixed-size panel just tall enough for one row of buttons — a second row
+                    // below would be clipped unless the helper grows the panel.
+                    using var panel = new Panel { Size = new Size(240, 40) };
+                    using var import = new Button { Size = new Size(107, 20), Location = new Point(11, 11) };
+                    using var export = new Button { Size = new Size(107, 20), Location = new Point(125, 11) };
+                    panel.Controls.Add(import);
+                    panel.Controls.Add(export);
+
+                    Button feRepo = FERepoResourceBrowserForm.AddBrowseButton(import, export, (s, e) => { });
+
+                    Assert.NotNull(feRepo);
+                    Assert.Contains(feRepo, panel.Controls.Cast<Control>());
+                    // The whole button must fit within the (grown) panel — no clipping (#1806).
+                    Assert.True(feRepo.Bottom <= panel.Height,
+                        $"FE-Repo button Bottom ({feRepo.Bottom}) must fit within panel Height ({panel.Height})");
+                    // It sits below the existing row, not on top of Import/Export.
+                    Assert.True(feRepo.Top >= import.Bottom,
+                        $"FE-Repo button Top ({feRepo.Top}) should be below Import.Bottom ({import.Bottom})");
+                }
+                catch (Exception ex)
+                {
+                    edi = ExceptionDispatchInfo.Capture(ex);
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.IsBackground = true;
+            thread.Start();
+
+            if (!thread.Join(TimeSpan.FromSeconds(30)))
+                throw new TimeoutException("STA thread did not complete within 30 seconds");
+
+            edi?.Throw();
+        }
+    }
+}

--- a/FEBuilderGBA/ImagePortraitForm.cs
+++ b/FEBuilderGBA/ImagePortraitForm.cs
@@ -49,15 +49,11 @@ namespace FEBuilderGBA
             U.SetIcon(ExportButton, Properties.Resources.icon_arrow);
             U.SetIcon(ImportButton, Properties.Resources.icon_upload);
 
-            // Add FE-Repo browse button below Import
-            var feRepoButton = new Button
-            {
-                Text = R._("FE-Repo"),
-                Size = new System.Drawing.Size(107, 20),
-                Location = new System.Drawing.Point(ImportButton.Left, ImportButton.Bottom + 2)
-            };
-            feRepoButton.Click += FERepoButton_Click;
-            ImportButton.Parent?.Controls.Add(feRepoButton);
+            // #1806 — use the shared FE-Repo browse-button helper (#1397), which places the button
+            // below the bottom-most control in the panel AND grows the panel's Height/MinimumSize so
+            // it can't fall out of the display range. The previous manual placement put the button at
+            // ImportButton.Bottom+2 without growing the fixed-size panel, so it was clipped (#1806).
+            FERepoResourceBrowserForm.AddBrowseButton(ImportButton, ExportButton, FERepoButton_Click);
 
             U.AllowDropFilename(this, ImageFormRef.IMAGE_FILE_FILTER, (string filename) =>
             {


### PR DESCRIPTION
## Summary
On the WinForms **Portrait Editor** the FE-Repo browse button was placed out of the display range and could not be shown. Root cause: the Portrait editor hand-placed its button at `ImportButton.Bottom + 2` inside the fixed-size `DragTargetPanel2` **without growing the panel**, so the extra row was clipped.

Every other image editor (BattleBG / CG / ItemIcon / …) already uses the shared `FERepoResourceBrowserForm.AddBrowseButton` helper (#1397), which places the button below the bottom-most control **and grows the panel's `Height`/`MinimumSize`** so a layout pass can't clip it. This migrates the Portrait editor to that same helper — a one-call, class-consistent fix.

## Test plan
- [x] New `FERepoBrowseButtonTests.AddBrowseButton_GrowsPanel_SoButtonIsNotClipped` — on an intentionally short fixed-size panel (that would otherwise clip a second row), asserts the FE-Repo button ends up fully inside the panel (`Bottom <= panel.Height`) and below the Import/Export row. **1/1 passed.**
- [x] WinForms x86 build: **0 errors**.

## Screenshots
This is a geometry fix; the new test asserts the button is in-bounds deterministically (a live before/after of the button behind the multi-level image-editor navigation was impractical to automate in this locked-down CI-agent environment). The reporter's original screenshot shows the clipped button; the fix routes placement through the same panel-growing helper used everywhere else.

![FERepoBrowseButtonTests passing](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/1806/test-proof.png)
![WinForms image-editor chooser (Portrait)](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/1806/image-editors.png)

Closes #1806

Copilot CLI: 1.0.69-0
Model: Claude Opus 4.8 (claude-opus-4.8)
