### PR TITLE
fix(winforms): reach patch2 Initialize/Update when up-to-date (#1816)

### DIFF
--- a/FEBuilderGBA.Tests/Unit/ToolUpdateDialogPatch2Tests.cs
+++ b/FEBuilderGBA.Tests/Unit/ToolUpdateDialogPatch2Tests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Windows.Forms;
+using Xunit;
+
+namespace FEBuilderGBA.Tests.Unit
+{
+    // #1816: the patch2 Git button (fetch config/patch2 via git) must be reachable when the core
+    // app is already up-to-date. patch2Only mode hides the Core button, shows the Git button
+    // (visible AND enabled even if git is missing, so the AutoUpdatePatch2Git -> TryAutoInstallGit
+    // fallback is live), and shows a patch2-focused message instead of the misleading
+    // "core -> 00000000.00" update text.
+    [Collection("SharedState")]
+    public class ToolUpdateDialogPatch2Tests
+    {
+        static T Get<T>(Control root, string name) where T : Control
+        {
+            var found = root.Controls.Find(name, true);
+            Assert.NotEmpty(found);
+            return Assert.IsAssignableFrom<T>(found[0]);
+        }
+
+        // Control.Visible's GETTER returns EFFECTIVE visibility (false while the parent form is not
+        // shown), so read the control's own STATE_VISIBLE flag (what InitSplitPackage actually set),
+        // independent of whether the form has been displayed.
+        static bool OwnVisible(Control c)
+        {
+            var m = typeof(Control).GetMethod("GetState",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            return (bool)m.Invoke(c, new object[] { 2 }); // STATE_VISIBLE = 0x02
+        }
+
+        static void RunSTA(Action body)
+        {
+            ExceptionDispatchInfo edi = null;
+            var t = new Thread(() =>
+            {
+                try { body(); }
+                catch (Exception ex) { edi = ExceptionDispatchInfo.Capture(ex); }
+            });
+            t.SetApartmentState(ApartmentState.STA);
+            t.IsBackground = true;
+            t.Start();
+            if (!t.Join(TimeSpan.FromSeconds(30)))
+                throw new TimeoutException("STA thread did not complete within 30 seconds");
+            edi?.Throw();
+        }
+
+        [Fact]
+        public void InitSplitPackage_Patch2Only_ReachesGitButton_HidesCore_NoMisleadingVersion()
+        {
+            RunSTA(() =>
+            {
+                using var f = new ToolUpdateDialogForm();
+                f.CreateControl();
+                var info = new UpdateInfo(); // URL_CORE null -> no core update
+
+                f.InitSplitPackage(info, patch2Only: true);
+
+                var patch2 = Get<Button>(f, "UpdatePatch2GitButton");
+                var core   = Get<Button>(f, "UpdateCoreButton");
+                var full   = Get<Button>(f, "AutoUpdateButton");
+                var msg    = Get<Control>(f, "Message");
+
+                Assert.True(OwnVisible(patch2), "Git Patch2 button must be reachable when core is up-to-date (#1816)");
+                Assert.True(patch2.Enabled, "Git Patch2 button must be enabled even if git is missing (auto-install path)");
+                Assert.False(OwnVisible(core), "Core button must be hidden when the core is already up-to-date");
+                Assert.False(OwnVisible(full), "Full/Auto button is always hidden in split-package mode");
+                // The patch2-only message must NOT show the bogus "core -> 00000000.00" transition.
+                Assert.DoesNotContain("00000000.00", msg.Text);
+            });
+        }
+
+        [Fact]
+        public void InitSplitPackage_WithCoreUpdate_ShowsCoreAndGitButtons()
+        {
+            RunSTA(() =>
+            {
+                using var f = new ToolUpdateDialogForm();
+                f.CreateControl();
+                var info = new UpdateInfo { URL_CORE = "https://example.com/FEBuilderGBA_ver_20260704.04.zip" };
+
+                f.InitSplitPackage(info); // normal split-package (a core update exists)
+
+                var core   = Get<Button>(f, "UpdateCoreButton");
+                var patch2 = Get<Button>(f, "UpdatePatch2GitButton");
+
+                Assert.True(OwnVisible(core), "Core button must be visible when a core update exists");
+                Assert.True(OwnVisible(patch2), "Git Patch2 button is always visible in split-package mode (#1816)");
+                Assert.True(patch2.Enabled);
+            });
+        }
+    }
+}

--- a/FEBuilderGBA.Tests/Unit/ToolUpdateDialogPatch2Tests.cs
+++ b/FEBuilderGBA.Tests/Unit/ToolUpdateDialogPatch2Tests.cs
@@ -67,6 +67,8 @@ namespace FEBuilderGBA.Tests.Unit
                 Assert.True(patch2.Enabled, "Git Patch2 button must be enabled even if git is missing (auto-install path)");
                 Assert.False(OwnVisible(core), "Core button must be hidden when the core is already up-to-date");
                 Assert.False(OwnVisible(full), "Full/Auto button is always hidden in split-package mode");
+                var openBrowser = Get<Button>(f, "OpenBrowserButton");
+                Assert.False(OwnVisible(openBrowser), "Open-Browser must be hidden in patch2-only mode (it would point at the core release, not patch2)");
                 // The patch2-only message must NOT show the bogus "core -> 00000000.00" transition.
                 Assert.DoesNotContain("00000000.00", msg.Text);
             });

