### PR TITLE
feat: content-repo Init/Update for FE-Repo & FE-Repo-Midi; fix dead OptionForm group (#1813)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/Patch2InitUpdateButtonTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/Patch2InitUpdateButtonTests.cs
@@ -75,5 +75,13 @@ namespace FEBuilderGBA.Avalonia.Tests
             var btn = view.FindControl<Button>("InitUpdatePatch2Button");
             Assert.NotNull(btn);
         }
+
+        [AvaloniaFact]
+        public void OptionsView_HasFERepoAndMusicInitUpdateButtons() // #1813
+        {
+            var view = new OptionsView();
+            Assert.NotNull(view.FindControl<Button>("InitUpdateFERepoButton"));
+            Assert.NotNull(view.FindControl<Button>("InitUpdateFERepoMusicButton"));
+        }
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/OptionsView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/OptionsView.axaml
@@ -43,8 +43,16 @@
                         HorizontalAlignment="Left" Margin="0,4,0,0" />
                 <TextBlock Text="FE-Repo Remote URL" Margin="0,4,0,0" />
                 <TextBox AutomationProperties.AutomationId="Options_FERepoUrlText_Input" Name="FERepoUrlTextBox" Watermark="https://github.com/Klokinator/FE-Repo" />
+                <!-- #1813: in-app Initialize/Update of the FE-Repo resource repository, next to its URL. -->
+                <Button AutomationProperties.AutomationId="Options_InitUpdateFERepo_Button" Name="InitUpdateFERepoButton"
+                        Content="Initialize / Update FE-Repo Now" Click="InitUpdateFERepo_Click"
+                        HorizontalAlignment="Left" Margin="0,4,0,0" />
                 <TextBlock Text="FE-Repo-Music Remote URL" Margin="0,4,0,0" />
                 <TextBox AutomationProperties.AutomationId="Options_FERepoMusicUrlText_Input" Name="FERepoMusicUrlTextBox" Watermark="https://github.com/laqieer/FE-Repo-Music-No-Preview" />
+                <!-- #1813: in-app Initialize/Update of the FE-Repo-Midi (music) repository, next to its URL. -->
+                <Button AutomationProperties.AutomationId="Options_InitUpdateFERepoMusic_Button" Name="InitUpdateFERepoMusicButton"
+                        Content="Initialize / Update FE-Repo-Midi Now" Click="InitUpdateFERepoMusic_Click"
+                        HorizontalAlignment="Left" Margin="0,4,0,0" />
               </StackPanel>
             </Expander>
 

--- a/FEBuilderGBA.Avalonia/Views/OptionsView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OptionsView.axaml.cs
@@ -180,7 +180,7 @@ namespace FEBuilderGBA.Avalonia.Views
         /// </summary>
         async void InitUpdatePatch2_Click(object? sender, RoutedEventArgs e)
             => await RunContentRepoInitUpdate(InitUpdatePatch2Button, Patch2UrlTextBox,
-                "submodule_patch2_url", GitUtil.GetPatch2RemoteUrl(),
+                "submodule_patch2_url", GitUtil.Patch2RemoteUrl,
                 Patch2GitService.GetPatch2Dir(CoreState.BaseDirectory ?? AppDomain.CurrentDomain.BaseDirectory),
                 "Patch database");
 
@@ -227,7 +227,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 switch (result.Kind)
                 {
                     case Patch2GitResultKind.GitNotFound:
-                        CoreState.Services?.ShowError($"Git was not found. Install Git and try again, or set up {displayName} manually — see the Patch Database Setup wiki page.");
+                        CoreState.Services?.ShowError($"Git was not found. Install Git and try again, or set up {displayName} manually.");
                         break;
                     case Patch2GitResultKind.AlreadyRunning:
                         CoreState.Services?.ShowInfo("A content repository operation is already running.");

--- a/FEBuilderGBA.Avalonia/Views/OptionsView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OptionsView.axaml.cs
@@ -179,50 +179,75 @@ namespace FEBuilderGBA.Avalonia.Views
         /// re-enabled in a finally.
         /// </summary>
         async void InitUpdatePatch2_Click(object? sender, RoutedEventArgs e)
+            => await RunContentRepoInitUpdate(InitUpdatePatch2Button, Patch2UrlTextBox,
+                "submodule_patch2_url", GitUtil.GetPatch2RemoteUrl(),
+                Patch2GitService.GetPatch2Dir(CoreState.BaseDirectory ?? AppDomain.CurrentDomain.BaseDirectory),
+                "Patch database");
+
+        async void InitUpdateFERepo_Click(object? sender, RoutedEventArgs e)
+            => await RunContentRepoInitUpdate(InitUpdateFERepoButton, FERepoUrlTextBox,
+                "submodule_fe_repo_url", GitUtil.FERepoDefaultUrl,
+                GitUtil.GetFERepoDir(CoreState.BaseDirectory ?? AppDomain.CurrentDomain.BaseDirectory),
+                "FE-Repo");
+
+        async void InitUpdateFERepoMusic_Click(object? sender, RoutedEventArgs e)
+            => await RunContentRepoInitUpdate(InitUpdateFERepoMusicButton, FERepoMusicUrlTextBox,
+                "submodule_fe_repo_music_url", GitUtil.FERepoMusicDefaultUrl,
+                GitUtil.GetFERepoMusicDir(CoreState.BaseDirectory ?? AppDomain.CurrentDomain.BaseDirectory),
+                "FE-Repo-Midi");
+
+        /// <summary>
+        /// #1813: shared in-app Initialize (clone) / Update (fetch+reset) of a git-delivered content repo
+        /// (patch2 / FE-Repo / FE-Repo-Midi), next to its remote-URL field. Trims + persists ONLY that
+        /// repo's own URL config key (never the whole Options form), passes the effective URL directly
+        /// (falling back to <paramref name="defaultUrl"/> when blank), and runs off the UI thread. All
+        /// user-facing messages use <paramref name="displayName"/> so a failure names the correct repo.
+        /// The button is disabled synchronously and re-enabled in a finally.
+        /// </summary>
+        async System.Threading.Tasks.Task RunContentRepoInitUpdate(
+            Button button, TextBox urlTextBox, string configKey, string defaultUrl, string repoDir, string displayName)
         {
-            InitUpdatePatch2Button.IsEnabled = false;
+            button.IsEnabled = false;
             try
             {
-                string url = (Patch2UrlTextBox.Text ?? "").Trim();
+                string url = (urlTextBox.Text ?? "").Trim();
+                urlTextBox.Text = url; // reflect the trim so a stray space can't be re-saved
 
-                // Persist only the patch2 URL key so it survives subsequent auto-updates, without
-                // side-effecting other unsaved Options fields (do NOT call the full _vm.Save()).
+                // Persist ONLY this repo's URL key (do NOT call the full _vm.Save()).
                 var cfg = CoreState.Config;
                 if (cfg != null)
                 {
-                    cfg["submodule_patch2_url"] = url;
+                    cfg[configKey] = url;
                     cfg.Save();
                 }
 
-                string baseDir = CoreState.BaseDirectory ?? AppDomain.CurrentDomain.BaseDirectory;
-                string urlOverride = string.IsNullOrWhiteSpace(url) ? null : url;
+                string effUrl = string.IsNullOrWhiteSpace(url) ? defaultUrl : url;
 
-                var result = await Task.Run(() => Patch2GitService.InitializeOrUpdate(baseDir, null, urlOverride));
+                var result = await Task.Run(() => ContentRepoGitService.InitializeOrUpdate(repoDir, effUrl, null));
                 switch (result.Kind)
                 {
                     case Patch2GitResultKind.GitNotFound:
-                        CoreState.Services?.ShowError("Git was not found. Install Git and try again, or set up config/patch2 manually — see the Patch Database Setup wiki page.");
+                        CoreState.Services?.ShowError($"Git was not found. Install Git and try again, or set up {displayName} manually — see the Patch Database Setup wiki page.");
                         break;
                     case Patch2GitResultKind.AlreadyRunning:
-                        CoreState.Services?.ShowInfo("A patch database operation is already running.");
+                        CoreState.Services?.ShowInfo("A content repository operation is already running.");
                         break;
                     case Patch2GitResultKind.Failed:
-                        CoreState.Services?.ShowError(string.Format("Patch database {0} failed (git exit {1}).",
-                            result.WasClone ? "initialize" : "update", result.ExitCode));
+                        CoreState.Services?.ShowError($"{displayName} {(result.WasClone ? "initialize" : "update")} failed (git exit {result.ExitCode}).");
                         break;
                     case Patch2GitResultKind.Success:
-                        CoreState.Services?.ShowInfo("Patch database updated. Restart recommended for all changes to take full effect.");
+                        CoreState.Services?.ShowInfo($"{displayName} updated. Restart recommended for all changes to take full effect.");
                         break;
                 }
             }
             catch (Exception ex)
             {
                 Log.Error("OptionsView", ex.ToString());
-                CoreState.Services?.ShowError("Patch database operation failed: " + ex.Message);
+                CoreState.Services?.ShowError($"{displayName} operation failed: " + ex.Message);
             }
             finally
             {
-                InitUpdatePatch2Button.IsEnabled = true;
+                button.IsEnabled = true;
             }
         }
     }

