### PR TITLE
fix: correct FE-Repo-Midi typo to FE-Repo-Music in UI labels/messages/translations

### DIFF
--- a/FEBuilderGBA.Avalonia/Views/OptionsView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/OptionsView.axaml
@@ -49,9 +49,9 @@
                         HorizontalAlignment="Left" Margin="0,4,0,0" />
                 <TextBlock Text="FE-Repo-Music Remote URL" Margin="0,4,0,0" />
                 <TextBox AutomationProperties.AutomationId="Options_FERepoMusicUrlText_Input" Name="FERepoMusicUrlTextBox" Watermark="https://github.com/laqieer/FE-Repo-Music-No-Preview" />
-                <!-- #1813: in-app Initialize/Update of the FE-Repo-Midi (music) repository, next to its URL. -->
+                <!-- #1813: in-app Initialize/Update of the FE-Repo-Music (music) repository, next to its URL. -->
                 <Button AutomationProperties.AutomationId="Options_InitUpdateFERepoMusic_Button" Name="InitUpdateFERepoMusicButton"
-                        Content="Initialize / Update FE-Repo-Midi Now" Click="InitUpdateFERepoMusic_Click"
+                        Content="Initialize / Update FE-Repo-Music Now" Click="InitUpdateFERepoMusic_Click"
                         HorizontalAlignment="Left" Margin="0,4,0,0" />
               </StackPanel>
             </Expander>

--- a/FEBuilderGBA.Avalonia/Views/OptionsView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OptionsView.axaml.cs
@@ -194,11 +194,11 @@ namespace FEBuilderGBA.Avalonia.Views
             => await RunContentRepoInitUpdate(InitUpdateFERepoMusicButton, FERepoMusicUrlTextBox,
                 "submodule_fe_repo_music_url", GitUtil.FERepoMusicDefaultUrl,
                 GitUtil.GetFERepoMusicDir(CoreState.BaseDirectory ?? AppDomain.CurrentDomain.BaseDirectory),
-                "FE-Repo-Midi");
+                "FE-Repo-Music");
 
         /// <summary>
         /// #1813: shared in-app Initialize (clone) / Update (fetch+reset) of a git-delivered content repo
-        /// (patch2 / FE-Repo / FE-Repo-Midi), next to its remote-URL field. Trims + persists ONLY that
+        /// (patch2 / FE-Repo / FE-Repo-Music), next to its remote-URL field. Trims + persists ONLY that
         /// repo's own URL config key (never the whole Options form), passes the effective URL directly
         /// (falling back to <paramref name="defaultUrl"/> when blank), and runs off the UI thread. All
         /// user-facing messages use <paramref name="displayName"/> so a failure names the correct repo.

--- a/FEBuilderGBA.Core.Tests/ContentRepoGitServiceTests.cs
+++ b/FEBuilderGBA.Core.Tests/ContentRepoGitServiceTests.cs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // #1813 — ContentRepoGitService: the generic in-app clone-or-update engine shared by patch2, FE-Repo,
-// and FE-Repo-Midi. The full clone/backup/restore matrix is already covered by the 12 Patch2GitServiceTests
+// and FE-Repo-Music. The full clone/backup/restore matrix is already covered by the 12 Patch2GitServiceTests
 // (which now exercise this core via the patch2 shim); this file adds the generic-API coverage plus the
 // cross-service single-flight exclusion the review board required.
 using System;

--- a/FEBuilderGBA.Core/GitUtil.cs
+++ b/FEBuilderGBA.Core/GitUtil.cs
@@ -32,7 +32,7 @@ namespace FEBuilderGBA
             return FERepoDefaultUrl;
         }
 