--- a/FEBuilderGBA.Tests/Unit/ToolUpdateDialogPatch2Tests.cs
+++ b/FEBuilderGBA.Tests/Unit/ToolUpdateDialogPatch2Tests.cs
@@ -28,6 +28,7 @@ namespace FEBuilderGBA.Tests.Unit
         {
             var m = typeof(Control).GetMethod("GetState",
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            Assert.NotNull(m); // guard: GetState(int) must exist on this .NET WinForms build
             return (bool)m.Invoke(c, new object[] { 2 }); // STATE_VISIBLE = 0x02
         }
 

--- a/FEBuilderGBA/ToolUpdateDialogForm.cs
+++ b/FEBuilderGBA/ToolUpdateDialogForm.cs
@@ -105,8 +105,11 @@ namespace FEBuilderGBA
             this.URL         = UpdateCheckSplitPackage.GetDownloadUrl(updateInfo, out pt);
             this.PackageType = pt;
 
+            // #1816: bilingual literal (JA + EN, both always shown) — matching the
+            // PatchMetadataCore.NotInitializedMessage pattern from #1811. Deliberately NOT wrapped in
+            // R._ so a future translation of one half can't duplicate the other.
             this.Message.Text = patch2Only
-                ? R._("プログラム本体は最新です。\r\nパッチデータ(config/patch2)がまだダウンロードされていません。\r\n下のボタンでパッチデータベースを取得してください。") + "\r\n\r\n"
+                ? "プログラム本体は最新です。\r\nパッチデータ(config/patch2)がまだダウンロードされていません。\r\n下のボタンでパッチデータベースを取得してください。\r\n\r\n"
                   + "The application is up to date. The patch database (config/patch2) has not been downloaded yet.\r\nUse the button below to fetch it."
                 : BuildUpdateMessage(updateInfo);
         }

--- a/FEBuilderGBA/ToolUpdateDialogForm.cs
+++ b/FEBuilderGBA/ToolUpdateDialogForm.cs
@@ -26,7 +26,6 @@ namespace FEBuilderGBA
         string URL;
         UpdateInfo UpdateInfoData;
         UpdateInfo.PackageType PackageType;