--- a/FEBuilderGBA.Core.Tests/ContentRepoGitServiceTests.cs
+++ b/FEBuilderGBA.Core.Tests/ContentRepoGitServiceTests.cs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// #1813 — ContentRepoGitService: the generic in-app clone-or-update engine shared by patch2, FE-Repo,
+// and FE-Repo-Midi. The full clone/backup/restore matrix is already covered by the 12 Patch2GitServiceTests
+// (which now exercise this core via the patch2 shim); this file adds the generic-API coverage plus the
+// cross-service single-flight exclusion the review board required.
+using System;
+using System.IO;
+using System.Text;
+using FEBuilderGBA;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    public class ContentRepoGitServiceTests
+    {
+        static string NewRepoDir(out string baseDir)
+        {
+            baseDir = Path.Combine(Path.GetTempPath(), "fe_crgit_" + Guid.NewGuid().ToString("N"));
+            string repoDir = Path.Combine(baseDir, "resources", "FE-Repo");
+            Directory.CreateDirectory(Path.GetDirectoryName(repoDir));
+            return repoDir;
+        }
+
+        static void Cleanup(string baseDir)
+        {
+            try { if (Directory.Exists(baseDir)) Directory.Delete(baseDir, true); } catch { }
+        }
+
+        sealed class FakeClone
+        {
+            public int Called; public bool TargetExistedAtCall; public int ReturnCode; public bool CreateOnSuccess;
+            public int Op(string g, string u, string t, Action<string> p, StringBuilder l)
+            {
+                Called++; TargetExistedAtCall = Directory.Exists(t);
+                if (ReturnCode == 0 && CreateOnSuccess) { Directory.CreateDirectory(t); File.WriteAllText(Path.Combine(t, "cloned.txt"), "ok"); }
+                return ReturnCode;
+            }
+        }
+        sealed class FakeUpdate { public int Called; public int ReturnCode; public int Op(string g, string r, Action<string> p, StringBuilder l, string u) { Called++; return ReturnCode; } }
+
+        [Fact]
+        public void GitNotFound_WhenGitExeNull()
+        {
+            var r = ContentRepoGitService.InitializeOrUpdateCore(
+                "any", null, "url", _ => false, new FakeClone().Op, new FakeUpdate().Op, null);
+            Assert.Equal(Patch2GitResultKind.GitNotFound, r.Kind);
+        }
+
+        [Fact]
+        public void EmptyResourceDir_ClonesWithNamedBackupThenNone()
+        {
+            string repoDir = NewRepoDir(out string baseDir);
+            try
+            {
+                Directory.CreateDirectory(repoDir); // empty submodule placeholder
+                var clone = new FakeClone { ReturnCode = 0, CreateOnSuccess = true };
+                var r = ContentRepoGitService.InitializeOrUpdateCore(
+                    repoDir, "git", "url", _ => false, clone.Op, new FakeUpdate().Op, null);
+
+                Assert.Equal(Patch2GitResultKind.Success, r.Kind);
+                Assert.True(r.WasClone);
+                Assert.False(clone.TargetExistedAtCall);                 // moved aside before clone
+                Assert.True(File.Exists(Path.Combine(repoDir, "cloned.txt")));
+                // Backup was named after the repo dir (FE-Repo), not "patch2", and removed on success.
+                Assert.Empty(Directory.GetDirectories(Path.Combine(baseDir, "resources"), "_FE-Repo_backup_*"));
+            }
+            finally { Cleanup(baseDir); }
+        }
+
+        [Fact]
+        public void ValidSubmoduleLink_TakesUpdatePath_NoBackup()
+        {
+            string repoDir = NewRepoDir(out string baseDir);
+            try
+            {
+                Directory.CreateDirectory(repoDir);
+                File.WriteAllText(Path.Combine(repoDir, "content.bin"), "existing"); // populated repo content
+                var clone = new FakeClone();
+                var update = new FakeUpdate { ReturnCode = 0 };
+                // isGitRepo => true simulates a valid .git-file submodule link (however large).
+                var r = ContentRepoGitService.InitializeOrUpdateCore(
+                    repoDir, "git", "url", _ => true, clone.Op, update.Op, null);
+
+                Assert.Equal(Patch2GitResultKind.Success, r.Kind);
+                Assert.False(r.WasClone);
+                Assert.Equal(1, update.Called);
+                Assert.Equal(0, clone.Called);                            // never cloned
+                Assert.True(File.Exists(Path.Combine(repoDir, "content.bin"))); // not backed up / destroyed
+                Assert.Empty(Directory.GetDirectories(Path.Combine(baseDir, "resources"), "_FE-Repo_backup_*"));
+            }
+            finally { Cleanup(baseDir); }
+        }
+
+        [Fact]
+        public void SingleFlight_ContentRepoGuardHeld_Patch2ReturnsAlreadyRunning()
+        {
+            Assert.True(ContentRepoGitService.TryEnter());
+            try
+            {
+                var r = Patch2GitService.InitializeOrUpdate("any", null, null);
+                Assert.Equal(Patch2GitResultKind.AlreadyRunning, r.Kind); // one shared guard across services
+            }
+            finally { ContentRepoGitService.Exit(); }
+        }
+
+        [Fact]
+        public void SingleFlight_Patch2GuardHeld_ContentRepoReturnsAlreadyRunning()
+        {
+            Assert.True(Patch2GitService.TryEnter());
+            try
+            {
+                var r = ContentRepoGitService.InitializeOrUpdate("any-dir", "url", null);
+                Assert.Equal(Patch2GitResultKind.AlreadyRunning, r.Kind);
+            }
+            finally { Patch2GitService.Exit(); }
+        }
+    }
+}

--- a/FEBuilderGBA.Core/ContentRepoGitService.cs
+++ b/FEBuilderGBA.Core/ContentRepoGitService.cs
@@ -1,0 +1,208 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// Cross-platform, in-app initialize (clone) / update (fetch+reset) of a git-delivered content
+    /// repository. Generalizes the patch2 workflow (#1812/#1817) so the three git-delivered repos —
+    /// <c>config/patch2</c>, <c>resources/FE-Repo</c>, <c>resources/FE-Repo-Music-No-Preview</c> — share
+    /// ONE implementation (#1813). The proven flow: if the directory is already a git repo → <c>git
+    /// fetch + reset</c>; otherwise move any existing directory aside (including an empty submodule
+    /// placeholder) and <c>git clone</c>, restoring the backup on failure.
+    ///
+    /// <para><see cref="Patch2GitService"/> is a thin patch2-specific facade that delegates here; its
+    /// public result types (<see cref="Patch2GitResult"/>/<see cref="Patch2GitResultKind"/>) are the
+    /// shared result types returned by this service.</para>
+    /// </summary>
+    public static class ContentRepoGitService
+    {
+        // The ONE canonical single-flight guard shared by every content-repo entry point (both GUIs'
+        // Options/Patch-Manager buttons AND the legacy WinForms ToolUpdateDialogForm.AutoUpdatePatch2Git,
+        // which reaches it via Patch2GitService.TryEnter/Exit pass-throughs). Global (one op at a time)
+        // — the ops are rare and foreground, so a concurrent trigger simply returns AlreadyRunning.
+        static readonly object _gate = new object();
+        static bool _running;
+
+        /// <summary>
+        /// Public entry: resolves the git executable, then runs the clone-or-update against
+        /// <paramref name="repoDir"/> using remote <paramref name="url"/>. Synchronous — callers wrap it
+        /// in <c>Task.Run</c>. <paramref name="progress"/> (nullable) receives git output lines on a
+        /// background thread. Guarded by the single-flight lock: a concurrent second call returns
+        /// <see cref="Patch2GitResultKind.AlreadyRunning"/>.
+        /// </summary>
+        public static Patch2GitResult InitializeOrUpdate(string repoDir, string url, Action<string> progress = null)
+        {
+            if (!TryEnter())
+                return new Patch2GitResult { Kind = Patch2GitResultKind.AlreadyRunning };
+            try
+            {
+                string gitExe = GitUtil.FindGitExecutable();
+                return InitializeOrUpdateCore(repoDir, gitExe, url, GitUtil.IsGitRepo, GitUtil.Clone, GitUtil.Update, progress);
+            }
+            finally
+            {
+                Exit();
+            }
+        }
+
+        /// <summary>
+        /// Testable core with all external dependencies injected — exercises the REAL backup file-move
+        /// logic so tests need no network or git. Pure (no static/guard state) so parallel tests using
+        /// isolated temp directories never race. <paramref name="gitExe"/> null/empty → GitNotFound.
+        /// A directory that <paramref name="isGitRepo"/> reports as a repo (incl. a submodule <c>.git</c>
+        /// link, however large) goes straight to the update path and is never backed up.
+        /// </summary>
+        internal static Patch2GitResult InitializeOrUpdateCore(
+            string repoDir, string gitExe, string url,
+            Func<string, bool> isGitRepo, Patch2GitService.CloneOp cloneOp, Patch2GitService.UpdateOp updateOp,
+            Action<string> progress)
+        {
+            if (string.IsNullOrEmpty(gitExe))
+                return new Patch2GitResult { Kind = Patch2GitResultKind.GitNotFound };
+
+            var log = new StringBuilder();
+
+            // UPDATE path — the directory is already a real git repo (or a valid submodule link).
+            if (isGitRepo(repoDir))
+            {
+                int code;
+                try
+                {
+                    code = updateOp(gitExe, repoDir, progress, log, url);
+                }
+                catch (Exception ex)
+                {
+                    // Report as Failed (with the exception in the log) rather than letting it escape.
+                    // Nothing was moved, so there is no backup to restore here.
+                    log.AppendLine(ex.ToString());
+                    return new Patch2GitResult
+                    {
+                        Kind = Patch2GitResultKind.Failed,
+                        ExitCode = -1,
+                        Log = log.ToString(),
+                        WasClone = false,
+                    };
+                }
+                return new Patch2GitResult
+                {
+                    Kind = code == 0 ? Patch2GitResultKind.Success : Patch2GitResultKind.Failed,
+                    ExitCode = code,
+                    Log = log.ToString(),
+                    WasClone = false,
+                };
+            }
+
+            // CLONE path. Move ANY existing directory aside first — including an empty submodule
+            // placeholder left by a non-recursive superproject clone (the single most common "needs
+            // Initialize" state) — so the clone target does not exist and we can roll back cleanly if
+            // the clone fails partway. The backup is a fast same-volume Directory.Move (rename, not a
+            // deep copy), so it is cheap even for a large non-repo directory.
+            string backupPath = null;
+            if (Directory.Exists(repoDir))
+            {
+                backupPath = Path.Combine(
+                    Path.GetDirectoryName(repoDir) ?? "",
+                    "_" + (Path.GetFileName(repoDir) ?? "repo") + "_backup_" + DateTime.Now.Ticks.ToString());
+
+                // Guard against a stale backup directory from a previously aborted run so
+                // Directory.Move never throws on an existing destination.
+                if (Directory.Exists(backupPath))
+                    Directory.Delete(backupPath, true);
+
+                Directory.Move(repoDir, backupPath);
+            }
+
+            int cloneCode;
+            try
+            {
+                cloneCode = cloneOp(gitExe, url, repoDir, progress, log);
+            }
+            catch (Exception ex)
+            {
+                // The clone op threw AFTER we moved the existing directory aside — restore the backup so
+                // the repository is never left stranded under _<name>_backup_*, capture the exception in
+                // the log, and report Failed (no exception escapes to strand state).
+                log.AppendLine(ex.ToString());
+                RestoreBackup(repoDir, backupPath);
+                return new Patch2GitResult
+                {
+                    Kind = Patch2GitResultKind.Failed,
+                    ExitCode = -1,
+                    Log = log.ToString(),
+                    WasClone = true,
+                };
+            }
+
+            if (cloneCode != 0)
+            {
+                // Restore the backup on failure — best-effort, leaving the tree as we found it.
+                RestoreBackup(repoDir, backupPath);
+
+                return new Patch2GitResult
+                {
+                    Kind = Patch2GitResultKind.Failed,
+                    ExitCode = cloneCode,
+                    Log = log.ToString(),
+                    WasClone = true,
+                };
+            }
+
+            // Success — drop the backup (a leftover backup is harmless but wastes disk).
+            if (backupPath != null)
+            {
+                try
+                {
+                    if (Directory.Exists(backupPath))
+                        Directory.Delete(backupPath, true);
+                }
+                catch
+                {
+                    // A leftover backup directory is non-fatal.
+                }
+            }
+
+            return new Patch2GitResult
+            {
+                Kind = Patch2GitResultKind.Success,
+                ExitCode = 0,
+                Log = log.ToString(),
+                WasClone = true,
+            };
+        }
+
+        /// <summary>Best-effort restore of a backed-up repository directory after a failed/throwing clone.</summary>
+        static void RestoreBackup(string repoDir, string backupPath)
+        {
+            try
+            {
+                if (Directory.Exists(repoDir))
+                    Directory.Delete(repoDir, true);
+                if (backupPath != null && Directory.Exists(backupPath))
+                    Directory.Move(backupPath, repoDir);
+            }
+            catch
+            {
+                // Restore is best-effort; the accumulated log / thrown exception still explains the failure.
+            }
+        }
+
+        /// <summary>Acquire the shared single-flight guard. Internal for deterministic re-entrancy tests.</summary>
+        internal static bool TryEnter()
+        {
+            lock (_gate)
+            {
+                if (_running) return false;
+                _running = true;
+                return true;
+            }
+        }
+
+        /// <summary>Release the shared single-flight guard.</summary>
+        internal static void Exit()
+        {
+            lock (_gate) { _running = false; }
+        }
+    }
+}