-        /// <summary>Returns the FE-Repo-Midi (music) remote URL: a user-configured custom URL when set, else the default (#1813).</summary>
+        /// <summary>Returns the FE-Repo-Music (music) remote URL: a user-configured custom URL when set, else the default (#1813).</summary>
         public static string GetFERepoMusicRemoteUrl()
         {
             string custom = CoreState.Config?.at("submodule_fe_repo_music_url", "");
@@ -45,7 +45,7 @@ namespace FEBuilderGBA
         public static string GetFERepoDir(string baseDir)
             => Path.Combine(baseDir ?? "", "resources", "FE-Repo");
 
-        /// <summary>Repo-root FE-Repo-Midi resource directory: <c>&lt;baseDir&gt;/resources/FE-Repo-Music-No-Preview</c> (#1813).</summary>
+        /// <summary>Repo-root FE-Repo-Music resource directory: <c>&lt;baseDir&gt;/resources/FE-Repo-Music-No-Preview</c> (#1813).</summary>
         public static string GetFERepoMusicDir(string baseDir)
             => Path.Combine(baseDir ?? "", "resources", "FE-Repo-Music-No-Preview");
 

--- a/FEBuilderGBA.Core/Patch2GitService.cs
+++ b/FEBuilderGBA.Core/Patch2GitService.cs
@@ -12,7 +12,7 @@ namespace FEBuilderGBA
         AlreadyRunning,
     }
 
-    /// <summary>Result of an in-app content-repo initialize/update operation (shared across patch2 / FE-Repo / FE-Repo-Midi).</summary>
+    /// <summary>Result of an in-app content-repo initialize/update operation (shared across patch2 / FE-Repo / FE-Repo-Music).</summary>
     public sealed class Patch2GitResult
     {
         public Patch2GitResultKind Kind { get; init; }

--- a/FEBuilderGBA.Tests/Unit/Patch2InitUpdateWinFormsTests.cs
+++ b/FEBuilderGBA.Tests/Unit/Patch2InitUpdateWinFormsTests.cs
@@ -9,7 +9,7 @@ namespace FEBuilderGBA.Tests.Unit
     /// <summary>
     /// #1812/#1813: verifies the WinForms in-app content-repo Initialize/Update wiring — the shared
     /// <see cref="ContentRepoGitWinForms.RunInitUpdate"/> host + the patch2 facade, the OptionForm patch2 /
-    /// FE-Repo / FE-Repo-Midi buttons + handlers, and the PatchForm button. Also a BEHAVIORAL test that
+    /// FE-Repo / FE-Repo-Music buttons + handlers, and the PatchForm button. Also a BEHAVIORAL test that
     /// the "Submodule Remote URLs" GroupBox actually attaches to a visible tab (regression guard for the
     /// #1813 dead-UI fix — the pre-existing condition only matched a non-existent "Etc" tab). The
     /// clone/update logic itself is covered by the Core Patch2GitService/ContentRepoGitService tests.

--- a/FEBuilderGBA/ContentRepoGitWinForms.cs
+++ b/FEBuilderGBA/ContentRepoGitWinForms.cs
@@ -6,7 +6,7 @@ namespace FEBuilderGBA
     /// <summary>
     /// #1813: WinForms host for the cross-platform <see cref="ContentRepoGitService"/> — runs an in-app
     /// Initialize (clone) / Update (fetch+reset) of any git-delivered content repo (patch2 / FE-Repo /
-    /// FE-Repo-Midi) with the standard <see cref="InputFormRef.AutoPleaseWait"/> progress pump, mirroring
+    /// FE-Repo-Music) with the standard <see cref="InputFormRef.AutoPleaseWait"/> progress pump, mirroring
     /// <c>ToolUpdateDialogForm.AutoUpdatePatch2Git</c>. All user-facing messages are parametrized by a
     /// repo <c>displayName</c> so a failure names the correct repo (not always "patch2"). Every WinForms
     /// content-repo entry point goes through the same single-flight guard inside

--- a/FEBuilderGBA/OptionForm.cs
+++ b/FEBuilderGBA/OptionForm.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
@@ -2040,14 +2040,14 @@ namespace FEBuilderGBA
                     _optionFERepoInitUpdateButton.Click += OptionFERepoInitUpdateButton_Click;
                     panel.Controls.Add(_optionFERepoInitUpdateButton, 1, 3);
 
-                    // FE-Repo-Midi (music) URL + Initialize/Update button (#1813)
+                    // FE-Repo-Music (music) URL + Initialize/Update button (#1813)
                     panel.Controls.Add(new Label { Text = R._("Music URL:"), Dock = DockStyle.Fill }, 0, 4);
                     panel.Controls.Add(_submoduleFERepoMusicUrl, 1, 4);
                     _submoduleFERepoMusicUrl.Dock = DockStyle.Fill;
                     _optionFERepoMusicInitUpdateButton = new Button
                     {
                         Name = "OptionFERepoMusicInitUpdateButton",
-                        Text = R._("Initialize / Update FE-Repo-Midi Now"),
+                        Text = R._("Initialize / Update FE-Repo-Music Now"),
                         AutoSize = true,
                         Anchor = AnchorStyles.Left
                     };
@@ -2093,10 +2093,10 @@ namespace FEBuilderGBA
         {
             RunSubmoduleInitUpdate(_optionFERepoMusicInitUpdateButton, _submoduleFERepoMusicUrl,
                 "submodule_fe_repo_music_url", GitUtil.FERepoMusicDefaultUrl,
-                GitUtil.GetFERepoMusicDir(Program.BaseDirectory), "FE-Repo-Midi");
+                GitUtil.GetFERepoMusicDir(Program.BaseDirectory), "FE-Repo-Music");
         }
 
