### PR TITLE
test: fix cross-class single-flight race in content-repo guard tests (#1813)

### DIFF
--- a/FEBuilderGBA.Core.Tests/ContentRepoGitServiceTests.cs
+++ b/FEBuilderGBA.Core.Tests/ContentRepoGitServiceTests.cs
@@ -11,6 +11,9 @@ using Xunit;
 
 namespace FEBuilderGBA.Core.Tests
 {
+    // Serialized with Patch2GitServiceTests: both exercise the shared static single-flight guard in
+    // ContentRepoGitService, so running them in parallel races. #1839 review-board finding.
+    [Collection("ContentRepoGitGuard")]
     public class ContentRepoGitServiceTests
     {
         static string NewRepoDir(out string baseDir)

--- a/FEBuilderGBA.Core.Tests/Patch2GitServiceTests.cs
+++ b/FEBuilderGBA.Core.Tests/Patch2GitServiceTests.cs
@@ -11,6 +11,10 @@ using Xunit;
 
 namespace FEBuilderGBA.Core.Tests
 {
+    // Serialized with ContentRepoGitServiceTests: both exercise the shared static single-flight guard in
+    // ContentRepoGitService, so running them in parallel races (a TryEnter in one class makes a TryEnter
+    // in the other unexpectedly return false). #1839 review-board finding.
+    [Collection("ContentRepoGitGuard")]
     public class Patch2GitServiceTests
     {
         static string NewBaseDir()


### PR DESCRIPTION
## Summary

Test-only follow-up to #1839 (content-repo generalization). The #1839 review board (claude-sonnet-5) found — and I empirically reproduced — a cross-class test race: `ContentRepoGitServiceTests` and `Patch2GitServiceTests` both exercise the **shared static single-flight guard** in `ContentRepoGitService`, but ran in parallel (separate classes) with no isolation. An isolated `--filter "FullyQualifiedName~SingleFlight"` run failed ~1/3 reliably (a `TryEnter` in one class makes a `TryEnter` in the other unexpectedly return `false`). The #1839 CI passed only by incidental timing.

## Fix

Put both classes in one xUnit collection (`[Collection("ContentRepoGitGuard")]`) so they serialize — no parallel access to the shared static guard.

## Test plan

- [x] Reproduced the race pre-fix: `--filter "FullyQualifiedName~SingleFlight"` failed 3/3 runs (1 of 3 tests failing)
- [x] Post-fix: `--filter "FullyQualifiedName~SingleFlight"` passes 4/4 repeated runs
- [x] No regression: full `Patch2GitService|ContentRepoGitService` filter — 17/17 pass

Test-only change (no production code, no GUI) — no screenshot applicable.

Refs #1813 / #1839

Copilot CLI: 1.0.69-0
Model: Claude Opus 4.8 (claude-opus-4.8)
