### PR TITLE
feat(winforms): in-app patch2 Initialize/Update buttons via Patch2GitService (#1812)

### DIFF
--- a/FEBuilderGBA.Tests/Unit/Patch2InitUpdateWinFormsTests.cs
+++ b/FEBuilderGBA.Tests/Unit/Patch2InitUpdateWinFormsTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Reflection;
+using System.Windows.Forms;
+using Xunit;
+
+namespace FEBuilderGBA.Tests.Unit
+{
+    /// <summary>
+    /// #1812: verifies the WinForms in-app patch2 Initialize/Update wiring is present — the shared
+    /// <see cref="Patch2GitWinForms.RunInitUpdate"/> host plus the OptionForm and PatchForm buttons +
+    /// click handlers. The clone/update logic itself is covered by the 12 cross-platform
+    /// <c>Patch2GitServiceTests</c> (Core); a real WinForms form instantiation here would require a
+    /// live ROM (PatchForm) / config + a translation-matched "Etc" tab (OptionForm), so the button
+    /// creation is proven visually by the PR screenshot instead. This structural test guards against
+    /// the wiring being renamed/removed (which would silently break the buttons).
+    /// </summary>
+    public class Patch2InitUpdateWinFormsTests
+    {
+        const BindingFlags NonPublicInstance = BindingFlags.NonPublic | BindingFlags.Instance;
+
+        [Fact]
+        public void Patch2GitWinForms_RunInitUpdate_HasExpectedSignature()
+        {
+            MethodInfo m = typeof(Patch2GitWinForms).GetMethod(
+                "RunInitUpdate", new[] { typeof(Form), typeof(string) });
+            Assert.NotNull(m);
+            Assert.True(m.IsStatic);
+            Assert.Equal(typeof(Patch2GitResult), m.ReturnType);
+        }
+
+        [Fact]
+        public void OptionForm_HasPatch2InitUpdateButtonFieldAndHandler()
+        {
+            Assert.NotNull(typeof(OptionForm).GetField("_optionPatch2InitUpdateButton", NonPublicInstance));
+            Assert.NotNull(typeof(OptionForm).GetMethod("OptionPatch2InitUpdateButton_Click", NonPublicInstance));
+        }
+
+        [Fact]
+        public void PatchForm_HasPatch2InitUpdateButtonCreatorAndHandler()
+        {
+            Assert.NotNull(typeof(PatchForm).GetMethod("AddPatch2InitUpdateButton", NonPublicInstance));
+            Assert.NotNull(typeof(PatchForm).GetMethod("Patch2InitUpdateButton_Click", NonPublicInstance));
+        }
+    }
+}

--- a/FEBuilderGBA/OptionForm.cs
+++ b/FEBuilderGBA/OptionForm.cs
@@ -2030,7 +2030,8 @@ namespace FEBuilderGBA
             // #1812: persist ONLY the patch2 URL key (not the whole form / not SaveSubmoduleUrls, which
             // would also commit + SetSubmoduleRemote the unsaved FE-Repo/Music fields) so a custom fork
             // URL survives later auto-updates, then run the init/update passing that URL directly.
-            string url = _submodulePatch2Url.Text ?? "";
+            string url = (_submodulePatch2Url.Text ?? "").Trim();
+            _submodulePatch2Url.Text = url; // reflect the trim back so a stray space can't be re-saved
             Program.Config["submodule_patch2_url"] = url;
             Program.Config.Save();
 

--- a/FEBuilderGBA/OptionForm.cs
+++ b/FEBuilderGBA/OptionForm.cs
@@ -1961,6 +1961,7 @@ namespace FEBuilderGBA
         TextBox _submodulePatch2Url;
         TextBox _submoduleFERepoUrl;
         TextBox _submoduleFERepoMusicUrl;
+        Button _optionPatch2InitUpdateButton;
 
         void LoadSubmoduleUrls()
         {
@@ -1985,13 +1986,13 @@ namespace FEBuilderGBA
                             {
                                 Text = R._("Submodule Remote URLs"),
                                 Dock = DockStyle.Bottom,
-                                Height = 110
+                                Height = 150
                             };
                             var panel = new TableLayoutPanel
                             {
                                 Dock = DockStyle.Fill,
                                 ColumnCount = 2,
-                                RowCount = 3,
+                                RowCount = 4,
                                 Padding = new Padding(4)
                             };
                             panel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 120));