--- a/FEBuilderGBA.Core/GitUtil.cs
+++ b/FEBuilderGBA.Core/GitUtil.cs
@@ -23,6 +23,32 @@ namespace FEBuilderGBA
             return Patch2RemoteUrl;
         }
 
+        /// <summary>Returns the FE-Repo remote URL: a user-configured custom URL when set, else the default (#1813).</summary>
+        public static string GetFERepoRemoteUrl()
+        {
+            string custom = CoreState.Config?.at("submodule_fe_repo_url", "");
+            if (!string.IsNullOrWhiteSpace(custom))
+                return custom;
+            return FERepoDefaultUrl;
+        }
+
+        /// <summary>Returns the FE-Repo-Midi (music) remote URL: a user-configured custom URL when set, else the default (#1813).</summary>
+        public static string GetFERepoMusicRemoteUrl()
+        {
+            string custom = CoreState.Config?.at("submodule_fe_repo_music_url", "");
+            if (!string.IsNullOrWhiteSpace(custom))
+                return custom;
+            return FERepoMusicDefaultUrl;
+        }
+
+        /// <summary>Repo-root FE-Repo resource directory: <c>&lt;baseDir&gt;/resources/FE-Repo</c> (#1813).</summary>
+        public static string GetFERepoDir(string baseDir)
+            => Path.Combine(baseDir ?? "", "resources", "FE-Repo");
+
+        /// <summary>Repo-root FE-Repo-Midi resource directory: <c>&lt;baseDir&gt;/resources/FE-Repo-Music-No-Preview</c> (#1813).</summary>
+        public static string GetFERepoMusicDir(string baseDir)
+            => Path.Combine(baseDir ?? "", "resources", "FE-Repo-Music-No-Preview");
+
         /// <summary>
         /// Returns path to git exe, or null if not found.
         /// Priority: configured path → "git" on system PATH → common Windows install locations.

--- a/FEBuilderGBA.Core/Patch2GitService.cs
+++ b/FEBuilderGBA.Core/Patch2GitService.cs
@@ -1,10 +1,9 @@
 using System;