-        private string _gitExe = null;  // cached in InitSplitPackage
 
         public void Init(string version, string url)
         {
@@ -49,11 +48,17 @@ namespace FEBuilderGBA
         /// </summary>
         public void InitSplitPackage(UpdateInfo updateInfo)
         {
-            this.UpdateInfoData = updateInfo;
+            InitSplitPackage(updateInfo, patch2Only: false);
+        }
 
-            // Detect git once and cache it
-            _gitExe = GitUtil.FindGitExecutable();
-            bool useGit = (_gitExe != null);
+        /// <summary>
+        /// #1816: when <paramref name="patch2Only"/> is true the core app is already up-to-date and
+        /// only the patch2 Initialize/Update action is offered (Core button hidden, patch2-focused
+        /// message). Reaches the Git Patch2 button on a fresh install with an empty config/patch2.
+        /// </summary>
+        public void InitSplitPackage(UpdateInfo updateInfo, bool patch2Only)
+        {
+            this.UpdateInfoData = updateInfo;
 
             // Always hide the legacy Full button in split-package mode
             this.AutoUpdateButton.Visible = false;
@@ -64,18 +69,21 @@ namespace FEBuilderGBA
             const int btnH   = 34;
             const int btnGap = 6;
 
-            // Core-only button — always shown
-            bool hasCore = !string.IsNullOrEmpty(updateInfo.URL_CORE);
+            // Core-only button — shown when a newer core exists (never in patch2-only mode)
+            bool hasCore = !patch2Only && !string.IsNullOrEmpty(updateInfo.URL_CORE);
             this.UpdateCoreButton.Visible  = hasCore;
             this.UpdateCoreButton.Enabled  = hasCore;
             this.UpdateCoreButton.Location = new System.Drawing.Point(17, y);
             if (hasCore) y += btnH + btnGap;
 
-            // Git Patch2 button — shown when git is found
-            this.UpdatePatch2GitButton.Visible  = useGit;
-            this.UpdatePatch2GitButton.Enabled  = useGit;
+            // #1816: always show the patch2 Git button in split-package mode. The click handler
+            // auto-installs Git when it is missing (AutoUpdatePatch2Git -> TryAutoInstallGit), so
+            // gating visibility on `useGit` hid the entry and made that fallback dead code — leaving
+            // a fresh install (empty config/patch2) with no in-app path to fetch the patch database.
+            this.UpdatePatch2GitButton.Visible  = true;
+            this.UpdatePatch2GitButton.Enabled  = true;
             this.UpdatePatch2GitButton.Location = new System.Drawing.Point(17, y);
-            if (useGit) y += btnH + btnGap;
+            y += btnH + btnGap;
 
             // Push OpenBrowser and Ignore below all visible update buttons
             // (keep at least the original gap from y=182 so layout isn't cramped)
@@ -94,7 +102,10 @@ namespace FEBuilderGBA
             this.URL         = UpdateCheckSplitPackage.GetDownloadUrl(updateInfo, out pt);
             this.PackageType = pt;
 
-            this.Message.Text = BuildUpdateMessage(updateInfo);
+            this.Message.Text = patch2Only
+                ? R._("プログラム本体は最新です。\r\nパッチデータ(config/patch2)がまだダウンロードされていません。\r\n下のボタンでパッチデータベースを取得してください。") + "\r\n\r\n"
+                  + "The application is up to date. The patch database (config/patch2) has not been downloaded yet.\r\nUse the button below to fetch it."
+                : BuildUpdateMessage(updateInfo);
         }
 
         private string BuildUpdateMessage(UpdateInfo updateInfo)

--- a/FEBuilderGBA/ToolUpdateDialogForm.cs
+++ b/FEBuilderGBA/ToolUpdateDialogForm.cs
@@ -85,10 +85,13 @@ namespace FEBuilderGBA
             this.UpdatePatch2GitButton.Location = new System.Drawing.Point(17, y);
             y += btnH + btnGap;
 
-            // Push OpenBrowser and Ignore below all visible update buttons
-            // (keep at least the original gap from y=182 so layout isn't cramped)
+            // #1816: in patch2-only mode "Open Browser" would point at the core release URL
+            // (irrelevant — patch2 is a separate git repo, not a release asset), so hide it and let
+            // Ignore take its slot. Push the remaining buttons below all visible update buttons.
+            this.OpenBrowserButton.Visible = !patch2Only;
+            this.OpenBrowserButton.Enabled = !patch2Only;
             int openY   = Math.Max(234, y);
-            int ignoreY = openY + btnH + btnGap;
+            int ignoreY = patch2Only ? openY : openY + btnH + btnGap;
             this.OpenBrowserButton.Location = new System.Drawing.Point(17, openY);
             this.IgnoreButton.Location      = new System.Drawing.Point(17, ignoreY);
 

--- a/FEBuilderGBA/UpdateCheck.cs
+++ b/FEBuilderGBA/UpdateCheck.cs
@@ -41,7 +41,22 @@ namespace FEBuilderGBA
                     else if (error.Contains("最新です"))
                     {
                         OverradeLastUpdateTime();
-                        R.ShowOK(error);
+                        // #1816: the core app is up-to-date, but a fresh install can still have an
+                        // empty config/patch2 (git-delivered since #1766). Open the split-package
+                        // dialog so the patch2 Initialize/Update (Git Patch2) button is reachable,
+                        // instead of the dead-end "you're on the latest" message. Checks the patch2
+                        // ROOT recursively so it works from the Welcome Update Check with no ROM.
+                        string patch2Root = System.IO.Path.Combine(Program.BaseDirectory, "config", "patch2");
+                        if (PatchMetadataCore.IsPatchLibraryEmpty(patch2Root))
+                        {
+                            ToolUpdateDialogForm f = (ToolUpdateDialogForm)InputFormRef.JumpFormLow<ToolUpdateDialogForm>();
+                            f.InitSplitPackage(updateInfo, patch2Only: true); // core is current — only offer patch2 init
+                            f.ShowDialog();
+                        }
+                        else
+                        {
+                            R.ShowOK(error);
+                        }
                         return;
                     }
                     // Otherwise fall through to legacy check


### PR DESCRIPTION
## Summary
The WinForms patch2 **Git Patch2** button (fetch `config/patch2` via git) was **unreachable** in the exact fresh-install case that needs it — the core app already latest, but `config/patch2` empty. This completes the **#1811** loop: the Patch-Manager empty-state message tells users to *"Use Check for Updates … to fetch it"*, but Check for Updates **dead-ended** ("you're on the latest", opens nothing) when the core was up-to-date, and the Git button was hidden when Git was missing (so its `TryAutoInstallGit` fallback was dead code).

## Changes (WinForms — reachability of an already-shipped button, bug/gap)
- `UpdateCheck.CheckUpdateUI` up-to-date branch: when `PatchMetadataCore.IsPatchLibraryEmpty(<BaseDirectory>/config/patch2)` (no `PATCH_*.txt` for **any** version — fresh install), open `ToolUpdateDialogForm.InitSplitPackage(updateInfo, patch2Only: true)` so the Git Patch2 button is reachable, instead of the dead-end message. Works from the ROM-less Welcome "Update Check".
- New `InitSplitPackage(updateInfo, patch2Only)` overload: hides the Core button, shows a **patch2-focused message** (not the misleading `core → 00000000.00` text — `URL_CORE` is left intact, so no empty-`Process.Start` either), hides Open-Browser (it would point at the irrelevant core release), and always shows the Git Patch2 button.
- Git Patch2 button is now always **Visible AND Enabled** (was gated on Git being found). The click handler already auto-installs Git when missing (`AutoUpdatePatch2Git` → `TryAutoInstallGit`).

## Scope
Bounded to reachability via the existing discoverable manual entry point. The dedicated Settings/Patch-Manager Initialize buttons + configurable URL are the **#1812** umbrella; the Avalonia counterpart is **#1817**. The silent auto-startup check is intentionally left as-is — the manual path + the #1811 Patch-Manager guidance cover the fresh-install flow without a startup modal (consistent with the issue's own framing).

## Test plan
- [x] `ToolUpdateDialogPatch2Tests` (STA): patch2Only reaches the **visible + enabled** Git button, hides Core/Full/Open-Browser, and shows **no** bogus `00000000.00` version; normal core-update mode still shows Core + Git. **2/2 passed.**
- [x] Full WinForms suite **1949/0**; WinForms x86 build **0 errors**.

The new branch itself sits behind a live network update-check, so it's exercised via the `InitSplitPackage(patch2Only)` unit tests (which assert the exact dialog state); the fixed behaviour is shown below.

![#1816 tests passing](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/1816/test-proof.png)

Closes #1816

Copilot CLI: 1.0.69-0
Model: Claude Opus 4.8 (claude-opus-4.8)