@@ -1999,11 +2000,21 @@ namespace FEBuilderGBA
                             panel.Controls.Add(new Label { Text = "Patch2 URL:", Dock = DockStyle.Fill }, 0, 0);
                             panel.Controls.Add(_submodulePatch2Url, 1, 0);
                             _submodulePatch2Url.Dock = DockStyle.Fill;
-                            panel.Controls.Add(new Label { Text = "FE-Repo URL:", Dock = DockStyle.Fill }, 0, 1);
-                            panel.Controls.Add(_submoduleFERepoUrl, 1, 1);
+                            // #1812: one-click in-app patch2 Initialize/Update, directly under its URL field.
+                            _optionPatch2InitUpdateButton = new Button
+                            {
+                                Name = "OptionPatch2InitUpdateButton",
+                                Text = R._("Initialize / Update Patch2 Now"),
+                                AutoSize = true,
+                                Anchor = AnchorStyles.Left
+                            };
+                            _optionPatch2InitUpdateButton.Click += OptionPatch2InitUpdateButton_Click;
+                            panel.Controls.Add(_optionPatch2InitUpdateButton, 1, 1);
+                            panel.Controls.Add(new Label { Text = "FE-Repo URL:", Dock = DockStyle.Fill }, 0, 2);
+                            panel.Controls.Add(_submoduleFERepoUrl, 1, 2);
                             _submoduleFERepoUrl.Dock = DockStyle.Fill;
-                            panel.Controls.Add(new Label { Text = "Music URL:", Dock = DockStyle.Fill }, 0, 2);
-                            panel.Controls.Add(_submoduleFERepoMusicUrl, 1, 2);
+                            panel.Controls.Add(new Label { Text = "Music URL:", Dock = DockStyle.Fill }, 0, 3);
+                            panel.Controls.Add(_submoduleFERepoMusicUrl, 1, 3);
                             _submoduleFERepoMusicUrl.Dock = DockStyle.Fill;
                             grp.Controls.Add(panel);
                             tp.Controls.Add(grp);
@@ -2011,6 +2022,26 @@ namespace FEBuilderGBA
                         }
                     }
                 }
+            }
+        }
+
+        void OptionPatch2InitUpdateButton_Click(object sender, EventArgs e)
+        {
+            // #1812: persist ONLY the patch2 URL key (not the whole form / not SaveSubmoduleUrls, which
+            // would also commit + SetSubmoduleRemote the unsaved FE-Repo/Music fields) so a custom fork
+            // URL survives later auto-updates, then run the init/update passing that URL directly.
+            string url = _submodulePatch2Url.Text ?? "";
+            Program.Config["submodule_patch2_url"] = url;
+            Program.Config.Save();
+
+            _optionPatch2InitUpdateButton.Enabled = false;
+            try
+            {
+                Patch2GitWinForms.RunInitUpdate(this, string.IsNullOrWhiteSpace(url) ? null : url);
+            }
+            finally
+            {
+                _optionPatch2InitUpdateButton.Enabled = true;
             }
         }
 

--- a/FEBuilderGBA/Patch2GitWinForms.cs
+++ b/FEBuilderGBA/Patch2GitWinForms.cs
@@ -49,7 +49,28 @@ namespace FEBuilderGBA
                         System.Windows.Forms.Application.DoEvents();
                     System.Threading.Thread.Sleep(80);
                 }
-                result = task.Result;
+
+                // Flush any final progress line that arrived just before the task completed.
+                string lastFlush = System.Threading.Interlocked.Exchange(ref lastLine[0], null);
+                if (!string.IsNullOrEmpty(lastFlush))
+                    pleaseWait.DoEvents(lastFlush);
+
+                try
+                {
+                    result = task.Result;
+                }
+                catch (Exception ex)
+                {
+                    // Patch2GitService is result-based for the git ops themselves, but its backup file-move
+                    // (Directory.Move/Delete) can still throw on a real I/O error — convert a faulted Task
+                    // into a Failed result so reading task.Result never crashes the UI.
+                    result = new Patch2GitResult
+                    {
+                        Kind = Patch2GitResultKind.Failed,
+                        ExitCode = -1,
+                        Log = (ex.InnerException ?? ex).ToString(),
+                    };
+                }
             }
 
             // Back on the UI thread after the using block — show the localized result.