-using System.IO;
 using System.Text;
 
 namespace FEBuilderGBA
 {
-    /// <summary>Outcome of a <see cref="Patch2GitService.InitializeOrUpdate"/> call.</summary>
+    /// <summary>Outcome of a content-repo initialize/update call (shared result type; patch2-named for #1812 history).</summary>
     public enum Patch2GitResultKind
     {
         Success,
@@ -13,7 +12,7 @@ namespace FEBuilderGBA
         AlreadyRunning,
     }
 
-    /// <summary>Result of an in-app patch2 initialize/update operation.</summary>
+    /// <summary>Result of an in-app content-repo initialize/update operation (shared across patch2 / FE-Repo / FE-Repo-Midi).</summary>
     public sealed class Patch2GitResult
     {
         public Patch2GitResultKind Kind { get; init; }
@@ -25,27 +24,17 @@ namespace FEBuilderGBA
     }
 
     /// <summary>
-    /// Cross-platform, in-app initialize/update of the git-delivered <c>config/patch2</c> database.
-    ///
-    /// Lifts the clone-or-update-with-backup decision (previously inline and WinForms-only in
-    /// <c>ToolUpdateDialogForm.AutoUpdatePatch2Git</c>) into a reusable, unit-testable Core service so
-    /// the Avalonia GUI (#1817) can offer real in-app Initialize/Update — the Avalonia half of #1812 —
-    /// without duplicating the logic. The proven WinForms flow is mirrored exactly: if the directory is
-    /// already a git repo → <c>git fetch + reset</c>; otherwise move any existing directory aside
-    /// (including an empty submodule placeholder from a non-recursive clone) and <c>git clone</c>,
-    /// restoring the backup on failure.
+    /// Thin patch2-specific facade over the generic <see cref="ContentRepoGitService"/> (#1813). Keeps
+    /// the patch2 public surface (<see cref="GetPatch2Dir"/>, <see cref="InitializeOrUpdate"/>,
+    /// <see cref="Patch2GitResult"/>) unchanged for the merged #1812/#1817 callers and the 12
+    /// <c>Patch2GitServiceTests</c>, resolving the patch2 directory + remote URL and delegating the
+    /// actual clone-or-update (and the shared single-flight guard) to <see cref="ContentRepoGitService"/>.
     /// </summary>
     public static class Patch2GitService
     {
-        // Single-flight guard (#1817 review board): Options and the Patch Manager can both trigger this,
-        // and they are independently openable windows — the same config/patch2 directory must never be
-        // backed-up/cloned by two threads at once. A second concurrent call returns AlreadyRunning.
-        static readonly object _gate = new object();
-        static bool _running;
-
         /// <summary>Repo-root patch database directory: <c>&lt;baseDir&gt;/config/patch2</c>.</summary>
         public static string GetPatch2Dir(string baseDir)
-            => Path.Combine(baseDir ?? "", "config", "patch2");
+            => System.IO.Path.Combine(baseDir ?? "", "config", "patch2");
 
         /// <summary>Delegate matching <see cref="GitUtil.Clone"/> so tests can inject a fake.</summary>
         public delegate int CloneOp(string gitExe, string url, string targetPath, Action<string> progress, StringBuilder log);
@@ -54,185 +43,31 @@ namespace FEBuilderGBA
         public delegate int UpdateOp(string gitExe, string repoPath, Action<string> progress, StringBuilder log, string remoteUrl);
 
         /// <summary>
-        /// Public entry: resolves the git executable and remote URL from the environment/config, then
-        /// runs the clone-or-update. Synchronous — callers wrap it in <c>Task.Run</c>. <paramref name="progress"/>
-        /// (nullable) receives git output lines on a background thread. <paramref name="urlOverride"/>
-        /// (nullable) forces a specific remote (used by the Options "Initialize / Update now" button so a
-        /// just-typed custom fork URL takes effect for both the clone and the update remote).
-        /// Guarded by a single-flight lock: a concurrent second call returns <see cref="Patch2GitResultKind.AlreadyRunning"/>.
+        /// Resolves the git executable and patch2 remote URL (custom fork override or default), then
+        /// delegates to <see cref="ContentRepoGitService.InitializeOrUpdate"/> against
+        /// <c>&lt;baseDir&gt;/config/patch2</c>. Guarded by the shared single-flight lock.
         /// </summary>
         public static Patch2GitResult InitializeOrUpdate(string baseDir, Action<string> progress = null, string urlOverride = null)
         {
-            if (!TryEnter())
-                return new Patch2GitResult { Kind = Patch2GitResultKind.AlreadyRunning };
-            try
-            {
-                string gitExe = GitUtil.FindGitExecutable();
-                string url = string.IsNullOrWhiteSpace(urlOverride) ? GitUtil.GetPatch2RemoteUrl() : urlOverride;
-                return InitializeOrUpdateCore(baseDir, gitExe, url, GitUtil.IsGitRepo, GitUtil.Clone, GitUtil.Update, progress);
-            }
-            finally
-            {
-                Exit();
-            }
+            string url = string.IsNullOrWhiteSpace(urlOverride) ? GitUtil.GetPatch2RemoteUrl() : urlOverride;
+            return ContentRepoGitService.InitializeOrUpdate(GetPatch2Dir(baseDir), url, progress);
         }
 
         /// <summary>
-        /// Testable core with all external dependencies injected — exercises the REAL backup file-move
-        /// logic so tests need no network or git. Pure (no static/guard state) so parallel tests using
-        /// isolated temp directories never race. <paramref name="gitExe"/> null/empty → GitNotFound.
+        /// Patch2 shim over the generic core (keeps the merged <c>Patch2GitServiceTests</c> unchanged):
+        /// maps <paramref name="baseDir"/> → <c>config/patch2</c> and forwards to
+        /// <see cref="ContentRepoGitService.InitializeOrUpdateCore"/>. Unguarded (like the generic core).
         /// </summary>
         internal static Patch2GitResult InitializeOrUpdateCore(
             string baseDir, string gitExe, string url,
             Func<string, bool> isGitRepo, CloneOp cloneOp, UpdateOp updateOp,
             Action<string> progress)
-        {
-            if (string.IsNullOrEmpty(gitExe))
-                return new Patch2GitResult { Kind = Patch2GitResultKind.GitNotFound };
+            => ContentRepoGitService.InitializeOrUpdateCore(GetPatch2Dir(baseDir), gitExe, url, isGitRepo, cloneOp, updateOp, progress);
 
-            string patchDir = GetPatch2Dir(baseDir);
-            var log = new StringBuilder();
+        /// <summary>Acquire the shared single-flight guard (pass-through to <see cref="ContentRepoGitService"/>).</summary>
+        internal static bool TryEnter() => ContentRepoGitService.TryEnter();
 
-            // UPDATE path — the directory is already a real git repo.
-            if (isGitRepo(patchDir))
-            {
-                int code;
-                try
-                {
-                    code = updateOp(gitExe, patchDir, progress, log, url);
-                }
-                catch (Exception ex)
-                {
-                    // Report as Failed (with the exception in the log) rather than letting it escape,
-                    // so both entry points get a uniform result-based error path. Nothing was moved,
-                    // so there is no backup to restore here.
-                    log.AppendLine(ex.ToString());
-                    return new Patch2GitResult
-                    {
-                        Kind = Patch2GitResultKind.Failed,
-                        ExitCode = -1,
-                        Log = log.ToString(),
-                        WasClone = false,
-                    };
-                }
-                return new Patch2GitResult
-                {
-                    Kind = code == 0 ? Patch2GitResultKind.Success : Patch2GitResultKind.Failed,
-                    ExitCode = code,
-                    Log = log.ToString(),
-                    WasClone = false,
-                };
-            }
-
-            // CLONE path. Move ANY existing directory aside first — including an empty submodule
-            // placeholder left by a non-recursive superproject clone (the single most common "needs
-            // Initialize" state) — so the clone target does not exist and we can roll back cleanly if
-            // the clone fails partway (otherwise partial .git debris would flip the next run onto the
-            // wrong IsGitRepo->Update branch).
-            string backupPath = null;
-            if (Directory.Exists(patchDir))
-            {
-                backupPath = Path.Combine(
-                    Path.GetDirectoryName(patchDir) ?? "",
-                    "_patch2_backup_" + DateTime.Now.Ticks.ToString());
-
-                // Guard against a stale backup directory from a previously aborted run so
-                // Directory.Move never throws on an existing destination.
-                if (Directory.Exists(backupPath))
-                    Directory.Delete(backupPath, true);
-
-                Directory.Move(patchDir, backupPath);
-            }
-
-            int cloneCode;
-            try
-            {
-                cloneCode = cloneOp(gitExe, url, patchDir, progress, log);
-            }
-            catch (Exception ex)
-            {
-                // The clone op threw AFTER we moved the existing directory aside — restore the backup so
-                // the patch database is never left stranded under _patch2_backup_*, capture the exception
-                // in the log, and report Failed (no exception escapes to strand state).
-                log.AppendLine(ex.ToString());
-                RestoreBackup(patchDir, backupPath);
-                return new Patch2GitResult
-                {
-                    Kind = Patch2GitResultKind.Failed,
-                    ExitCode = -1,
-                    Log = log.ToString(),
-                    WasClone = true,
-                };
-            }
-
-            if (cloneCode != 0)
-            {
-                // Restore the backup on failure — best-effort, leaving the tree as we found it.
-                RestoreBackup(patchDir, backupPath);
-
-                return new Patch2GitResult
-                {
-                    Kind = Patch2GitResultKind.Failed,
-                    ExitCode = cloneCode,
-                    Log = log.ToString(),
-                    WasClone = true,
-                };
-            }
-
-            // Success — drop the backup (a leftover backup is harmless but wastes disk).
-            if (backupPath != null)
-            {
-                try
-                {
-                    if (Directory.Exists(backupPath))
-                        Directory.Delete(backupPath, true);
-                }
-                catch
-                {
-                    // A leftover backup directory is non-fatal.
-                }
-            }
-
-            return new Patch2GitResult
-            {
-                Kind = Patch2GitResultKind.Success,
-                ExitCode = 0,
-                Log = log.ToString(),
-                WasClone = true,
-            };
-        }
-
-        /// <summary>Best-effort restore of a backed-up patch2 directory after a failed/throwing clone.</summary>
-        static void RestoreBackup(string patchDir, string backupPath)
-        {
-            try
-            {
-                if (Directory.Exists(patchDir))
-                    Directory.Delete(patchDir, true);
-                if (backupPath != null && Directory.Exists(backupPath))
-                    Directory.Move(backupPath, patchDir);
-            }
-            catch
-            {
-                // Restore is best-effort; the accumulated log / thrown exception still explains the failure.
-            }
-        }
-
-        /// <summary>Acquire the single-flight guard. Internal for deterministic re-entrancy tests.</summary>
-        internal static bool TryEnter()
-        {
-            lock (_gate)
-            {
-                if (_running) return false;
-                _running = true;
-                return true;
-            }
-        }
-
-        /// <summary>Release the single-flight guard.</summary>
-        internal static void Exit()
-        {
-            lock (_gate) { _running = false; }
-        }
+        /// <summary>Release the shared single-flight guard (pass-through to <see cref="ContentRepoGitService"/>).</summary>
+        internal static void Exit() => ContentRepoGitService.Exit();
     }
 }

--- a/FEBuilderGBA.Tests/Unit/Patch2InitUpdateWinFormsTests.cs
+++ b/FEBuilderGBA.Tests/Unit/Patch2InitUpdateWinFormsTests.cs
@@ -1,45 +1,106 @@
 using System;
 using System.Reflection;
