### PR TITLE
feat(avalonia): in-app patch2 Initialize/Update via Patch2GitService (#1817)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/Patch2InitUpdateButtonTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/Patch2InitUpdateButtonTests.cs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1817 — Avalonia in-app patch2 Initialize/Update surfaces. Verifies:
+//   * PatchManagerViewModel.Patch2ButtonText derives Initialize/Update from the REPO-ROOT
+//     config/patch2 git status (via CoreState.BaseDirectory), not the per-version subfolder;
+//   * the Init/Update buttons exist (by name) on the Patch Manager and Options views headlessly.
+using System;
+using System.IO;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    [Collection("SharedState")]
+    public class Patch2InitUpdateButtonTests
+    {
+        [Fact]
+        public void Patch2ButtonText_NonRepoDir_ShowsInitialize()
+        {
+            string saved = CoreState.BaseDirectory;
+            string baseDir = Path.Combine(Path.GetTempPath(), "fe_p2btn_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path.Combine(baseDir, "config", "patch2")); // exists, but not a git repo
+            try
+            {
+                CoreState.BaseDirectory = baseDir;
+                var vm = new PatchManagerViewModel();
+                Assert.Equal("Initialize Patch Database", vm.Patch2ButtonText);
+            }
+            finally
+            {
+                CoreState.BaseDirectory = saved;
+                try { Directory.Delete(baseDir, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void Patch2ButtonText_GitRepoDir_ShowsUpdate()
+        {
+            string saved = CoreState.BaseDirectory;
+            string baseDir = Path.Combine(Path.GetTempPath(), "fe_p2btn_" + Guid.NewGuid().ToString("N"));
+            string patch2 = Path.Combine(baseDir, "config", "patch2");
+            Directory.CreateDirectory(Path.Combine(patch2, ".git")); // .git DIRECTORY → IsGitRepo true
+            try
+            {
+                CoreState.BaseDirectory = baseDir;
+                var vm = new PatchManagerViewModel();
+                Assert.Equal("Update Patch Database", vm.Patch2ButtonText);
+            }
+            finally
+            {
+                CoreState.BaseDirectory = saved;
+                try { Directory.Delete(baseDir, true); } catch { }
+            }
+        }
+    }
+
+    public class Patch2InitUpdateViewTests
+    {
+        [AvaloniaFact]
+        public void PatchManagerView_HasInitUpdateButton()
+        {
+            var view = new PatchManagerView();
+            var btn = view.FindControl<Button>("InitUpdatePatch2Button");
+            Assert.NotNull(btn);
+            Assert.False(string.IsNullOrWhiteSpace(btn!.Content?.ToString()));
+        }
+
+        [AvaloniaFact]
+        public void OptionsView_HasInitUpdateButton()
+        {
+            var view = new OptionsView();
+            var btn = view.FindControl<Button>("InitUpdatePatch2Button");
+            Assert.NotNull(btn);
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/App.axaml.cs
+++ b/FEBuilderGBA.Avalonia/App.axaml.cs
@@ -414,6 +414,11 @@ namespace FEBuilderGBA.Avalonia
                     // #1784 PR proof: MapSettingDifficultyDialogView is ROM-independent, so
                     // it renders real PNG proof of the centered "Apply" action button.
                     "MapSettingDifficultyDialogView" => new Views.MapSettingDifficultyDialogView(),
+                    // #1817 PR proof: the Patch Manager is ROM-independent for the empty-state
+                    // screenshot (LoadPatches catches a missing ROM/patch2), so it renders real
+                    // PNG proof of the new "Initialize / Update Patch Database" button and the
+                    // empty-state notice in the left panel.
+                    "PatchManagerView" => new Views.PatchManagerView(),
                     _ => throw new ArgumentException($"Unsupported --screenshot-window view: {viewName}"),
                 };
 

--- a/FEBuilderGBA.Avalonia/ViewModels/PatchManagerViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/PatchManagerViewModel.cs
@@ -83,6 +83,24 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
 
+        /// <summary>
+        /// Label for the in-app patch2 Initialize/Update button (#1817). "Update Patch Database" when the
+        /// repo-root <c>config/patch2</c> is already a git repo, otherwise "Initialize Patch Database".
+        /// Uses <see cref="Patch2GitService.GetPatch2Dir"/> on <see cref="CoreState.BaseDirectory"/> (the
+        /// repo root) — NOT the per-version <c>ResolvePatchDirectory</c> subfolder, which is never itself a
+        /// git repo and would permanently mislabel the button.
+        /// </summary>
+        public string Patch2ButtonText
+        {
+            get
+            {
+                string baseDir = CoreState.BaseDirectory ?? AppDomain.CurrentDomain.BaseDirectory;
+                return GitUtil.IsGitRepo(Patch2GitService.GetPatch2Dir(baseDir))
+                    ? "Update Patch Database"
+                    : "Initialize Patch Database";
+            }
+        }
+
         public string FilterText
         {
             get => _filterText;

--- a/FEBuilderGBA.Avalonia/ViewModels/ToolUpdateDialogViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ToolUpdateDialogViewModel.cs
@@ -17,7 +17,10 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             if (rom?.RomInfo == null) return new List<AddrResult>();
 
             var result = new List<AddrResult>();
-            result.Add(new AddrResult(0, "Update Checker", 0));
+            // #1817: honest placeholder — this view is not an app update-checker (that is tracked in
+            // #1804). Point users to the real in-app patch2 Initialize/Update in the Patch Manager /
+            // Options rather than implying update functionality this stub does not have.
+            result.Add(new AddrResult(0, "Patch database: use Patch Manager or Options", 0));
             return result;
         }
 

--- a/FEBuilderGBA.Avalonia/Views/OptionsView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/OptionsView.axaml
@@ -37,6 +37,10 @@
                 <TextBlock Text="Leave blank for defaults. Set custom URLs for forks/mirrors." FontSize="11" Foreground="Gray" />
                 <TextBlock Text="Patch2 Remote URL" Margin="0,4,0,0" />
                 <TextBox AutomationProperties.AutomationId="Options_Patch2UrlText_Input" Name="Patch2UrlTextBox" Watermark="https://github.com/laqieer/FEBuilderGBA-patch2.git" />
+                <!-- #1817: in-app Initialize/Update of the patch2 database, next to its URL field. -->
+                <Button AutomationProperties.AutomationId="Options_InitUpdatePatch2_Button" Name="InitUpdatePatch2Button"
+                        Content="Initialize / Update Patch Database Now" Click="InitUpdatePatch2_Click"
+                        HorizontalAlignment="Left" Margin="0,4,0,0" />
                 <TextBlock Text="FE-Repo Remote URL" Margin="0,4,0,0" />
                 <TextBox AutomationProperties.AutomationId="Options_FERepoUrlText_Input" Name="FERepoUrlTextBox" Watermark="https://github.com/Klokinator/FE-Repo" />
                 <TextBlock Text="FE-Repo-Music Remote URL" Margin="0,4,0,0" />

--- a/FEBuilderGBA.Avalonia/Views/OptionsView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OptionsView.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
 using global::Avalonia.Platform.Storage;
@@ -167,6 +168,62 @@ namespace FEBuilderGBA.Avalonia.Views
         void CancelButton_Click(object? sender, RoutedEventArgs e)
         {
             Close(false);
+        }
+
+        /// <summary>
+        /// #1817: initialize (clone) or update (fetch+reset) the patch2 database in-app, next to its
+        /// remote-URL field. Passes the current textbox value directly to the service as an override so a
+        /// just-typed custom fork URL takes effect immediately, and persists ONLY the
+        /// <c>submodule_patch2_url</c> config key (not the whole Options form) so the custom URL survives
+        /// later auto-updates without committing other pending edits. Button disabled synchronously and
+        /// re-enabled in a finally.
+        /// </summary>
+        async void InitUpdatePatch2_Click(object? sender, RoutedEventArgs e)
+        {
+            InitUpdatePatch2Button.IsEnabled = false;
+            try
+            {
+                string url = (Patch2UrlTextBox.Text ?? "").Trim();
+
+                // Persist only the patch2 URL key so it survives subsequent auto-updates, without
+                // side-effecting other unsaved Options fields (do NOT call the full _vm.Save()).
+                var cfg = CoreState.Config;
+                if (cfg != null)
+                {
+                    cfg["submodule_patch2_url"] = url;
+                    cfg.Save();
+                }
+
+                string baseDir = CoreState.BaseDirectory ?? AppDomain.CurrentDomain.BaseDirectory;
+                string urlOverride = string.IsNullOrWhiteSpace(url) ? null : url;
+
+                var result = await Task.Run(() => Patch2GitService.InitializeOrUpdate(baseDir, null, urlOverride));
+                switch (result.Kind)
+                {
+                    case Patch2GitResultKind.GitNotFound:
+                        CoreState.Services?.ShowError("Git was not found. Install Git and try again, or set up config/patch2 manually — see the Patch Database Setup wiki page.");
+                        break;
+                    case Patch2GitResultKind.AlreadyRunning:
+                        CoreState.Services?.ShowInfo("A patch database operation is already running.");
+                        break;
+                    case Patch2GitResultKind.Failed:
+                        CoreState.Services?.ShowError(string.Format("Patch database {0} failed (git exit {1}).",
+                            result.WasClone ? "initialize" : "update", result.ExitCode));
+                        break;
+                    case Patch2GitResultKind.Success:
+                        CoreState.Services?.ShowInfo("Patch database updated. Restart recommended for all changes to take full effect.");
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error("OptionsView", ex.ToString());
+                CoreState.Services?.ShowError("Patch database operation failed: " + ex.Message);
+            }
+            finally
+            {
+                InitUpdatePatch2Button.IsEnabled = true;
+            }
         }
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/PatchManagerView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/PatchManagerView.axaml
@@ -7,7 +7,7 @@
         SizeToContent="WidthAndHeight">
   <Grid ColumnDefinitions="400,*" Margin="8">
     <!-- Left panel: search + patch list -->
-    <Grid Grid.Column="0" RowDefinitions="Auto,Auto,*" Margin="0,0,4,0">
+    <Grid Grid.Column="0" RowDefinitions="Auto,Auto,Auto,*" Margin="0,0,4,0">
       <!-- Search box -->
       <TextBox AutomationProperties.AutomationId="PatchManager_Search_Input" Grid.Row="0" Name="SearchBox" Watermark="Filter patches by name, tag, or author..."
                Margin="0,0,0,4" />
@@ -16,8 +16,14 @@
       <TextBlock AutomationProperties.AutomationId="PatchManager_Summary_Label" Grid.Row="1" Name="SummaryLabel" Margin="0,0,0,4" FontSize="12"
                  Foreground="Gray" />
 
+      <!-- In-app patch2 Initialize / Update (#1817). Always visible so a user with an empty
+           config/patch2 can fetch the database without selecting a patch first. -->
+      <Button AutomationProperties.AutomationId="PatchManager_InitUpdatePatch2_Button" Grid.Row="2" Name="InitUpdatePatch2Button"
+              Content="Initialize Patch Database" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center"
+              Margin="0,0,0,4" />
+
       <!-- Patch list -->
-      <ListBox AutomationProperties.AutomationId="PatchManager_PatchList_List" Grid.Row="2" Name="PatchListBox" SelectionMode="Single">
+      <ListBox AutomationProperties.AutomationId="PatchManager_PatchList_List" Grid.Row="3" Name="PatchListBox" SelectionMode="Single">
         <ListBox.ItemTemplate>
           <DataTemplate DataType="vm:PatchEntry">
             <Grid ColumnDefinitions="*,Auto" Margin="2">

--- a/FEBuilderGBA.Avalonia/Views/PatchManagerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/PatchManagerView.axaml.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
+using global::Avalonia.Threading;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
 
@@ -22,6 +25,7 @@ namespace FEBuilderGBA.Avalonia.Views
             InstallButton.Click += OnInstallClick;
             ForceInstallButton.Click += OnForceInstallClick;
             UninstallButton.Click += OnUninstallClick;
+            InitUpdatePatch2Button.Click += OnInitUpdatePatch2Click;
         }
 
         void LoadPatches()
@@ -31,6 +35,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.LoadPatchList();
                 PatchListBox.ItemsSource = _vm.FilteredPatches;
                 UpdateSummary();
+                InitUpdatePatch2Button.Content = _vm.Patch2ButtonText;
                 // Surface the VM's load-time status (e.g. the Android patch2-unavailable
                 // empty-state notice, #1641) into the status label. Always assign so a
                 // cleared StatusMessage ("") also resets the label — never leaves a stale notice.
@@ -176,6 +181,72 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             if (PatchListBox.ItemCount > 0)
                 PatchListBox.SelectedIndex = 0;
+        }
+
+        /// <summary>
+        /// #1817: in-app patch2 Initialize (clone) / Update (fetch+reset), the Avalonia half of #1812.
+        /// Runs <see cref="Patch2GitService.InitializeOrUpdate"/> off the UI thread; the button is
+        /// disabled synchronously on click and re-enabled in a finally so a mid-run exception can't leave
+        /// it stuck. git progress lines are throttled to ~150 ms to avoid saturating the UI thread
+        /// (a single clone emits hundreds of progress lines).
+        /// </summary>
+        async void OnInitUpdatePatch2Click(object? sender, RoutedEventArgs e)
+        {
+            InitUpdatePatch2Button.IsEnabled = false;   // synchronous re-entrancy guard
+            string baseDir = CoreState.BaseDirectory ?? AppDomain.CurrentDomain.BaseDirectory;
+
+            long lastPost = 0;
+            Action<string> progress = line =>
+            {
+                if (string.IsNullOrEmpty(line)) return;
+                long now = Environment.TickCount64;
+                if (now - Interlocked.Read(ref lastPost) < 150) return;   // throttle UI posts
+                Interlocked.Exchange(ref lastPost, now);
+                Dispatcher.UIThread.Post(() => StatusMessageLabel.Text = "Git: " + line);
+            };
+
+            try
+            {
+                StatusMessageLabel.Text = "Working…";
+                var result = await Task.Run(() => Patch2GitService.InitializeOrUpdate(baseDir, progress));
+                switch (result.Kind)
+                {
+                    case Patch2GitResultKind.GitNotFound:
+                        StatusMessageLabel.Text = "Git was not found. Install Git and try again, or set up config/patch2 manually — see the Patch Database Setup wiki page.";
+                        break;
+                    case Patch2GitResultKind.AlreadyRunning:
+                        StatusMessageLabel.Text = "A patch database operation is already running.";
+                        break;
+                    case Patch2GitResultKind.Failed:
+                        StatusMessageLabel.Text = string.Format("Patch database {0} failed (git exit {1}). {2}",
+                            result.WasClone ? "initialize" : "update", result.ExitCode, LastLogLine(result.Log));
+                        break;
+                    case Patch2GitResultKind.Success:
+                        LoadPatches();   // re-scan config/patch2 from disk so new patches appear immediately
+                        StatusMessageLabel.Text = "Patch database updated — list refreshed. Restart recommended for all changes to take full effect.";
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error("PatchManagerView", ex.ToString());
+                StatusMessageLabel.Text = "Patch database operation failed: " + ex.Message;
+            }
+            finally
+            {
+                InitUpdatePatch2Button.Content = _vm.Patch2ButtonText;
+                InitUpdatePatch2Button.IsEnabled = true;
+            }
+        }
+
+        static string LastLogLine(string log)
+        {
+            if (string.IsNullOrEmpty(log)) return "";
+            var lines = log.Replace("\r", "").Split('\n');
+            for (int i = lines.Length - 1; i >= 0; i--)
+                if (!string.IsNullOrWhiteSpace(lines[i]))
+                    return lines[i].Trim();
+            return "";
         }
 
         /// <summary>

--- a/FEBuilderGBA.Avalonia/Views/ToolUpdateDialogView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ToolUpdateDialogView.axaml
@@ -15,7 +15,7 @@
              about what it does rather than implying update functionality it lacks, and point users to the
              real in-app patch database Initialize/Update surfaces. -->
         <TextBlock TextWrapping="Wrap" Foreground="Gray"
-                   Text="This screen does not check for application updates yet (tracked in issue #1804). To initialize or update the patch database (patch2), use the Patch Manager, or Options → Submodule Remote URLs → “Initialize / Update Patch Database Now”." />
+                   Text="This screen does not check for application updates yet. To initialize or update the patch database (patch2), use the Patch Manager or the Options window." />
 
         <Grid ColumnDefinitions="140,*" RowDefinitions="Auto">
           <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />

--- a/FEBuilderGBA.Avalonia/Views/ToolUpdateDialogView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ToolUpdateDialogView.axaml
@@ -11,6 +11,12 @@
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="Update Checker" FontSize="18" FontWeight="Bold" />
 
+        <!-- #1817: this screen is not an application update-checker yet (tracked in #1804). Be honest
+             about what it does rather than implying update functionality it lacks, and point users to the
+             real in-app patch database Initialize/Update surfaces. -->
+        <TextBlock TextWrapping="Wrap" Foreground="Gray"
+                   Text="This screen does not check for application updates yet (tracked in issue #1804). To initialize or update the patch database (patch2), use the Patch Manager, or Options → Submodule Remote URLs → “Initialize / Update Patch Database Now”." />
+
         <Grid ColumnDefinitions="140,*" RowDefinitions="Auto">
           <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
           <TextBlock AutomationProperties.AutomationId="ToolUpdateDialog_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />

--- a/FEBuilderGBA.Core.Tests/Patch2GitServiceTests.cs
+++ b/FEBuilderGBA.Core.Tests/Patch2GitServiceTests.cs
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1817 — Patch2GitService: cross-platform in-app patch2 initialize (clone) / update (fetch+reset).
+// Deterministic and offline — the git clone/update operations are injected fakes, and each test uses
+// an isolated temp baseDir (GUID) so the REAL backup file-move logic is exercised without network,
+// without a real git, and without cross-test races.
+using System;
+using System.IO;
+using System.Text;
+using FEBuilderGBA;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    public class Patch2GitServiceTests
+    {
+        static string NewBaseDir()
+        {
+            string b = Path.Combine(Path.GetTempPath(), "fe_p2git_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path.Combine(b, "config"));
+            return b;
+        }
+
+        static void Cleanup(string baseDir)
+        {
+            try { if (Directory.Exists(baseDir)) Directory.Delete(baseDir, true); } catch { }
+        }
+
+        static int BackupCount(string baseDir)
+            => Directory.GetDirectories(Path.Combine(baseDir, "config"), "_patch2_backup_*").Length;
+
+        // Fake clone: records whether the target existed at call time and, on "success", creates a
+        // populated target directory the way a real git clone would.
+        sealed class FakeClone
+        {
+            public int Called;
+            public string LastTarget;
+            public bool TargetExistedAtCall;
+            public int ReturnCode;
+            public bool CreateOnSuccess;
+
+            public int Op(string gitExe, string url, string targetPath, Action<string> progress, StringBuilder log)
+            {
+                Called++;
+                LastTarget = targetPath;
+                TargetExistedAtCall = Directory.Exists(targetPath);
+                if (ReturnCode == 0 && CreateOnSuccess)
+                {
+                    Directory.CreateDirectory(targetPath);
+                    File.WriteAllText(Path.Combine(targetPath, "cloned.txt"), "ok");
+                }
+                return ReturnCode;
+            }
+        }
+
+        sealed class FakeUpdate
+        {
+            public int Called;
+            public int ReturnCode;
+            public int Op(string gitExe, string repoPath, Action<string> progress, StringBuilder log, string remoteUrl)
+            {
+                Called++;
+                return ReturnCode;
+            }
+        }
+
+        [Fact]
+        public void GetPatch2Dir_ComposesConfigPatch2()
+        {
+            Assert.Equal(Path.Combine("X", "config", "patch2"), Patch2GitService.GetPatch2Dir("X"));
+        }
+
+        [Fact]
+        public void GitNotFound_WhenGitExeNull()
+        {
+            var r = Patch2GitService.InitializeOrUpdateCore(
+                "any", null, "url", _ => false, new FakeClone().Op, new FakeUpdate().Op, null);
+            Assert.Equal(Patch2GitResultKind.GitNotFound, r.Kind);
+        }
+
+        [Fact]
+        public void ExistingRepo_TakesUpdatePath_NoClone()
+        {
+            string baseDir = NewBaseDir();
+            try
+            {
+                var clone = new FakeClone { ReturnCode = 0, CreateOnSuccess = true };
+                var update = new FakeUpdate { ReturnCode = 0 };
+                var r = Patch2GitService.InitializeOrUpdateCore(
+                    baseDir, "git", "url", _ => true, clone.Op, update.Op, null);
+
+                Assert.Equal(Patch2GitResultKind.Success, r.Kind);
+                Assert.False(r.WasClone);
+                Assert.Equal(1, update.Called);
+                Assert.Equal(0, clone.Called);
+            }
+            finally { Cleanup(baseDir); }
+        }
+
+        [Fact]
+        public void ExistingRepo_UpdateFailure_ReturnsFailed()
+        {
+            string baseDir = NewBaseDir();
+            try
+            {
+                var clone = new FakeClone();
+                var update = new FakeUpdate { ReturnCode = 128 };
+                var r = Patch2GitService.InitializeOrUpdateCore(
+                    baseDir, "git", "url", _ => true, clone.Op, update.Op, null);
+
+                Assert.Equal(Patch2GitResultKind.Failed, r.Kind);
+                Assert.Equal(128, r.ExitCode);
+                Assert.False(r.WasClone);
+                Assert.Equal(0, clone.Called);
+            }
+            finally { Cleanup(baseDir); }
+        }
+
+        [Fact]
+        public void NonExistentDir_ClonesWithNoBackup()
+        {
+            string baseDir = NewBaseDir();
+            try
+            {
+                var clone = new FakeClone { ReturnCode = 0, CreateOnSuccess = true };
+                var r = Patch2GitService.InitializeOrUpdateCore(
+                    baseDir, "git", "url", _ => false, clone.Op, new FakeUpdate().Op, null);
+
+                Assert.Equal(Patch2GitResultKind.Success, r.Kind);
+                Assert.True(r.WasClone);
+                Assert.Equal(1, clone.Called);
+                Assert.False(clone.TargetExistedAtCall);   // clone target must not exist when clone runs
+                Assert.Equal(Patch2GitService.GetPatch2Dir(baseDir), clone.LastTarget);
+                Assert.True(Directory.Exists(Patch2GitService.GetPatch2Dir(baseDir)));
+                Assert.Equal(0, BackupCount(baseDir));
+            }
+            finally { Cleanup(baseDir); }
+        }
+
+        [Fact]
+        public void PreExistingEmptyDir_MovedAsideBeforeClone_Success()
+        {
+            string baseDir = NewBaseDir();
+            try
+            {
+                string patchDir = Patch2GitService.GetPatch2Dir(baseDir);
+                Directory.CreateDirectory(patchDir);   // empty submodule placeholder (zero entries)
+                Assert.Empty(Directory.GetFileSystemEntries(patchDir));
+
+                var clone = new FakeClone { ReturnCode = 0, CreateOnSuccess = true };
+                var r = Patch2GitService.InitializeOrUpdateCore(
+                    baseDir, "git", "url", _ => false, clone.Op, new FakeUpdate().Op, null);
+
+                Assert.Equal(Patch2GitResultKind.Success, r.Kind);
+                Assert.True(r.WasClone);
+                Assert.Equal(1, clone.Called);
+                Assert.False(clone.TargetExistedAtCall);   // the empty dir was moved aside first
+                Assert.True(File.Exists(Path.Combine(patchDir, "cloned.txt")));
+                Assert.Equal(0, BackupCount(baseDir));      // backup removed on success
+            }
+            finally { Cleanup(baseDir); }
+        }
+
+        [Fact]
+        public void PreExistingEmptyDir_CloneFails_RestoresAndNoBackupLeft()
+        {
+            string baseDir = NewBaseDir();
+            try
+            {
+                string patchDir = Patch2GitService.GetPatch2Dir(baseDir);
+                Directory.CreateDirectory(patchDir);   // empty placeholder
+
+                var clone = new FakeClone { ReturnCode = 128, CreateOnSuccess = false };
+                var r = Patch2GitService.InitializeOrUpdateCore(
+                    baseDir, "git", "url", _ => false, clone.Op, new FakeUpdate().Op, null);
+
+                Assert.Equal(Patch2GitResultKind.Failed, r.Kind);
+                Assert.True(r.WasClone);
+                Assert.True(Directory.Exists(patchDir));   // original empty dir restored
+                Assert.Equal(0, BackupCount(baseDir));      // no dangling backup
+            }
+            finally { Cleanup(baseDir); }
+        }
+
+        [Fact]
+        public void PreExistingNonRepoFiles_CloneSuccess_ReplacesAndNoBackup()
+        {
+            string baseDir = NewBaseDir();
+            try
+            {
+                string patchDir = Patch2GitService.GetPatch2Dir(baseDir);
+                Directory.CreateDirectory(patchDir);
+                File.WriteAllText(Path.Combine(patchDir, "stray.txt"), "old");
+
+                var clone = new FakeClone { ReturnCode = 0, CreateOnSuccess = true };
+                var r = Patch2GitService.InitializeOrUpdateCore(
+                    baseDir, "git", "url", _ => false, clone.Op, new FakeUpdate().Op, null);
+
+                Assert.Equal(Patch2GitResultKind.Success, r.Kind);
+                Assert.False(clone.TargetExistedAtCall);
+                Assert.False(File.Exists(Path.Combine(patchDir, "stray.txt")));  // replaced by clone
+                Assert.True(File.Exists(Path.Combine(patchDir, "cloned.txt")));
+                Assert.Equal(0, BackupCount(baseDir));
+            }
+            finally { Cleanup(baseDir); }
+        }
+
+        [Fact]
+        public void PreExistingNonRepoFiles_CloneFails_RestoresMarker()
+        {
+            string baseDir = NewBaseDir();
+            try
+            {
+                string patchDir = Patch2GitService.GetPatch2Dir(baseDir);
+                Directory.CreateDirectory(patchDir);
+                File.WriteAllText(Path.Combine(patchDir, "stray.txt"), "old");
+
+                var clone = new FakeClone { ReturnCode = 1, CreateOnSuccess = false };
+                var r = Patch2GitService.InitializeOrUpdateCore(
+                    baseDir, "git", "url", _ => false, clone.Op, new FakeUpdate().Op, null);
+
+                Assert.Equal(Patch2GitResultKind.Failed, r.Kind);
+                Assert.True(File.Exists(Path.Combine(patchDir, "stray.txt")));  // restored
+                Assert.Equal("old", File.ReadAllText(Path.Combine(patchDir, "stray.txt")));
+                Assert.Equal(0, BackupCount(baseDir));
+            }
+            finally { Cleanup(baseDir); }
+        }
+
+        [Fact]
+        public void SingleFlight_SecondConcurrentCall_ReturnsAlreadyRunning()
+        {
+            Assert.True(Patch2GitService.TryEnter());   // simulate an in-progress operation
+            try
+            {
+                var r = Patch2GitService.InitializeOrUpdate("any", null, null);
+                Assert.Equal(Patch2GitResultKind.AlreadyRunning, r.Kind);
+            }
+            finally
+            {
+                Patch2GitService.Exit();
+            }
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/Patch2GitServiceTests.cs
+++ b/FEBuilderGBA.Core.Tests/Patch2GitServiceTests.cs
@@ -227,6 +227,52 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void PreExistingDir_CloneThrows_RestoresBackupAndReturnsFailed()
+        {
+            string baseDir = NewBaseDir();
+            try
+            {
+                string patchDir = Patch2GitService.GetPatch2Dir(baseDir);
+                Directory.CreateDirectory(patchDir);
+                File.WriteAllText(Path.Combine(patchDir, "stray.txt"), "old");
+
+                Patch2GitService.CloneOp throwingClone =
+                    (g, u, t, p, l) => throw new InvalidOperationException("boom");
+
+                var r = Patch2GitService.InitializeOrUpdateCore(
+                    baseDir, "git", "url", _ => false, throwingClone, new FakeUpdate().Op, null);
+
+                // The clone threw after the move, but no exception escapes and the original dir is restored.
+                Assert.Equal(Patch2GitResultKind.Failed, r.Kind);
+                Assert.True(r.WasClone);
+                Assert.Contains("boom", r.Log);
+                Assert.True(File.Exists(Path.Combine(patchDir, "stray.txt")));
+                Assert.Equal("old", File.ReadAllText(Path.Combine(patchDir, "stray.txt")));
+                Assert.Equal(0, BackupCount(baseDir));   // no dangling backup left behind
+            }
+            finally { Cleanup(baseDir); }
+        }
+
+        [Fact]
+        public void ExistingRepo_UpdateThrows_ReturnsFailedNoThrow()
+        {
+            string baseDir = NewBaseDir();
+            try
+            {
+                Patch2GitService.UpdateOp throwingUpdate =
+                    (g, r, p, l, u) => throw new InvalidOperationException("kaboom");
+
+                var res = Patch2GitService.InitializeOrUpdateCore(
+                    baseDir, "git", "url", _ => true, new FakeClone().Op, throwingUpdate, null);
+
+                Assert.Equal(Patch2GitResultKind.Failed, res.Kind);
+                Assert.False(res.WasClone);
+                Assert.Contains("kaboom", res.Log);
+            }
+            finally { Cleanup(baseDir); }
+        }
+
+        [Fact]
         public void SingleFlight_SecondConcurrentCall_ReturnsAlreadyRunning()
         {
             Assert.True(Patch2GitService.TryEnter());   // simulate an in-progress operation

--- a/FEBuilderGBA.Core/Patch2GitService.cs
+++ b/FEBuilderGBA.Core/Patch2GitService.cs
@@ -1,0 +1,194 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace FEBuilderGBA
+{
+    /// <summary>Outcome of a <see cref="Patch2GitService.InitializeOrUpdate"/> call.</summary>
+    public enum Patch2GitResultKind
+    {
+        Success,
+        GitNotFound,
+        Failed,
+        AlreadyRunning,
+    }
+
+    /// <summary>Result of an in-app patch2 initialize/update operation.</summary>
+    public sealed class Patch2GitResult
+    {
+        public Patch2GitResultKind Kind { get; init; }
+        public int ExitCode { get; init; }
+        public string Log { get; init; } = "";
+        /// <summary>True when the operation took the clone path (fresh init), false for update.</summary>
+        public bool WasClone { get; init; }
+        public bool Success => Kind == Patch2GitResultKind.Success;
+    }
+
+    /// <summary>
+    /// Cross-platform, in-app initialize/update of the git-delivered <c>config/patch2</c> database.
+    ///
+    /// Lifts the clone-or-update-with-backup decision (previously inline and WinForms-only in
+    /// <c>ToolUpdateDialogForm.AutoUpdatePatch2Git</c>) into a reusable, unit-testable Core service so
+    /// the Avalonia GUI (#1817) can offer real in-app Initialize/Update — the Avalonia half of #1812 —
+    /// without duplicating the logic. The proven WinForms flow is mirrored exactly: if the directory is
+    /// already a git repo → <c>git fetch + reset</c>; otherwise move any existing directory aside
+    /// (including an empty submodule placeholder from a non-recursive clone) and <c>git clone</c>,
+    /// restoring the backup on failure.
+    /// </summary>
+    public static class Patch2GitService
+    {
+        // Single-flight guard (#1817 review board): Options and the Patch Manager can both trigger this,
+        // and they are independently openable windows — the same config/patch2 directory must never be
+        // backed-up/cloned by two threads at once. A second concurrent call returns AlreadyRunning.
+        static readonly object _gate = new object();
+        static bool _running;
+
+        /// <summary>Repo-root patch database directory: <c>&lt;baseDir&gt;/config/patch2</c>.</summary>
+        public static string GetPatch2Dir(string baseDir)
+            => Path.Combine(baseDir ?? "", "config", "patch2");
+
+        /// <summary>Delegate matching <see cref="GitUtil.Clone"/> so tests can inject a fake.</summary>
+        public delegate int CloneOp(string gitExe, string url, string targetPath, Action<string> progress, StringBuilder log);
+
+        /// <summary>Delegate matching <see cref="GitUtil.Update"/> so tests can inject a fake.</summary>
+        public delegate int UpdateOp(string gitExe, string repoPath, Action<string> progress, StringBuilder log, string remoteUrl);
+
+        /// <summary>
+        /// Public entry: resolves the git executable and remote URL from the environment/config, then
+        /// runs the clone-or-update. Synchronous — callers wrap it in <c>Task.Run</c>. <paramref name="progress"/>
+        /// (nullable) receives git output lines on a background thread. <paramref name="urlOverride"/>
+        /// (nullable) forces a specific remote (used by the Options "Initialize / Update now" button so a
+        /// just-typed custom fork URL takes effect for both the clone and the update remote).
+        /// Guarded by a single-flight lock: a concurrent second call returns <see cref="Patch2GitResultKind.AlreadyRunning"/>.
+        /// </summary>
+        public static Patch2GitResult InitializeOrUpdate(string baseDir, Action<string> progress = null, string urlOverride = null)
+        {
+            if (!TryEnter())
+                return new Patch2GitResult { Kind = Patch2GitResultKind.AlreadyRunning };
+            try
+            {
+                string gitExe = GitUtil.FindGitExecutable();
+                string url = string.IsNullOrWhiteSpace(urlOverride) ? GitUtil.GetPatch2RemoteUrl() : urlOverride;
+                return InitializeOrUpdateCore(baseDir, gitExe, url, GitUtil.IsGitRepo, GitUtil.Clone, GitUtil.Update, progress);
+            }
+            finally
+            {
+                Exit();
+            }
+        }
+
+        /// <summary>
+        /// Testable core with all external dependencies injected — exercises the REAL backup file-move
+        /// logic so tests need no network or git. Pure (no static/guard state) so parallel tests using
+        /// isolated temp directories never race. <paramref name="gitExe"/> null/empty → GitNotFound.
+        /// </summary>
+        internal static Patch2GitResult InitializeOrUpdateCore(
+            string baseDir, string gitExe, string url,
+            Func<string, bool> isGitRepo, CloneOp cloneOp, UpdateOp updateOp,
+            Action<string> progress)
+        {
+            if (string.IsNullOrEmpty(gitExe))
+                return new Patch2GitResult { Kind = Patch2GitResultKind.GitNotFound };
+
+            string patchDir = GetPatch2Dir(baseDir);
+            var log = new StringBuilder();
+
+            // UPDATE path — the directory is already a real git repo.
+            if (isGitRepo(patchDir))
+            {
+                int code = updateOp(gitExe, patchDir, progress, log, url);
+                return new Patch2GitResult
+                {
+                    Kind = code == 0 ? Patch2GitResultKind.Success : Patch2GitResultKind.Failed,
+                    ExitCode = code,
+                    Log = log.ToString(),
+                    WasClone = false,
+                };
+            }
+
+            // CLONE path. Move ANY existing directory aside first — including an empty submodule
+            // placeholder left by a non-recursive superproject clone (the single most common "needs
+            // Initialize" state) — so the clone target does not exist and we can roll back cleanly if
+            // the clone fails partway (otherwise partial .git debris would flip the next run onto the
+            // wrong IsGitRepo->Update branch).
+            string backupPath = null;
+            if (Directory.Exists(patchDir))
+            {
+                backupPath = Path.Combine(
+                    Path.GetDirectoryName(patchDir) ?? "",
+                    "_patch2_backup_" + DateTime.Now.Ticks.ToString());
+
+                // Guard against a stale backup directory from a previously aborted run so
+                // Directory.Move never throws on an existing destination.
+                if (Directory.Exists(backupPath))
+                    Directory.Delete(backupPath, true);
+
+                Directory.Move(patchDir, backupPath);
+            }
+
+            int cloneCode = cloneOp(gitExe, url, patchDir, progress, log);
+            if (cloneCode != 0)
+            {
+                // Restore the backup on failure — best-effort, leaving the tree as we found it.
+                try
+                {
+                    if (Directory.Exists(patchDir))
+                        Directory.Delete(patchDir, true);
+                    if (backupPath != null && Directory.Exists(backupPath))
+                        Directory.Move(backupPath, patchDir);
+                }
+                catch
+                {
+                    // Restore is best-effort; the accumulated log still explains the clone failure.
+                }
+
+                return new Patch2GitResult
+                {
+                    Kind = Patch2GitResultKind.Failed,
+                    ExitCode = cloneCode,
+                    Log = log.ToString(),
+                    WasClone = true,
+                };
+            }
+
+            // Success — drop the backup (a leftover backup is harmless but wastes disk).
+            if (backupPath != null)
+            {
+                try
+                {
+                    if (Directory.Exists(backupPath))
+                        Directory.Delete(backupPath, true);
+                }
+                catch
+                {
+                    // A leftover backup directory is non-fatal.
+                }
+            }
+
+            return new Patch2GitResult
+            {
+                Kind = Patch2GitResultKind.Success,
+                ExitCode = 0,
+                Log = log.ToString(),
+                WasClone = true,
+            };
+        }
+
+        /// <summary>Acquire the single-flight guard. Internal for deterministic re-entrancy tests.</summary>
+        internal static bool TryEnter()
+        {
+            lock (_gate)
+            {
+                if (_running) return false;
+                _running = true;
+                return true;
+            }
+        }
+
+        /// <summary>Release the single-flight guard.</summary>
+        internal static void Exit()
+        {
+            lock (_gate) { _running = false; }
+        }
+    }
+}

--- a/FEBuilderGBA.Core/Patch2GitService.cs
+++ b/FEBuilderGBA.Core/Patch2GitService.cs
@@ -96,7 +96,25 @@ namespace FEBuilderGBA
             // UPDATE path — the directory is already a real git repo.
             if (isGitRepo(patchDir))
             {
-                int code = updateOp(gitExe, patchDir, progress, log, url);
+                int code;
+                try
+                {
+                    code = updateOp(gitExe, patchDir, progress, log, url);
+                }
+                catch (Exception ex)
+                {
+                    // Report as Failed (with the exception in the log) rather than letting it escape,
+                    // so both entry points get a uniform result-based error path. Nothing was moved,
+                    // so there is no backup to restore here.
+                    log.AppendLine(ex.ToString());
+                    return new Patch2GitResult
+                    {
+                        Kind = Patch2GitResultKind.Failed,
+                        ExitCode = -1,
+                        Log = log.ToString(),
+                        WasClone = false,
+                    };
+                }
                 return new Patch2GitResult
                 {
                     Kind = code == 0 ? Patch2GitResultKind.Success : Patch2GitResultKind.Failed,
@@ -126,21 +144,31 @@ namespace FEBuilderGBA
                 Directory.Move(patchDir, backupPath);
             }
 
-            int cloneCode = cloneOp(gitExe, url, patchDir, progress, log);
+            int cloneCode;
+            try
+            {
+                cloneCode = cloneOp(gitExe, url, patchDir, progress, log);
+            }
+            catch (Exception ex)
+            {
+                // The clone op threw AFTER we moved the existing directory aside — restore the backup so
+                // the patch database is never left stranded under _patch2_backup_*, capture the exception
+                // in the log, and report Failed (no exception escapes to strand state).
+                log.AppendLine(ex.ToString());
+                RestoreBackup(patchDir, backupPath);
+                return new Patch2GitResult
+                {
+                    Kind = Patch2GitResultKind.Failed,
+                    ExitCode = -1,
+                    Log = log.ToString(),
+                    WasClone = true,
+                };
+            }
+
             if (cloneCode != 0)
             {
                 // Restore the backup on failure — best-effort, leaving the tree as we found it.
-                try
-                {
-                    if (Directory.Exists(patchDir))
-                        Directory.Delete(patchDir, true);
-                    if (backupPath != null && Directory.Exists(backupPath))
-                        Directory.Move(backupPath, patchDir);
-                }
-                catch
-                {
-                    // Restore is best-effort; the accumulated log still explains the clone failure.
-                }
+                RestoreBackup(patchDir, backupPath);
 
                 return new Patch2GitResult
                 {
@@ -172,6 +200,22 @@ namespace FEBuilderGBA
                 Log = log.ToString(),
                 WasClone = true,
             };
+        }
+
+        /// <summary>Best-effort restore of a backed-up patch2 directory after a failed/throwing clone.</summary>
+        static void RestoreBackup(string patchDir, string backupPath)
+        {
+            try
+            {
+                if (Directory.Exists(patchDir))
+                    Directory.Delete(patchDir, true);
+                if (backupPath != null && Directory.Exists(backupPath))
+                    Directory.Move(backupPath, patchDir);
+            }
+            catch
+            {
+                // Restore is best-effort; the accumulated log / thrown exception still explains the failure.
+            }
         }
 
         /// <summary>Acquire the single-flight guard. Internal for deterministic re-entrancy tests.</summary>

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -14162,3 +14162,12 @@ ROM（.gba）は絶対に添付しないでください。
 
 :Type to filter the command list (case-insensitive substring).
 コマンド一覧を絞り込む文字列を入力します（大文字小文字を区別しない部分一致）。
+
+:Initialize Patch Database
+パッチデータベースを初期化
+
+:Initialize / Update Patch Database Now
+パッチデータベースを今すぐ初期化／更新
+
+:This screen does not check for application updates yet. To initialize or update the patch database (patch2), use the Patch Manager or the Options window.
+この画面はまだアプリケーションの更新を確認しません。パッチデータベース（patch2）を初期化または更新するには、パッチマネージャまたはオプション画面を使用してください。

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -27983,3 +27983,12 @@ ROM 重建需要桌面文件系统访问权限，本设备不可用。
 
 :Type to filter the command list (case-insensitive substring).
 输入以筛选命令列表（不区分大小写的子串匹配）。
+
+:Initialize Patch Database
+初始化补丁数据库
+
+:Initialize / Update Patch Database Now
+立即初始化/更新补丁数据库
+
+:This screen does not check for application updates yet. To initialize or update the patch database (patch2), use the Patch Manager or the Options window.
+此界面尚不检查应用程序更新。要初始化或更新补丁数据库（patch2），请使用补丁管理器或选项窗口。


### PR DESCRIPTION
## Summary

Adds real **in-app Initialize (clone) / Update (fetch+reset)** of the git-delivered `config/patch2` database to the **Avalonia** GUI — the Avalonia half of #1812. Previously `GitUtil.Clone`/`GitUtil.Update` existed in Core and were wired only in WinForms, so an Avalonia user with an empty `config/patch2` (the #1808/#1811 fresh-download state) had **no in-app way** to fetch or update the patch database; the Update Checker was an inert stub and Options only set the remote URL.

Plan + cross-model plan board: issue #1817 (all three models BLOCKed the first plan; every required fix was adopted — see the `## Cross-Model Review Board` comment there).

## Scope (per the dual-GUI policy)

New feature → **Avalonia only**; WinForms (stable) is untouched. patch2 only — FE-Repo/FE-Repo-Midi = #1813, first-run wizard = #1814, app update-checker = #1804.

## What changed

- **Core `Patch2GitService`** — reusable, unit-tested clone-or-update-with-backup service lifting the proven WinForms `AutoUpdatePatch2Git` decision out of the GUI. Single-flight guard (both entry points), moves **any** existing dir aside before clone (incl. an empty submodule placeholder), unique+guarded backup path, restore-on-failure. Injectable seam for offline deterministic tests.
- **Patch Manager** — always-visible **Initialize / Update Patch Database** button (label derived from the repo-root `config/patch2` git status via `GetPatch2Dir(CoreState.BaseDirectory)`), off-thread with ~150 ms-throttled progress, synchronous disable + `try/finally` re-enable, refreshes the list and shows an accurate restart-recommended message on success.
- **Options** — **Initialize / Update Patch Database Now** button next to the Patch2 URL; passes the textbox URL directly (`urlOverride`) and persists **only** `submodule_patch2_url`.
- **Update Checker stub** — honest text pointing users to the Patch Manager / Options (app updater tracked in #1804), instead of implying update functionality it lacks.

## Screenshots

Avalonia Patch Manager with an empty `config/patch2` — the new **Initialize Patch Database** button in the left panel (rendered with the real desktop Skia rasterizer via `--screenshot-window=PatchManagerView`):

![Patch Manager Initialize/Update](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/1817/patchmanager-init.png)

## GUI Test Report

| # | GUI check | Result |
|---|---|---|
| 1 | Patch Manager renders the new **Initialize Patch Database** button in the empty-state (real Skia render, screenshot above) | ✅ Pass |
| 2 | `PatchManagerView` exposes `InitUpdatePatch2Button` headlessly with non-empty content (`Patch2InitUpdateViewTests`) | ✅ Pass |
| 3 | `OptionsView` exposes `InitUpdatePatch2Button` headlessly (`Patch2InitUpdateViewTests`) | ✅ Pass |
| 4 | Button label = "Initialize Patch Database" (non-repo `config/patch2`) / "Update Patch Database" (git repo), via repo-root base dir (`Patch2InitUpdateButtonTests`) | ✅ Pass |
| 5 | No regression across PatchManager/Options/ToolUpdateDialog/ControlProperty/AndroidResource views (90 tests) | ✅ Pass |

## Test plan

- [x] `dotnet build FEBuilderGBA.Core` (Release) — 0 errors
- [x] `dotnet build FEBuilderGBA.Avalonia` (Release) — 0 errors
- [x] Core `Patch2GitServiceTests` — **10/10 passed** (GitNotFound; existing-repo→update + update-failure; non-existent→clone; pre-existing **empty** dir moved-aside→clone success **and** clone-fail restore; non-repo-files replace-on-success **and** restore-on-fail; single-flight → AlreadyRunning; `GetPatch2Dir`)
- [x] Avalonia `Patch2InitUpdateButtonTests` + `Patch2InitUpdateViewTests` — **4/4 passed**
- [x] Regression: `PatchManager|Options|ToolUpdateDialog|ControlProperty|AndroidResource` — **90/90 passed**
- [x] Structural: `AvaloniaScrollViewer` source-scan — **3/3 passed**
- [x] Real GUI screenshot rendered via `--screenshot-window=PatchManagerView` (desktop Skia), shown above

Closes #1817

Copilot CLI: 1.0.69-0
Model: Claude Opus 4.8 (claude-opus-4.8)