@@ -62,10 +83,11 @@ namespace FEBuilderGBA
                     R.ShowStopError("A patch database operation is already running.");
                     break;
                 case Patch2GitResultKind.Failed:
+                    string logTail = string.IsNullOrEmpty(result.Log) ? "" : "\r\n\r\n" + result.Log.Trim();
                     if (result.WasClone)
-                        R.ShowStopError("Patch database initialization failed (git exit {0}).", result.ExitCode);
+                        R.ShowStopError("Patch database initialization failed (git exit {0}).{1}", result.ExitCode, logTail);
                     else
-                        R.ShowStopError("Patch database update failed (git exit {0}).", result.ExitCode);
+                        R.ShowStopError("Patch database update failed (git exit {0}).{1}", result.ExitCode, logTail);
                     break;
                 case Patch2GitResultKind.Success:
                     R.ShowOK("Patch database updated. Restart recommended for all changes to take full effect.");

--- a/FEBuilderGBA/Patch2GitWinForms.cs
+++ b/FEBuilderGBA/Patch2GitWinForms.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Windows.Forms;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// #1812: WinForms host for the cross-platform <see cref="Patch2GitService"/> — runs an in-app
+    /// patch2 Initialize (clone) / Update (fetch+reset) with the standard <see cref="InputFormRef.AutoPleaseWait"/>
+    /// progress pump, mirroring <c>ToolUpdateDialogForm.AutoUpdatePatch2Git</c>. Shared by the OptionForm
+    /// and PatchForm "Initialize / Update Patch2" buttons so the logic lives in exactly one place and all
+    /// WinForms patch2 entry points go through the same single-flight guard inside Patch2GitService.
+    /// </summary>
+    public static class Patch2GitWinForms
+    {
+        /// <summary>
+        /// Runs the patch2 init/update synchronously on the UI thread (pumping the message loop while the
+        /// git op runs on a background Task) and shows the localized result. Returns the
+        /// <see cref="Patch2GitResult"/> so callers (e.g. PatchForm) can rescan on success.
+        /// <paramref name="urlOverride"/> (nullable) forces a specific remote — OptionForm passes its
+        /// Patch2 URL textbox so a just-typed custom fork URL takes effect.
+        /// </summary>
+        public static Patch2GitResult RunInitUpdate(Form owner, string urlOverride)
+        {
+            Patch2GitResult result;
+
+            using (InputFormRef.AutoPleaseWait pleaseWait = new InputFormRef.AutoPleaseWait(owner))
+            {
+                // lastLine[0] is written by the git output callback on the background thread and consumed
+                // by the UI-thread poll loop via Interlocked — the callback never touches any UI control
+                // (InputFormRef.DoEvents no-ops on a background thread, so it must not be called there).
+                var lastLine = new string[1];
+                Action<string> progress = line =>
+                {
+                    if (!string.IsNullOrEmpty(line))
+                        System.Threading.Interlocked.Exchange(ref lastLine[0], line);
+                };
+
+                pleaseWait.DoEvents("Git: patch2 ...");
+                var task = System.Threading.Tasks.Task.Run(
+                    () => Patch2GitService.InitializeOrUpdate(Program.BaseDirectory, progress, urlOverride));
+
+                // Pump the UI message loop while the background git op runs (mirror PollGitProgress).
+                while (!task.IsCompleted)
+                {
+                    string line = System.Threading.Interlocked.Exchange(ref lastLine[0], null);
+                    if (!string.IsNullOrEmpty(line))
+                        pleaseWait.DoEvents(line);
+                    else
+                        System.Windows.Forms.Application.DoEvents();
+                    System.Threading.Thread.Sleep(80);
+                }
+                result = task.Result;
+            }
+
+            // Back on the UI thread after the using block — show the localized result.
+            switch (result.Kind)
+            {
+                case Patch2GitResultKind.GitNotFound:
+                    R.ShowStopError("Git was not found. Install Git and try again, or set up config/patch2 manually — see the Patch Database Setup wiki page.");
+                    break;
+                case Patch2GitResultKind.AlreadyRunning:
+                    R.ShowStopError("A patch database operation is already running.");
+                    break;
+                case Patch2GitResultKind.Failed:
+                    if (result.WasClone)
+                        R.ShowStopError("Patch database initialization failed (git exit {0}).", result.ExitCode);
+                    else
+                        R.ShowStopError("Patch database update failed (git exit {0}).", result.ExitCode);
+                    break;
+                case Patch2GitResultKind.Success:
+                    R.ShowOK("Patch database updated. Restart recommended for all changes to take full effect.");
+                    break;
+            }
+
+            return result;
+        }
+    }
+}