+using System.Threading;
 using System.Windows.Forms;
 using Xunit;
 
 namespace FEBuilderGBA.Tests.Unit
 {
     /// <summary>
-    /// #1812: verifies the WinForms in-app patch2 Initialize/Update wiring is present — the shared
-    /// <see cref="Patch2GitWinForms.RunInitUpdate"/> host plus the OptionForm and PatchForm buttons +
-    /// click handlers. The clone/update logic itself is covered by the 12 cross-platform
-    /// <c>Patch2GitServiceTests</c> (Core); a real WinForms form instantiation here would require a
-    /// live ROM (PatchForm) / config + a translation-matched "Etc" tab (OptionForm), so the button
-    /// creation is proven visually by the PR screenshot instead. This structural test guards against
-    /// the wiring being renamed/removed (which would silently break the buttons).
+    /// #1812/#1813: verifies the WinForms in-app content-repo Initialize/Update wiring — the shared
+    /// <see cref="ContentRepoGitWinForms.RunInitUpdate"/> host + the patch2 facade, the OptionForm patch2 /
+    /// FE-Repo / FE-Repo-Midi buttons + handlers, and the PatchForm button. Also a BEHAVIORAL test that
+    /// the "Submodule Remote URLs" GroupBox actually attaches to a visible tab (regression guard for the
+    /// #1813 dead-UI fix — the pre-existing condition only matched a non-existent "Etc" tab). The
+    /// clone/update logic itself is covered by the Core Patch2GitService/ContentRepoGitService tests.
     /// </summary>
+    [Collection("SharedState")]
     public class Patch2InitUpdateWinFormsTests
     {
-        const BindingFlags NonPublicInstance = BindingFlags.NonPublic | BindingFlags.Instance;
+        const BindingFlags NPI = BindingFlags.NonPublic | BindingFlags.Instance;
 
         [Fact]
-        public void Patch2GitWinForms_RunInitUpdate_HasExpectedSignature()
+        public void ContentRepoGitWinForms_RunInitUpdate_HasExpectedSignature()
         {
-            MethodInfo m = typeof(Patch2GitWinForms).GetMethod(
-                "RunInitUpdate", new[] { typeof(Form), typeof(string) });
+            MethodInfo m = typeof(ContentRepoGitWinForms).GetMethod(
+                "RunInitUpdate", new[] { typeof(Form), typeof(string), typeof(string), typeof(string) });
             Assert.NotNull(m);
             Assert.True(m.IsStatic);
             Assert.Equal(typeof(Patch2GitResult), m.ReturnType);
         }
 
         [Fact]
-        public void OptionForm_HasPatch2InitUpdateButtonFieldAndHandler()
+        public void Patch2GitWinForms_RunInitUpdate_StillPresent()
         {
-            Assert.NotNull(typeof(OptionForm).GetField("_optionPatch2InitUpdateButton", NonPublicInstance));
-            Assert.NotNull(typeof(OptionForm).GetMethod("OptionPatch2InitUpdateButton_Click", NonPublicInstance));
+            MethodInfo m = typeof(Patch2GitWinForms).GetMethod(
+                "RunInitUpdate", new[] { typeof(Form), typeof(string) });
+            Assert.NotNull(m);
+            Assert.Equal(typeof(Patch2GitResult), m.ReturnType);
+        }
+
+        [Fact]
+        public void OptionForm_HasContentRepoButtonHandlers()
+        {
+            Assert.NotNull(typeof(OptionForm).GetField("_optionPatch2InitUpdateButton", NPI));
+            Assert.NotNull(typeof(OptionForm).GetField("_optionFERepoInitUpdateButton", NPI));
+            Assert.NotNull(typeof(OptionForm).GetField("_optionFERepoMusicInitUpdateButton", NPI));
+            Assert.NotNull(typeof(OptionForm).GetMethod("OptionPatch2InitUpdateButton_Click", NPI));
+            Assert.NotNull(typeof(OptionForm).GetMethod("OptionFERepoInitUpdateButton_Click", NPI));
+            Assert.NotNull(typeof(OptionForm).GetMethod("OptionFERepoMusicInitUpdateButton_Click", NPI));
         }
 
         [Fact]
         public void PatchForm_HasPatch2InitUpdateButtonCreatorAndHandler()
         {
-            Assert.NotNull(typeof(PatchForm).GetMethod("AddPatch2InitUpdateButton", NonPublicInstance));
-            Assert.NotNull(typeof(PatchForm).GetMethod("Patch2InitUpdateButton_Click", NonPublicInstance));
+            Assert.NotNull(typeof(PatchForm).GetMethod("AddPatch2InitUpdateButton", NPI));
+            Assert.NotNull(typeof(PatchForm).GetMethod("Patch2InitUpdateButton_Click", NPI));
+        }
+
+        // #1813 regression guard: the Submodule GroupBox (with the 3 URL fields + 3 Init/Update buttons)
+        // must actually attach to a TabPage, not vanish because no "Etc" tab exists. Renders the real
+        // OptionForm on an STA thread, invokes LoadSubmoduleUrls, and asserts the patch2 button's parent
+        // chain reaches a visible TabPage.
+        [Fact]
+        public void OptionForm_SubmoduleGroupBox_AttachesToAVisibleTab()
+        {
+            string err = null;
+            var t = new Thread(() =>
+            {
+                try
+                {
+                    Type prog = typeof(OptionForm).Assembly.GetType("FEBuilderGBA.Program");
+                    Type cfgT = typeof(OptionForm).Assembly.GetType("FEBuilderGBA.ConfigWinForms");
+                    object cfg = Activator.CreateInstance(cfgT);
+                    prog.GetProperty("Config").GetSetMethod(true).Invoke(null, new[] { cfg });
+
+                    using var form = new OptionForm();
+                    form.CreateControl();
+                    typeof(OptionForm).GetMethod("LoadSubmoduleUrls", NPI).Invoke(form, null);
+
+                    var found = form.Controls.Find("OptionPatch2InitUpdateButton", true);
+                    Assert.Single(found);
+
+                    // Walk up to confirm a TabPage ancestor (i.e. it is attached to a real, visible tab).
+                    Control cur = found[0];
+                    bool onTab = false;
+                    while (cur != null)
+                    {
+                        if (cur is TabPage) { onTab = true; break; }
+                        cur = cur.Parent;
+                    }
+                    Assert.True(onTab, "Submodule GroupBox/patch2 button is not attached to any TabPage (dead UI).");
+
+                    // The FE-Repo + Music buttons must be present too.
+                    Assert.Single(form.Controls.Find("OptionFERepoInitUpdateButton", true));
+                    Assert.Single(form.Controls.Find("OptionFERepoMusicInitUpdateButton", true));
+                }
+                catch (Exception ex) { err = ex.ToString(); }
+            });
+            t.SetApartmentState(ApartmentState.STA);
+            t.IsBackground = true;
+            t.Start();
+            t.Join(TimeSpan.FromSeconds(30));
+            Assert.True(err == null, err);
         }
     }
 }

--- a/FEBuilderGBA.Tests/Unit/Patch2InitUpdateWinFormsTests.cs
+++ b/FEBuilderGBA.Tests/Unit/Patch2InitUpdateWinFormsTests.cs
@@ -70,36 +70,45 @@ namespace FEBuilderGBA.Tests.Unit
                 {
                     Type prog = typeof(OptionForm).Assembly.GetType("FEBuilderGBA.Program");
                     Type cfgT = typeof(OptionForm).Assembly.GetType("FEBuilderGBA.ConfigWinForms");
+                    var cfgProp = prog.GetProperty("Config");
+                    object prevCfg = cfgProp.GetValue(null); // restore afterwards so we don't leak shared state
                     object cfg = Activator.CreateInstance(cfgT);
-                    prog.GetProperty("Config").GetSetMethod(true).Invoke(null, new[] { cfg });
-
-                    using var form = new OptionForm();
-                    form.CreateControl();
-                    typeof(OptionForm).GetMethod("LoadSubmoduleUrls", NPI).Invoke(form, null);
-
-                    var found = form.Controls.Find("OptionPatch2InitUpdateButton", true);
-                    Assert.Single(found);
-
-                    // Walk up to confirm a TabPage ancestor (i.e. it is attached to a real, visible tab).
-                    Control cur = found[0];
-                    bool onTab = false;
-                    while (cur != null)
+                    cfgProp.GetSetMethod(true).Invoke(null, new[] { cfg });
+                    try
                     {
-                        if (cur is TabPage) { onTab = true; break; }
-                        cur = cur.Parent;
-                    }
-                    Assert.True(onTab, "Submodule GroupBox/patch2 button is not attached to any TabPage (dead UI).");
+                        using var form = new OptionForm();
+                        form.CreateControl();
+                        typeof(OptionForm).GetMethod("LoadSubmoduleUrls", NPI).Invoke(form, null);
 
-                    // The FE-Repo + Music buttons must be present too.
-                    Assert.Single(form.Controls.Find("OptionFERepoInitUpdateButton", true));
-                    Assert.Single(form.Controls.Find("OptionFERepoMusicInitUpdateButton", true));
+                        var found = form.Controls.Find("OptionPatch2InitUpdateButton", true);
+                        Assert.Single(found);
+
+                        // Walk up to confirm a TabPage ancestor (i.e. it is attached to a real, visible tab).
+                        Control cur = found[0];
+                        bool onTab = false;
+                        while (cur != null)
+                        {
+                            if (cur is TabPage) { onTab = true; break; }
+                            cur = cur.Parent;
+                        }
+                        Assert.True(onTab, "Submodule GroupBox/patch2 button is not attached to any TabPage (dead UI).");
+
+                        // The FE-Repo + Music buttons must be present too.
+                        Assert.Single(form.Controls.Find("OptionFERepoInitUpdateButton", true));
+                        Assert.Single(form.Controls.Find("OptionFERepoMusicInitUpdateButton", true));
+                    }
+                    finally
+                    {
+                        cfgProp.GetSetMethod(true).Invoke(null, new[] { prevCfg });
+                    }
                 }
                 catch (Exception ex) { err = ex.ToString(); }
             });
             t.SetApartmentState(ApartmentState.STA);
             t.IsBackground = true;
             t.Start();
-            t.Join(TimeSpan.FromSeconds(30));
+            bool completed = t.Join(TimeSpan.FromSeconds(30));
+            Assert.True(completed, "STA thread did not complete within the timeout.");
             Assert.True(err == null, err);
         }
     }

