### PR TITLE
docs: correct patch2 in-app update docs + add first-time setup guide (#1818)

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,15 +475,30 @@ When you check for updates the app compares the remote version against the local
 
 ### Updating Patch2 via Git
 
-Patch2 is a [git submodule](https://github.com/laqieer/FEBuilderGBA-patch2) updated independently of core releases.
+The patch database (`config/patch2/`, ~44,000 files) is delivered over git from the separate
+[FEBuilderGBA-patch2](https://github.com/laqieer/FEBuilderGBA-patch2) repository — since #1766 it is
+**not** bundled in the release, so a freshly-downloaded standalone build ships empty
+`FE6/FE7J/FE7U/FE8J/FE8U` stub folders that you fetch on first use.
 
-- **In-app:** Tools → Check for Updates → "Gitでパッチデータを更新します"
-- **Manual:** `cd config/patch2 && git pull`
-- **First run:** The app detects missing patch2 directories and offers to clone them automatically. If Git is not installed, empty directories are created so the app still starts.
+- **In-app (WinForms):** on the **Welcome screen** click **"Update Check"**. When `config/patch2/`
+  is empty (a fresh install) the dialog offers a **"Git Patch2"** button
+  (`Gitでパッチデータを更新します`) — shown even when the core app is already up-to-date (#1816), and
+  even if Git is not installed (it offers to auto-install Git first). Clicking it clones/updates
+  patch2. The **Patch Manager** also shows a *"patch database has not been downloaded yet — use
+  Check for Updates"* notice when `config/patch2/` is empty, instead of an error (#1811).
+- **Manual (any platform):** delete the empty stub folders, then either
+  `git clone --depth=1 https://github.com/laqieer/FEBuilderGBA-patch2.git config/patch2`, or
+  download & extract the repo's `master.zip` into `config/patch2/`, or reuse a populated
+  `config/patch2/` from an older release. To refresh an existing clone: `cd config/patch2 && git pull`.
+- **Avalonia:** a discoverable in-app patch2 initialize/update flow is not available yet
+  ([#1817](https://github.com/laqieer/FEBuilderGBA/issues/1817)) — the Options window can set the
+  remote URL, but use one of the manual methods above to fetch patch2 for now.
 
 The patch2 git source defaults to `github.com/laqieer/FEBuilderGBA-patch2`. To use a
 different remote (for example a private mirror), set a custom `submodule_patch2_url`
-value in `config.xml`; when present it overrides the default GitHub remote.
+value in `config.xml`; when present it overrides the default GitHub remote. See
+[docs/UPDATE-GUIDE.md](docs/UPDATE-GUIDE.md#first-time-patch2-setup) for a step-by-step
+first-time setup and troubleshooting guide.
 
 ### Benefits
 

--- a/README.md
+++ b/README.md
@@ -486,8 +486,8 @@ The patch database (`config/patch2/`, ~44,000 files) is delivered over git from 
   (`Gitでパッチデータを更新します`) — shown even when the core app is already up-to-date (#1816), and
   even if Git is not installed (it offers to auto-install Git first). Clicking it clones/updates
   patch2 (restart FEBuilderGBA afterwards to apply the new patch data). The **Patch Manager** also
-  shows a *"patch database has not been downloaded yet — use
-  Check for Updates"* notice when `config/patch2/` is empty, instead of an error (#1811).
+  shows the *"The patch database has not been downloaded yet. Use Check for Updates / Initialize
+  Repository to fetch it."* notice when `config/patch2/` is empty, instead of an error (#1811).
 - **Manual (any platform):** delete the empty stub folders, then either
   `git clone --depth=1 https://github.com/laqieer/FEBuilderGBA-patch2.git config/patch2`, or
   download & extract the repo's `master.zip` into `config/patch2/`, or reuse a populated

--- a/README.md
+++ b/README.md
@@ -480,11 +480,13 @@ The patch database (`config/patch2/`, ~44,000 files) is delivered over git from 
 **not** bundled in the release, so a freshly-downloaded standalone build ships empty
 `FE6/FE7J/FE7U/FE8J/FE8U` stub folders that you fetch on first use.
 
-- **In-app (WinForms):** on the **Welcome screen** click **"Update Check"**. When `config/patch2/`
+- **In-app (WinForms):** on the **Welcome screen** click the **update button** ("Update FEBuilderGBA
+  to the Latest Version"). When `config/patch2/`
   is empty (a fresh install) the dialog offers a **"Git Patch2"** button
   (`Gitでパッチデータを更新します`) — shown even when the core app is already up-to-date (#1816), and
   even if Git is not installed (it offers to auto-install Git first). Clicking it clones/updates
-  patch2. The **Patch Manager** also shows a *"patch database has not been downloaded yet — use
+  patch2 (restart FEBuilderGBA afterwards to apply the new patch data). The **Patch Manager** also
+  shows a *"patch database has not been downloaded yet — use
   Check for Updates"* notice when `config/patch2/` is empty, instead of an error (#1811).
 - **Manual (any platform):** delete the empty stub folders, then either
   `git clone --depth=1 https://github.com/laqieer/FEBuilderGBA-patch2.git config/patch2`, or

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -164,9 +164,14 @@ The patch2 remote is returned by `GitUtil.GetPatch2RemoteUrl()`: it defaults to
 `github.com/laqieer/FEBuilderGBA-patch2`, unless a custom `submodule_patch2_url`
 override is set in `config.xml`, in which case that value is used instead.
 
-In the UI this is **Tools → Check for Updates** ([`FEBuilderGBA/ToolUpdateDialogForm.cs`](../FEBuilderGBA/ToolUpdateDialogForm.cs)):
-when Git is found, a dedicated **Git Patch2** button performs the clone/update; if Git is absent, the app keeps
-the five empty `config/patch2/{FE6,FE7J,FE7U,FE8J,FE8U}` directories so startup still succeeds.
+In the UI this is the **Welcome screen → "Update Check"** dialog
+([`FEBuilderGBA/ToolUpdateDialogForm.cs`](../FEBuilderGBA/ToolUpdateDialogForm.cs)): a dedicated
+**Git Patch2** button performs the clone/update. Since #1816 that button is reachable even when the
+core app is already up-to-date (as long as `config/patch2/` is empty) and is shown even when Git is
+absent — clicking it offers to auto-install Git first. A fresh install keeps the five empty
+`config/patch2/{FE6,FE7J,FE7U,FE8J,FE8U}` stub directories so startup still succeeds, and the Patch
+Manager shows a "patch database not downloaded yet" notice rather than an error (#1811). Avalonia has
+no equivalent in-app flow yet ([#1817](https://github.com/laqieer/FEBuilderGBA/issues/1817)).
 
 See **[README → 🔄 Update System / Updating Patch2 via Git](../README.md#-update-system)** for the user-facing summary.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -249,7 +249,8 @@ git -C config/patch2 log -1 --format="%h %s"
 
 **Solutions:**
 - Confirm Git is installed and discoverable — `GitUtil.FindGitExecutable()` checks the configured path, then
-  `git` on `PATH`, then common Windows install locations. If none is found the button is hidden.
+  `git` on `PATH`, then common Windows install locations. Since #1816 the button stays visible even when
+  Git is absent and offers to **auto-install Git** on click (rather than hiding the entry).
 - Check network access to the patch2 remote (`github.com/laqieer/FEBuilderGBA-patch2`, or a custom `submodule_patch2_url`).
 - The patch2 repo is public; `GIT_TERMINAL_PROMPT=0` is set, so a credential prompt would surface as a failure
   rather than a hang — re-run with a clean `config/patch2/` to force a fresh `--depth=1` clone.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -164,8 +164,8 @@ The patch2 remote is returned by `GitUtil.GetPatch2RemoteUrl()`: it defaults to
 `github.com/laqieer/FEBuilderGBA-patch2`, unless a custom `submodule_patch2_url`
 override is set in `config.xml`, in which case that value is used instead.
 
-In the UI this is the **Welcome screen → "Update Check"** dialog
-([`FEBuilderGBA/ToolUpdateDialogForm.cs`](../FEBuilderGBA/ToolUpdateDialogForm.cs)): a dedicated
+In the UI this is the **Welcome screen** update button ("Update FEBuilderGBA to the Latest Version"), which opens the update
+dialog ([`FEBuilderGBA/ToolUpdateDialogForm.cs`](../FEBuilderGBA/ToolUpdateDialogForm.cs)): a dedicated
 **Git Patch2** button performs the clone/update. Since #1816 that button is reachable even when the
 core app is already up-to-date (as long as `config/patch2/` is empty) and is shown even when Git is
 absent — clicking it offers to auto-install Git first. A fresh install keeps the five empty

--- a/docs/UPDATE-GUIDE.md
+++ b/docs/UPDATE-GUIDE.md
@@ -9,13 +9,13 @@ FEBuilderGBA features an intelligent update system that automatically downloads 
 ### Simple Method (Recommended)
 
 1. **Open FEBuilderGBA**
-2. On the **Welcome screen**, click the **update button** ("Update FEBuilderGBA to the Latest Version") (WinForms). *(Avalonia has no in-app update checker yet — [#1817](https://github.com/laqieer/FEBuilderGBA/issues/1817).)*
+2. On the **Welcome screen**, click the **update button** ("Update FEBuilderGBA to the Latest Version") (WinForms). *(Avalonia's update checker is currently a non-functional stub — [#1817](https://github.com/laqieer/FEBuilderGBA/issues/1817).)*
 3. **Review what's being updated:**
    - The dialog shows which components have updates
    - Current version vs. latest version displayed
 4. **Click the update button** to download and install
 5. **Wait for completion:**
-   - For patch updates: No restart needed, just refresh
+   - For patch database (patch2) updates via git: **restart FEBuilderGBA** to apply the new patches
    - For application updates: FEBuilderGBA will restart automatically
 
 That's it! The system handles everything else automatically.

--- a/docs/UPDATE-GUIDE.md
+++ b/docs/UPDATE-GUIDE.md
@@ -27,8 +27,10 @@ If automatic updates don't work:
 1. Go to [Latest Release](https://github.com/laqieer/FEBuilderGBA/releases/latest)
 2. Download the appropriate package (see "Which Package to Download" below)
 3. Extract the archive
-4. **For FULL/CORE packages:** Replace your existing FEBuilderGBA folder
-5. **For PATCH2 packages:** Extract into your existing FEBuilderGBA folder (merge/replace files)
+4. **For the desktop application package:** Replace your existing FEBuilderGBA folder.
+5. **Patch database (`config/patch2/`):** since #1766 this is delivered over **git**, not as a
+   downloadable package — see [First-time patch2 setup](#first-time-patch2-setup) below if
+   `config/patch2/` is empty.
 
 ## First-time patch2 setup
 
@@ -99,7 +101,13 @@ empty state is handled gracefully (a friendly notice, not a crash).
   - You have the latest patches already
   - **Automatic updater selects this for you**
 
-### 🔹 PATCH2 Package (Patch database updates only)
+### 🔹 PATCH2 Package (Patch database updates only) — *historical*
+
+> **Note (#1766):** the patch database is now delivered over **git**, not as a downloadable
+> `.7z` asset — see [First-time patch2 setup](#first-time-patch2-setup). The
+> `FEBuilderGBA_PATCH2_{version}.7z` package described below is no longer produced; this entry is
+> kept for older releases only.
+
 - **Filename:** `FEBuilderGBA_PATCH2_{version}.7z`
 - **Size:** ~10-20MB
 - **Contains:** Patch database only (~44,000 patch files)

--- a/docs/UPDATE-GUIDE.md
+++ b/docs/UPDATE-GUIDE.md
@@ -9,7 +9,7 @@ FEBuilderGBA features an intelligent update system that automatically downloads 
 ### Simple Method (Recommended)
 
 1. **Open FEBuilderGBA**
-2. On the **Welcome screen**, click **"Update Check"** (WinForms). *(Avalonia has no in-app update checker yet — [#1817](https://github.com/laqieer/FEBuilderGBA/issues/1817).)*
+2. On the **Welcome screen**, click the **update button** ("Update FEBuilderGBA to the Latest Version") (WinForms). *(Avalonia has no in-app update checker yet — [#1817](https://github.com/laqieer/FEBuilderGBA/issues/1817).)*
 3. **Review what's being updated:**
    - The dialog shows which components have updates
    - Current version vs. latest version displayed
@@ -42,11 +42,12 @@ downloaded yet — use Check for Updates / Initialize Repository to fetch it"* n
 
 ### In-app (WinForms)
 
-1. On the **Welcome screen**, click **"Update Check"**.
+1. On the **Welcome screen**, click the **update button** ("Update FEBuilderGBA to the Latest Version").
 2. Even when the core app is already up-to-date, if `config/patch2/` is empty the dialog offers a
    **"Git Patch2"** button (`Gitでパッチデータを更新します`) — #1816.
 3. Click it. If Git is not installed the app offers to auto-install it first, then clones the patch
-   database. No restart is needed.
+   database. **Restart FEBuilderGBA afterwards** to apply the new patch data (patch definitions are
+   loaded at startup).
 
 > **Avalonia:** a discoverable in-app initialize/update flow is not available yet
 > ([#1817](https://github.com/laqieer/FEBuilderGBA/issues/1817)); the Options window can set the

--- a/docs/UPDATE-GUIDE.md
+++ b/docs/UPDATE-GUIDE.md
@@ -9,7 +9,7 @@ FEBuilderGBA features an intelligent update system that automatically downloads 
 ### Simple Method (Recommended)
 
 1. **Open FEBuilderGBA**
-2. **Click "Tools" → "Check for Updates"** (or press the update button)
+2. On the **Welcome screen**, click **"Update Check"** (WinForms). *(Avalonia has no in-app update checker yet — [#1817](https://github.com/laqieer/FEBuilderGBA/issues/1817).)*
 3. **Review what's being updated:**
    - The dialog shows which components have updates
    - Current version vs. latest version displayed
@@ -29,6 +29,54 @@ If automatic updates don't work:
 3. Extract the archive
 4. **For FULL/CORE packages:** Replace your existing FEBuilderGBA folder
 5. **For PATCH2 packages:** Extract into your existing FEBuilderGBA folder (merge/replace files)
+
+## First-time patch2 setup
+
+Since #1766 the **patch database** (`config/patch2/`, ~44,000 files) is delivered over **git** from
+the separate [FEBuilderGBA-patch2](https://github.com/laqieer/FEBuilderGBA-patch2) repository rather
+than bundled in the download. A freshly-extracted standalone build therefore ships **empty**
+`FE6/FE7J/FE7U/FE8J/FE8U` stub folders under `config/patch2/`, and you fetch the patches on first use.
+
+If you open the **Patch Manager** before fetching them, it shows a *"The patch database has not been
+downloaded yet — use Check for Updates / Initialize Repository to fetch it"* notice (not an error, #1811).
+
+### In-app (WinForms)
+
+1. On the **Welcome screen**, click **"Update Check"**.
+2. Even when the core app is already up-to-date, if `config/patch2/` is empty the dialog offers a
+   **"Git Patch2"** button (`Gitでパッチデータを更新します`) — #1816.
+3. Click it. If Git is not installed the app offers to auto-install it first, then clones the patch
+   database. No restart is needed.
+
+> **Avalonia:** a discoverable in-app initialize/update flow is not available yet
+> ([#1817](https://github.com/laqieer/FEBuilderGBA/issues/1817)); the Options window can set the
+> remote URL, but use a manual method below to fetch patch2 for now.
+
+### Manual (any platform)
+
+Delete the empty stub folders under `config/patch2/` first, then choose one:
+
+1. **git clone** (recommended — supports incremental updates later):
+   ```
+   git clone --depth=1 https://github.com/laqieer/FEBuilderGBA-patch2.git config/patch2
+   ```
+2. **Download the zip:** grab
+   `https://github.com/laqieer/FEBuilderGBA-patch2/archive/refs/heads/master.zip`
+   and extract its contents into `config/patch2/`.
+3. **Reuse** a populated `config/patch2/` from an older FEBuilderGBA release.
+
+To refresh an existing clone later: `cd config/patch2 && git pull`.
+
+### Custom / mirror remote
+
+The patch2 git source defaults to `github.com/laqieer/FEBuilderGBA-patch2`. To use a different remote
+(e.g. a private mirror), set `submodule_patch2_url` in `config.xml`; when present it overrides the default.
+
+### Troubleshooting: "Open Patch File" shows an error / the patch list is empty
+
+This means `config/patch2/` has not been fetched yet (the fresh-install state above). Follow the
+first-time setup steps to download the patch database, then reopen the Patch Manager. As of #1811 the
+empty state is handled gracefully (a friendly notice, not a crash).
 
 ## Which Package to Download?
 


### PR DESCRIPTION
## Summary
Corrects the patch2 in-app update docs to match the shipped behaviour (per #1811/#1816) and adds first-time setup + troubleshooting guidance. **Docs-only, no code changes** — not subject to the dual-GUI policy (#1818).

## Changes
- **README** "Updating Patch2 via Git": entry point is the **Welcome → "Update Check"** dialog (not "Tools → Check for Updates"); since #1816 the **Git Patch2** button is reachable even when the core app is up-to-date (empty `config/patch2/`) and shown even when Git is missing (auto-install); notes the #1811 Patch-Manager empty-state notice, the manual setup methods, and the Avalonia gap (#1817).
- **docs/UPDATE-GUIDE.md**: fixes the entry point; adds a **"First-time patch2 setup"** section (in-app WinForms + `git clone` / zip / reuse manual methods + custom `submodule_patch2_url` remote) and an **"Open Patch File shows an error / patch list is empty"** troubleshooting entry.
- **docs/DEPLOYMENT.md**: corrects the same entry-point/gating inaccuracy and notes the Avalonia gap.

## Test plan
- [x] Docs-only; no build/test impact. No doc-validation test references the changed files (`DeadWikiLinkTests` only scans for the old `dw.ngmansion.xyz` wiki host, which these changes don't introduce).
- [x] Behaviour documented matches the merged #1811 (empty-state notice) and #1816 (reachable Git Patch2 button) PRs.

A companion **wiki** page ("Patch Database (patch2) Setup & Updates") + Getting-Started/Reporting-Bugs links follow once this lands (issue part C).

Closes #1818

Copilot CLI: 1.0.69-0
Model: Claude Opus 4.8 (claude-opus-4.8)