--- a/FEBuilderGBA/Patch2GitWinForms.cs
+++ b/FEBuilderGBA/Patch2GitWinForms.cs
@@ -84,7 +84,11 @@ namespace FEBuilderGBA
                     break;
                 case Patch2GitResultKind.Failed:
                     string logTail = string.IsNullOrEmpty(result.Log) ? "" : "\r\n\r\n" + result.Log.Trim();
-                    if (result.WasClone)
+                    if (result.ExitCode < 0)
+                        // Exception-synthesized fallback (a rare backup file-move I/O failure) — the
+                        // clone/update distinction isn't reliably known here, so use neutral wording.
+                        R.ShowStopError("Patch database operation failed.{0}", logTail);
+                    else if (result.WasClone)
                         R.ShowStopError("Patch database initialization failed (git exit {0}).{1}", result.ExitCode, logTail);
                     else
                         R.ShowStopError("Patch database update failed (git exit {0}).{1}", result.ExitCode, logTail);

--- a/FEBuilderGBA/PatchForm.cs
+++ b/FEBuilderGBA/PatchForm.cs
@@ -20,12 +20,48 @@ namespace FEBuilderGBA
         {
             InitializeComponent();
 
+            AddPatch2InitUpdateButton(); // #1812
             fixDocsBugs = new U.FixDocsBugs(this);
 //            InputFormRef.TabControlHideTabOption(this.TAB);
             ClearCheckIF();
             ReScan();
             this.PatchList.OwnerDraw(ListBoxEx.DrawTextOnly, DrawMode.Normal);
             InputFormRef.markupJumpLabel(this.FilterExLabel);
+        }
+
+        // #1812: one-click in-app patch2 Initialize/Update surfaced directly in the Patch Manager, next
+        // to Open/Reload, so when the #1811 empty-patch2 notice appears the user can fix it in one click.
+        // Added programmatically (widening the existing right-docked button panel) to avoid Designer churn.
+        void AddPatch2InitUpdateButton()
+        {
+            var btn = new Button
+            {
+                Name = "PatchFormPatch2InitUpdateButton",
+                Text = R._("Init/Update Patch2"),
+                Location = new Point(426, -2),
+                Size = new Size(195, 41),
+                Margin = new Padding(2),
+                UseVisualStyleBackColor = true,
+            };
+            btn.Click += Patch2InitUpdateButton_Click;
+            this.panel5.Size = new Size(625, this.panel5.Size.Height);
+            this.panel5.Controls.Add(btn);
+        }
+
+        void Patch2InitUpdateButton_Click(object sender, EventArgs e)
+        {
+            Control btn = sender as Control;
+            if (btn != null) btn.Enabled = false;
+            try
+            {
+                Patch2GitResult r = Patch2GitWinForms.RunInitUpdate(this, null);
+                if (r.Success)
+                    ReScan(); // patches were just fetched → rescan so they appear without a restart
+            }
+            finally
+            {
+                if (btn != null) btn.Enabled = true;
+            }
         }
 
         U.FixDocsBugs fixDocsBugs;

--- a/FEBuilderGBA/ToolUpdateDialogForm.cs
+++ b/FEBuilderGBA/ToolUpdateDialogForm.cs
@@ -156,6 +156,17 @@ namespace FEBuilderGBA
                 return;
             }
 