--- a/FEBuilderGBA/ContentRepoGitWinForms.cs
+++ b/FEBuilderGBA/ContentRepoGitWinForms.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Windows.Forms;
+
+namespace FEBuilderGBA
+{
+    /// <summary>
+    /// #1813: WinForms host for the cross-platform <see cref="ContentRepoGitService"/> — runs an in-app
+    /// Initialize (clone) / Update (fetch+reset) of any git-delivered content repo (patch2 / FE-Repo /
+    /// FE-Repo-Midi) with the standard <see cref="InputFormRef.AutoPleaseWait"/> progress pump, mirroring
+    /// <c>ToolUpdateDialogForm.AutoUpdatePatch2Git</c>. All user-facing messages are parametrized by a
+    /// repo <c>displayName</c> so a failure names the correct repo (not always "patch2"). Every WinForms
+    /// content-repo entry point goes through the same single-flight guard inside
+    /// <see cref="ContentRepoGitService"/>.
+    /// </summary>
+    public static class ContentRepoGitWinForms
+    {
+        /// <summary>
+        /// Runs the init/update for <paramref name="repoDir"/> (remote <paramref name="url"/>) synchronously
+        /// on the UI thread — pumping the message loop while the git op runs on a background Task — and shows
+        /// the result named by <paramref name="displayName"/>. Returns the <see cref="Patch2GitResult"/> so
+        /// callers (e.g. PatchForm) can rescan on success.
+        /// </summary>
+        public static Patch2GitResult RunInitUpdate(Form owner, string repoDir, string url, string displayName)
+        {
+            Patch2GitResult result;
+
+            using (InputFormRef.AutoPleaseWait pleaseWait = new InputFormRef.AutoPleaseWait(owner))
+            {
+                // lastLine[0] is written by the git output callback on the background thread and consumed
+                // by the UI-thread poll loop via Interlocked — the callback never touches any UI control
+                // (InputFormRef.DoEvents no-ops on a background thread, so it must not be called there).
+                var lastLine = new string[1];
+                Action<string> progress = line =>
+                {
+                    if (!string.IsNullOrEmpty(line))
+                        System.Threading.Interlocked.Exchange(ref lastLine[0], line);
+                };
+
+                pleaseWait.DoEvents("Git: " + displayName + " ...");
+                var task = System.Threading.Tasks.Task.Run(
+                    () => ContentRepoGitService.InitializeOrUpdate(repoDir, url, progress));
+
+                // Pump the UI message loop while the background git op runs (mirror PollGitProgress).
+                while (!task.IsCompleted)
+                {
+                    string line = System.Threading.Interlocked.Exchange(ref lastLine[0], null);
+                    if (!string.IsNullOrEmpty(line))
+                        pleaseWait.DoEvents(line);
+                    else
+                        System.Windows.Forms.Application.DoEvents();
+                    System.Threading.Thread.Sleep(80);
+                }
+
+                // Flush any final progress line that arrived just before the task completed.
+                string lastFlush = System.Threading.Interlocked.Exchange(ref lastLine[0], null);
+                if (!string.IsNullOrEmpty(lastFlush))
+                    pleaseWait.DoEvents(lastFlush);
+
+                try
+                {
+                    result = task.Result;
+                }
+                catch (Exception ex)
+                {
+                    // ContentRepoGitService is result-based for the git ops themselves, but its backup
+                    // file-move (Directory.Move/Delete) can still throw on a real I/O error — convert a
+                    // faulted Task into a Failed result so reading task.Result never crashes the UI.
+                    result = new Patch2GitResult
+                    {
+                        Kind = Patch2GitResultKind.Failed,
+                        ExitCode = -1,
+                        Log = (ex.InnerException ?? ex).ToString(),
+                    };
+                }
+            }
+
+            // Back on the UI thread after the using block — show the result, named by displayName.
+            switch (result.Kind)
+            {
+                case Patch2GitResultKind.GitNotFound:
+                    R.ShowStopError("Git was not found. Install Git and try again, or set up {0} manually — see the Patch Database Setup wiki page.", displayName);
+                    break;
+                case Patch2GitResultKind.AlreadyRunning:
+                    R.ShowStopError("A content repository operation is already running.");
+                    break;
+                case Patch2GitResultKind.Failed:
+                    string logTail = string.IsNullOrEmpty(result.Log) ? "" : "\r\n\r\n" + result.Log.Trim();
+                    if (result.ExitCode < 0)
+                        // Exception-synthesized fallback (a rare backup file-move I/O failure) — the
+                        // clone/update distinction isn't reliably known here, so use neutral wording.
+                        R.ShowStopError("{0} operation failed.{1}", displayName, logTail);
+                    else if (result.WasClone)
+                        R.ShowStopError("{0} initialization failed (git exit {1}).{2}", displayName, result.ExitCode, logTail);
+                    else
+                        R.ShowStopError("{0} update failed (git exit {1}).{2}", displayName, result.ExitCode, logTail);
+                    break;
+                case Patch2GitResultKind.Success:
+                    R.ShowOK("{0} updated. Restart recommended for all changes to take full effect.", displayName);
+                    break;
+            }
+
+            return result;
+        }
+    }
+}

--- a/FEBuilderGBA/ContentRepoGitWinForms.cs
+++ b/FEBuilderGBA/ContentRepoGitWinForms.cs
@@ -78,7 +78,7 @@ namespace FEBuilderGBA
             switch (result.Kind)
             {
                 case Patch2GitResultKind.GitNotFound:
-                    R.ShowStopError("Git was not found. Install Git and try again, or set up {0} manually — see the Patch Database Setup wiki page.", displayName);
+                    R.ShowStopError("Git was not found. Install Git and try again, or set up {0} manually.", displayName);
                     break;
                 case Patch2GitResultKind.AlreadyRunning:
                     R.ShowStopError("A content repository operation is already running.");

--- a/FEBuilderGBA/OptionForm.cs
+++ b/FEBuilderGBA/OptionForm.cs
@@ -2013,7 +2013,7 @@ namespace FEBuilderGBA
                     panel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100));
 
                     // Patch2 URL + Initialize/Update button (#1812)
-                    panel.Controls.Add(new Label { Text = "Patch2 URL:", Dock = DockStyle.Fill }, 0, 0);
+                    panel.Controls.Add(new Label { Text = R._("Patch2 URL:"), Dock = DockStyle.Fill }, 0, 0);
                     panel.Controls.Add(_submodulePatch2Url, 1, 0);
                     _submodulePatch2Url.Dock = DockStyle.Fill;
                     _optionPatch2InitUpdateButton = new Button
@@ -2027,7 +2027,7 @@ namespace FEBuilderGBA
                     panel.Controls.Add(_optionPatch2InitUpdateButton, 1, 1);
 
                     // FE-Repo URL + Initialize/Update button (#1813)
-                    panel.Controls.Add(new Label { Text = "FE-Repo URL:", Dock = DockStyle.Fill }, 0, 2);
+                    panel.Controls.Add(new Label { Text = R._("FE-Repo URL:"), Dock = DockStyle.Fill }, 0, 2);
                     panel.Controls.Add(_submoduleFERepoUrl, 1, 2);
                     _submoduleFERepoUrl.Dock = DockStyle.Fill;
                     _optionFERepoInitUpdateButton = new Button
@@ -2041,7 +2041,7 @@ namespace FEBuilderGBA
                     panel.Controls.Add(_optionFERepoInitUpdateButton, 1, 3);
 
                     // FE-Repo-Midi (music) URL + Initialize/Update button (#1813)
-                    panel.Controls.Add(new Label { Text = "Music URL:", Dock = DockStyle.Fill }, 0, 4);
+                    panel.Controls.Add(new Label { Text = R._("Music URL:"), Dock = DockStyle.Fill }, 0, 4);
                     panel.Controls.Add(_submoduleFERepoMusicUrl, 1, 4);
                     _submoduleFERepoMusicUrl.Dock = DockStyle.Fill;
                     _optionFERepoMusicInitUpdateButton = new Button

--- a/FEBuilderGBA/OptionForm.cs
+++ b/FEBuilderGBA/OptionForm.cs
@@ -1962,6 +1962,8 @@ namespace FEBuilderGBA
         TextBox _submoduleFERepoUrl;
         TextBox _submoduleFERepoMusicUrl;
         Button _optionPatch2InitUpdateButton;