-        // #1813: shared handler for the FE-Repo / FE-Repo-Midi Initialize/Update buttons — persists ONLY
+        // #1813: shared handler for the FE-Repo / FE-Repo-Music Initialize/Update buttons — persists ONLY
         // that repo's own URL key (never SaveSubmoduleUrls, which also applies the other fields), passes
         // the effective URL (textbox else default) to the generic WinForms host, and disables the button
         // for the duration.

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -14175,5 +14175,5 @@ ROM（.gba）は絶対に添付しないでください。
 :Initialize / Update FE-Repo Now
 FE-Repoを今すぐ初期化／更新
 
-:Initialize / Update FE-Repo-Midi Now
-FE-Repo-Midiを今すぐ初期化／更新
+:Initialize / Update FE-Repo-Music Now
+FE-Repo-Musicを今すぐ初期化／更新

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -27996,5 +27996,5 @@ ROM 重建需要桌面文件系统访问权限，本设备不可用。
 :Initialize / Update FE-Repo Now
 立即初始化/更新 FE-Repo
 
-:Initialize / Update FE-Repo-Midi Now
-立即初始化/更新 FE-Repo-Midi
+:Initialize / Update FE-Repo-Music Now
+立即初始化/更新 FE-Repo-Music


### PR DESCRIPTION
## Summary

`FE-Repo-Midi` was a typo for **`FE-Repo-Music`** (the repo is `FE-Repo-Music-No-Preview`; the config key `submodule_fe_repo_music_url` and all identifiers already used `FERepoMusic`). Introduced as a display-string typo in #1813 — this is a **pure string rename, no logic change**.

Corrected in both GUIs + shared code/translations:
- Button label `Initialize / Update FE-Repo-Music Now` (Avalonia + WinForms)
- The `displayName` used in result messages (`FE-Repo-Music updated`, etc.)
- ja/zh translation key + values
- Code comments (Core/GitUtil, Patch2GitService, ContentRepoGitWinForms, tests)

## Test plan

- [x] `dotnet build` Core + Avalonia (Release) — 0 errors; WinForms `msbuild x86` — 0 errors
- [x] Core `Patch2GitService|ContentRepoGitService` — 17/17
- [x] Avalonia `Patch2InitUpdate|L10nCoverage` — 15/15 (L10n happy with the renamed translation key)
- [x] WinForms `Patch2InitUpdateWinForms` — 5/5

Pure rename, no GUI behavior change — no screenshot applicable.

Refs #1813

Copilot CLI: 1.0.69-0
Model: Claude Opus 4.8 (claude-opus-4.8)