+            // #1812: participate in Patch2GitService's single-flight guard so this legacy inline path and
+            // the new OptionForm/PatchForm buttons (which go through Patch2GitService) never mutate
+            // config/patch2 concurrently. Non-blocking: a concurrent trigger is rejected here.
+            if (!Patch2GitService.TryEnter())
+            {
+                R.ShowStopError("A patch database operation is already running.");
+                return;
+            }
+            try
+            {
+
             // Resolve git executable — auto-install if not found
             string gitExe = GitUtil.FindGitExecutable();
             if (gitExe == null)
@@ -256,6 +267,12 @@ namespace FEBuilderGBA
             R.ShowOK("パッチデータの更新が完了しました。\r\n変更を反映するには再起動してください。");
             this.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.Close();
+
+            }
+            finally
+            {
+                Patch2GitService.Exit();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Completes the **WinForms half of #1812** (the Avalonia half shipped in #1817), reusing the board-reviewed cross-platform **`Patch2GitService`**. WinForms now has one-click in-app **Initialize (clone) / Update (fetch+reset)** of the git-delivered `config/patch2` database, next to its remote-URL setting and in the Patch Manager — closing the #1808/#1811 onboarding gap on Windows.

Plan + cross-model plan board on the issue (all three models BLOCKed the first plan; every required fix adopted — see the `## Cross-Model Review Board` comment on #1812).

## Scope

#1812 explicitly exempts this blocking onboarding infra from the WinForms freeze. WinForms only; **patch2 only** (FE-Repo/FE-Repo-Midi = #1813, first-run wizard = #1814). Reuses `Patch2GitService` unchanged — no new Core logic.

## What changed

- **`OptionForm`** — "Initialize / Update Patch2 Now" button directly under the Patch2 URL field (Submodule Remote URLs / Etc tab). Persists **only** `submodule_patch2_url` (+ `Config.Save()`) — never the whole form / `SaveSubmoduleUrls()` — and passes it as `urlOverride`.
- **`PatchForm`** (Patch Manager) — "Init/Update Patch2" button in the always-visible bottom bar; **rescans on success** so patches appear without a restart.
- **`Patch2GitWinForms.RunInitUpdate`** — shared helper mirroring `AutoUpdatePatch2Git`'s proven `Task.Run` + `AutoPleaseWait` **poll pattern** (git progress via an `Interlocked` buffer on the worker thread; result dialogs on the UI thread; `GitNotFound` points to the Patch Database Setup wiki).
- **`AutoUpdatePatch2Git`** now participates in `Patch2GitService`'s single-flight guard (`TryEnter/Exit`) so all three WinForms patch2 entry points can't mutate `config/patch2` concurrently.
- Both buttons disable on click and re-enable in a `finally`.

## Screenshots

WinForms **OptionForm → Etc tab**, showing the new **Initialize / Update Patch2 Now** button directly under the Patch2 URL (real GUI render via a `Show()`-based STA capture — `DrawToBitmap` on the actual form):

![OptionForm patch2 button](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/1812/optionform-patch2-button.png)

## GUI Test Report

| # | GUI check | Result |
|---|---|---|
| 1 | OptionForm Submodule tab renders the new **Initialize / Update Patch2 Now** button under the Patch2 URL (real `Show()`-rendered capture, above) | ✅ Pass |
| 2 | `OptionForm` exposes the `_optionPatch2InitUpdateButton` field + `OptionPatch2InitUpdateButton_Click` handler (`Patch2InitUpdateWinFormsTests`) | ✅ Pass |
| 3 | `PatchForm` exposes `AddPatch2InitUpdateButton` + `Patch2InitUpdateButton_Click` (`Patch2InitUpdateWinFormsTests`) | ✅ Pass |
| 4 | `Patch2GitWinForms.RunInitUpdate(Form, string) → Patch2GitResult` present | ✅ Pass |
| 5 | No regression across Patch2 / ToolUpdateDialog / OptionForm tests (12 tests) | ✅ Pass |

## Test plan

- [x] WinForms build (`msbuild /p:Configuration=Release /p:Platform=x86 /t:build /restore`) — 0 errors
- [x] `Patch2InitUpdateWinFormsTests` (structural wiring: helper signature + both forms' button field/creator + handlers) — **3/3 passed**
- [x] Regression: `Patch2 | ToolUpdateDialog | OptionForm` filters — **12/12 passed** (incl. the #1816 `ToolUpdateDialogPatch2Tests` after the single-flight guard wrap)
- [x] Clone/update/backup/single-flight logic covered by the reused Core `Patch2GitServiceTests` — **12/12** (from #1817)
- [x] Real WinForms GUI screenshot of the actual OptionForm with the new button (above)

Closes #1812

Copilot CLI: 1.0.69-0
Model: Claude Opus 4.8 (claude-opus-4.8)