+        Button _optionFERepoInitUpdateButton;      // #1813
+        Button _optionFERepoMusicInitUpdateButton; // #1813
 
         void LoadSubmoduleUrls()
         {
@@ -1973,54 +1975,88 @@ namespace FEBuilderGBA
             _submoduleFERepoUrl = new TextBox { Text = Program.Config.at("submodule_fe_repo_url", "") };
             _submoduleFERepoMusicUrl = new TextBox { Text = Program.Config.at("submodule_fe_repo_music_url", "") };
 
-            // Add a GroupBox to the "Etc" tab if it exists
+            // #1813 fix: the original code only attached the GroupBox to a tab whose text contains
+            // "Etc"/"etc"/その他 — but no such tab exists (the tabs are Path/Path2/Color/Shortcut Key/
+            // FELint/Function/Function2/Function3), so the URL fields + the #1812 patch2 button were
+            // invisible dead UI in every language. Prefer a matching tab if one ever exists, otherwise
+            // attach to the LAST tab so the group is always visible.
             foreach (Control c in this.Controls)
             {
-                if (c is TabControl tc)
+                if (c is TabControl tc && tc.TabPages.Count > 0)
                 {
+                    TabPage target = null;
                     foreach (TabPage tp in tc.TabPages)
                     {
                         if (tp.Text.Contains("Etc") || tp.Text.Contains("etc") || tp.Text.Contains(R._("その他")))
                         {
-                            var grp = new GroupBox
-                            {
-                                Text = R._("Submodule Remote URLs"),
-                                Dock = DockStyle.Bottom,
-                                Height = 150
-                            };
-                            var panel = new TableLayoutPanel
-                            {
-                                Dock = DockStyle.Fill,
-                                ColumnCount = 2,
-                                RowCount = 4,
-                                Padding = new Padding(4)
-                            };
-                            panel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 120));
-                            panel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100));
-                            panel.Controls.Add(new Label { Text = "Patch2 URL:", Dock = DockStyle.Fill }, 0, 0);
-                            panel.Controls.Add(_submodulePatch2Url, 1, 0);
-                            _submodulePatch2Url.Dock = DockStyle.Fill;
-                            // #1812: one-click in-app patch2 Initialize/Update, directly under its URL field.
-                            _optionPatch2InitUpdateButton = new Button
-                            {
-                                Name = "OptionPatch2InitUpdateButton",
-                                Text = R._("Initialize / Update Patch2 Now"),
-                                AutoSize = true,
-                                Anchor = AnchorStyles.Left
-                            };
-                            _optionPatch2InitUpdateButton.Click += OptionPatch2InitUpdateButton_Click;
-                            panel.Controls.Add(_optionPatch2InitUpdateButton, 1, 1);
-                            panel.Controls.Add(new Label { Text = "FE-Repo URL:", Dock = DockStyle.Fill }, 0, 2);
-                            panel.Controls.Add(_submoduleFERepoUrl, 1, 2);
-                            _submoduleFERepoUrl.Dock = DockStyle.Fill;
-                            panel.Controls.Add(new Label { Text = "Music URL:", Dock = DockStyle.Fill }, 0, 3);
-                            panel.Controls.Add(_submoduleFERepoMusicUrl, 1, 3);
-                            _submoduleFERepoMusicUrl.Dock = DockStyle.Fill;
-                            grp.Controls.Add(panel);
-                            tp.Controls.Add(grp);
-                            return;
+                            target = tp;
+                            break;
                         }
                     }
+                    if (target == null)
+                        target = tc.TabPages[tc.TabPages.Count - 1];
+
+                    var grp = new GroupBox
+                    {
+                        Text = R._("Submodule Remote URLs"),
+                        Dock = DockStyle.Bottom,
+                        Height = 230 // #1813: 6 rows (3 URLs + 3 Init/Update buttons)
+                    };
+                    var panel = new TableLayoutPanel
+                    {
+                        Dock = DockStyle.Fill,
+                        ColumnCount = 2,
+                        RowCount = 6,
+                        Padding = new Padding(4)
+                    };
+                    panel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 120));
+                    panel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100));
+
+                    // Patch2 URL + Initialize/Update button (#1812)
+                    panel.Controls.Add(new Label { Text = "Patch2 URL:", Dock = DockStyle.Fill }, 0, 0);
+                    panel.Controls.Add(_submodulePatch2Url, 1, 0);
+                    _submodulePatch2Url.Dock = DockStyle.Fill;
+                    _optionPatch2InitUpdateButton = new Button
+                    {
+                        Name = "OptionPatch2InitUpdateButton",
+                        Text = R._("Initialize / Update Patch2 Now"),
+                        AutoSize = true,
+                        Anchor = AnchorStyles.Left
+                    };
+                    _optionPatch2InitUpdateButton.Click += OptionPatch2InitUpdateButton_Click;
+                    panel.Controls.Add(_optionPatch2InitUpdateButton, 1, 1);
+
+                    // FE-Repo URL + Initialize/Update button (#1813)
+                    panel.Controls.Add(new Label { Text = "FE-Repo URL:", Dock = DockStyle.Fill }, 0, 2);
+                    panel.Controls.Add(_submoduleFERepoUrl, 1, 2);
+                    _submoduleFERepoUrl.Dock = DockStyle.Fill;
+                    _optionFERepoInitUpdateButton = new Button
+                    {
+                        Name = "OptionFERepoInitUpdateButton",
+                        Text = R._("Initialize / Update FE-Repo Now"),
+                        AutoSize = true,
+                        Anchor = AnchorStyles.Left
+                    };
+                    _optionFERepoInitUpdateButton.Click += OptionFERepoInitUpdateButton_Click;
+                    panel.Controls.Add(_optionFERepoInitUpdateButton, 1, 3);
+
+                    // FE-Repo-Midi (music) URL + Initialize/Update button (#1813)
+                    panel.Controls.Add(new Label { Text = "Music URL:", Dock = DockStyle.Fill }, 0, 4);
+                    panel.Controls.Add(_submoduleFERepoMusicUrl, 1, 4);
+                    _submoduleFERepoMusicUrl.Dock = DockStyle.Fill;
+                    _optionFERepoMusicInitUpdateButton = new Button
+                    {
+                        Name = "OptionFERepoMusicInitUpdateButton",
+                        Text = R._("Initialize / Update FE-Repo-Midi Now"),
+                        AutoSize = true,
+                        Anchor = AnchorStyles.Left
+                    };
+                    _optionFERepoMusicInitUpdateButton.Click += OptionFERepoMusicInitUpdateButton_Click;
+                    panel.Controls.Add(_optionFERepoMusicInitUpdateButton, 1, 5);
+
+                    grp.Controls.Add(panel);
+                    target.Controls.Add(grp);
+                    return;
                 }
             }
         }
@@ -2043,6 +2079,43 @@ namespace FEBuilderGBA
             finally
             {
                 _optionPatch2InitUpdateButton.Enabled = true;
+            }
+        }
+
+        void OptionFERepoInitUpdateButton_Click(object sender, EventArgs e) // #1813
+        {
+            RunSubmoduleInitUpdate(_optionFERepoInitUpdateButton, _submoduleFERepoUrl,
+                "submodule_fe_repo_url", GitUtil.FERepoDefaultUrl,
+                GitUtil.GetFERepoDir(Program.BaseDirectory), "FE-Repo");
+        }
+
+        void OptionFERepoMusicInitUpdateButton_Click(object sender, EventArgs e) // #1813
+        {
+            RunSubmoduleInitUpdate(_optionFERepoMusicInitUpdateButton, _submoduleFERepoMusicUrl,
+                "submodule_fe_repo_music_url", GitUtil.FERepoMusicDefaultUrl,
+                GitUtil.GetFERepoMusicDir(Program.BaseDirectory), "FE-Repo-Midi");
+        }
+
+        // #1813: shared handler for the FE-Repo / FE-Repo-Midi Initialize/Update buttons — persists ONLY
+        // that repo's own URL key (never SaveSubmoduleUrls, which also applies the other fields), passes
+        // the effective URL (textbox else default) to the generic WinForms host, and disables the button
+        // for the duration.
+        void RunSubmoduleInitUpdate(Button button, TextBox urlTextBox, string configKey, string defaultUrl, string repoDir, string displayName)
+        {
+            string url = (urlTextBox.Text ?? "").Trim();
+            urlTextBox.Text = url; // reflect the trim back so a stray space can't be re-saved
+            Program.Config[configKey] = url;
+            Program.Config.Save();
+
+            button.Enabled = false;
+            try
+            {
+                string effUrl = string.IsNullOrWhiteSpace(url) ? defaultUrl : url;
+                ContentRepoGitWinForms.RunInitUpdate(this, repoDir, effUrl, displayName);
+            }
+            finally
+            {
+                button.Enabled = true;
             }
         }
 

--- a/FEBuilderGBA/Patch2GitWinForms.cs
+++ b/FEBuilderGBA/Patch2GitWinForms.cs
@@ -1,104 +1,25 @@
-using System;
 using System.Windows.Forms;
 
 namespace FEBuilderGBA
 {
     /// <summary>
-    /// #1812: WinForms host for the cross-platform <see cref="Patch2GitService"/> — runs an in-app
-    /// patch2 Initialize (clone) / Update (fetch+reset) with the standard <see cref="InputFormRef.AutoPleaseWait"/>
-    /// progress pump, mirroring <c>ToolUpdateDialogForm.AutoUpdatePatch2Git</c>. Shared by the OptionForm
-    /// and PatchForm "Initialize / Update Patch2" buttons so the logic lives in exactly one place and all
-    /// WinForms patch2 entry points go through the same single-flight guard inside Patch2GitService.
+    /// #1812: thin patch2 facade over <see cref="ContentRepoGitWinForms"/> (#1813). Kept so the merged
+    /// OptionForm/PatchForm patch2 buttons and the reflection test keep calling
+    /// <c>Patch2GitWinForms.RunInitUpdate(Form, string)</c> unchanged; it resolves the patch2 directory +
+    /// remote URL (custom fork override or default) and delegates to the generic WinForms host.
     /// </summary>
     public static class Patch2GitWinForms
     {
         /// <summary>
-        /// Runs the patch2 init/update synchronously on the UI thread (pumping the message loop while the
-        /// git op runs on a background Task) and shows the localized result. Returns the
-        /// <see cref="Patch2GitResult"/> so callers (e.g. PatchForm) can rescan on success.
-        /// <paramref name="urlOverride"/> (nullable) forces a specific remote — OptionForm passes its
-        /// Patch2 URL textbox so a just-typed custom fork URL takes effect.
+        /// Runs the in-app patch2 Initialize/Update. <paramref name="urlOverride"/> (nullable) forces a
+        /// specific remote — OptionForm passes its Patch2 URL textbox so a just-typed custom fork URL
+        /// takes effect. Returns the <see cref="Patch2GitResult"/> so PatchForm can rescan on success.
         /// </summary>
         public static Patch2GitResult RunInitUpdate(Form owner, string urlOverride)
         {
-            Patch2GitResult result;
-
-            using (InputFormRef.AutoPleaseWait pleaseWait = new InputFormRef.AutoPleaseWait(owner))
-            {
-                // lastLine[0] is written by the git output callback on the background thread and consumed
-                // by the UI-thread poll loop via Interlocked — the callback never touches any UI control
-                // (InputFormRef.DoEvents no-ops on a background thread, so it must not be called there).
-                var lastLine = new string[1];
-                Action<string> progress = line =>
-                {
-                    if (!string.IsNullOrEmpty(line))
-                        System.Threading.Interlocked.Exchange(ref lastLine[0], line);
-                };
-
-                pleaseWait.DoEvents("Git: patch2 ...");
-                var task = System.Threading.Tasks.Task.Run(
-                    () => Patch2GitService.InitializeOrUpdate(Program.BaseDirectory, progress, urlOverride));
-
-                // Pump the UI message loop while the background git op runs (mirror PollGitProgress).
-                while (!task.IsCompleted)
-                {
-                    string line = System.Threading.Interlocked.Exchange(ref lastLine[0], null);
-                    if (!string.IsNullOrEmpty(line))
-                        pleaseWait.DoEvents(line);
-                    else
-                        System.Windows.Forms.Application.DoEvents();
-                    System.Threading.Thread.Sleep(80);
-                }
-
-                // Flush any final progress line that arrived just before the task completed.
-                string lastFlush = System.Threading.Interlocked.Exchange(ref lastLine[0], null);
-                if (!string.IsNullOrEmpty(lastFlush))
-                    pleaseWait.DoEvents(lastFlush);
-
-                try
-                {
-                    result = task.Result;
-                }
-                catch (Exception ex)
-                {
-                    // Patch2GitService is result-based for the git ops themselves, but its backup file-move
-                    // (Directory.Move/Delete) can still throw on a real I/O error — convert a faulted Task
-                    // into a Failed result so reading task.Result never crashes the UI.
-                    result = new Patch2GitResult
-                    {
-                        Kind = Patch2GitResultKind.Failed,
-                        ExitCode = -1,
-                        Log = (ex.InnerException ?? ex).ToString(),
-                    };
-                }
-            }
-
-            // Back on the UI thread after the using block — show the localized result.
-            switch (result.Kind)
-            {
-                case Patch2GitResultKind.GitNotFound:
-                    R.ShowStopError("Git was not found. Install Git and try again, or set up config/patch2 manually — see the Patch Database Setup wiki page.");
-                    break;
-                case Patch2GitResultKind.AlreadyRunning:
-                    R.ShowStopError("A patch database operation is already running.");
-                    break;
-                case Patch2GitResultKind.Failed:
-                    string logTail = string.IsNullOrEmpty(result.Log) ? "" : "\r\n\r\n" + result.Log.Trim();
-                    if (result.ExitCode < 0)
-                        // Exception-synthesized fallback (a rare backup file-move I/O failure) — the
-                        // clone/update distinction isn't reliably known here, so use neutral wording.
-                        R.ShowStopError("Patch database operation failed.{0}", logTail);
-                    else if (result.WasClone)
-                        R.ShowStopError("Patch database initialization failed (git exit {0}).{1}", result.ExitCode, logTail);
-                    else
-                        R.ShowStopError("Patch database update failed (git exit {0}).{1}", result.ExitCode, logTail);
-                    break;
-                case Patch2GitResultKind.Success:
-                    R.ShowOK("Patch database updated. Restart recommended for all changes to take full effect.");
-                    break;
-            }
-
-            return result;
+            string repoDir = Patch2GitService.GetPatch2Dir(Program.BaseDirectory);
+            string url = string.IsNullOrWhiteSpace(urlOverride) ? GitUtil.GetPatch2RemoteUrl() : urlOverride;
+            return ContentRepoGitWinForms.RunInitUpdate(owner, repoDir, url, "Patch database");
         }
     }
 }

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -14171,3 +14171,9 @@ ROM（.gba）は絶対に添付しないでください。
 
 :This screen does not check for application updates yet. To initialize or update the patch database (patch2), use the Patch Manager or the Options window.
 この画面はまだアプリケーションの更新を確認しません。パッチデータベース（patch2）を初期化または更新するには、パッチマネージャまたはオプション画面を使用してください。
+
+:Initialize / Update FE-Repo Now
+FE-Repoを今すぐ初期化／更新
+
+:Initialize / Update FE-Repo-Midi Now
+FE-Repo-Midiを今すぐ初期化／更新

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -27992,3 +27992,9 @@ ROM 重建需要桌面文件系统访问权限，本设备不可用。
 
 :This screen does not check for application updates yet. To initialize or update the patch database (patch2), use the Patch Manager or the Options window.
 此界面尚不检查应用程序更新。要初始化或更新补丁数据库（patch2），请使用补丁管理器或选项窗口。
+
+:Initialize / Update FE-Repo Now
+立即初始化/更新 FE-Repo
+
+:Initialize / Update FE-Repo-Midi Now
+立即初始化/更新 FE-Repo-Midi


### PR DESCRIPTION
## Summary

Generalizes the patch2 in-app **Initialize (clone) / Update (fetch+reset) + configurable URL** workflow (#1812/#1817) so the three git-delivered repos — `config/patch2`, `resources/FE-Repo`, `resources/FE-Repo-Music-No-Preview` — **share one implementation** (#1813's explicit ask), and adds **FE-Repo + FE-Repo-Midi** management to both GUIs' Settings. Also fixes a real dead-UI bug the review board uncovered.

Plan + cross-model plan board on the issue (all three models BLOCKed the first plan; every required fix adopted — see the `## Cross-Model Review Board` comment on #1813).

## Scope

#1813 explicitly ships to **both GUIs** and exempts this blocking content-repo infra from the WinForms freeze. Reuses the merged patch2 code via delegation (patch2 behaviour preserved).

## What changed

- **Core `ContentRepoGitService`** — generic `InitializeOrUpdate(repoDir, url, progress)` holding the clone-or-update-with-backup logic + the **one canonical single-flight guard**. `Patch2GitService` is now a thin facade delegating to it, so its public API + `Patch2GitResult` types are unchanged and the **12 `Patch2GitServiceTests` stay green**. Backup dir is named after the repo (no more `_patch2_backup_` under `resources/`). `GitUtil` gains `GetFERepoRemoteUrl`/`GetFERepoMusicRemoteUrl` (custom key else default) + dir helpers.
- **WinForms** — generalized `ContentRepoGitWinForms.RunInitUpdate(Form, repoDir, url, displayName)` with **per-repo messages** (an FE-Repo failure no longer tells the user to fix `config/patch2`). OptionForm gains FE-Repo + FE-Repo-Midi Init/Update buttons (each persists only its own URL key).
- **Dead-UI fix** — the "Submodule Remote URLs" GroupBox only attached to a **non-existent "Etc" tab**, so the URL fields **and the merged #1812 patch2 button were invisible in production** (the 8 tabs are Path/…/Function 3). Now attaches to a real tab; a **behavioral test** renders `OptionForm` and asserts the attachment.
- **Avalonia** — `OptionsView` gains FE-Repo + FE-Repo-Midi Init/Update buttons via a shared parametrized handler.

## Screenshots

**WinForms OptionForm** (Function 3 tab) — the now-visible Submodule group with **Initialize / Update** buttons for Patch2, FE-Repo, and FE-Repo-Midi:

![WinForms OptionForm content repos](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/1813/optionform-content-repos.png)

**Avalonia Options** — the Submodule Remote URLs expander with the content-repo Init/Update surface:

![Avalonia Options content repos](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/1813/avalonia-options-content-repos.png)

## GUI Test Report

| # | GUI check | Result |
|---|---|---|
| 1 | WinForms OptionForm renders the Submodule group + Patch2/FE-Repo/FE-Repo-Midi buttons on a real tab (screenshot; dead-UI fix) | ✅ Pass |
| 2 | `OptionForm` Submodule GroupBox attaches to a visible `TabPage` (behavioral `Show()` test) | ✅ Pass |
| 3 | `OptionForm` exposes patch2/FE-Repo/FE-Repo-Midi button fields + handlers | ✅ Pass |
| 4 | Avalonia `OptionsView` exposes `InitUpdateFERepoButton` + `InitUpdateFERepoMusicButton` (headless) | ✅ Pass |
| 5 | No regression across Options/Patch2/L10n/ToolUpdateDialog (Avalonia 40, WinForms 42) | ✅ Pass |

## Test plan

- [x] `dotnet build` Core + Avalonia (Release) — 0 errors; WinForms `msbuild x86` — 0 errors
- [x] Core `Patch2GitServiceTests` (12, via delegation) + `ContentRepoGitServiceTests` (5: git-not-found, empty-dir named-backup clone, valid-submodule update-no-backup, **cross-service single-flight exclusion ×2**) — **17/17**
- [x] WinForms `Patch2InitUpdateWinFormsTests` (5, incl. the **behavioral dead-UI-fix attachment** test) — **5/5**; regression `Patch2|Option|ToolUpdateDialog` — **42/42**
- [x] Avalonia `Patch2InitUpdate` (5, incl. FE-Repo/Music buttons) + `L10nCoverage` (3) — regression `Options|Patch2InitUpdate|L10n|ToolUpdateDialog` — **40/40**
- [x] Real GUI screenshots of the actual OptionForm (all 3 buttons) + Avalonia Options (above)

Closes #1813

Copilot CLI: 1.0.69-0
Model: Claude Opus 4.8 (claude-opus-4.8)
