### PR TITLE
fix: always show FE-Repo-Music button on Song editors (#1815)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/SongTrackFERepoMusicTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/SongTrackFERepoMusicTests.cs
@@ -44,7 +44,10 @@ namespace FEBuilderGBA.Avalonia.Tests
             // button), so it is discoverable even before the music submodule is
             // cloned; the browser then shows the "not found / clone" empty-state.
             Assert.Contains("SongTrack_FERepoMusic_Button", axaml);
-            Assert.DoesNotContain("IsVisible=\"{Binding IsFERepoMusicAvailable}\"", axaml);
+            // Assert the availability property is absent entirely (not just one
+            // exact IsVisible-binding string) so a reintroduced gate with
+            // different whitespace/formatting is caught (#1845 bot review).
+            Assert.DoesNotContain("IsFERepoMusicAvailable", axaml);
         }
 
         [Fact]
@@ -69,8 +72,9 @@ namespace FEBuilderGBA.Avalonia.Tests
 
             string axaml = ReadSource(Path.Combine("FEBuilderGBA.Avalonia", "Views", "SongExchangeView.axaml"));
             Assert.Contains("SongExchange_FERepoMusic_Button", axaml);
-            // #1815: always visible, not gated on music-submodule availability.
-            Assert.DoesNotContain("IsVisible=\"{Binding IsFERepoMusicAvailable}\"", axaml);
+            // #1815: always visible — assert the availability property is absent
+            // entirely so a reformatted gate is still caught (#1845 bot review).
+            Assert.DoesNotContain("IsFERepoMusicAvailable", axaml);
         }
 
         [Fact]

--- a/FEBuilderGBA.Avalonia.Tests/SongTrackFERepoMusicTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/SongTrackFERepoMusicTests.cs
@@ -37,12 +37,14 @@ namespace FEBuilderGBA.Avalonia.Tests
         }
 
         [Fact]
-        public void FERepoMusicButton_IsGatedByAvailability()
+        public void FERepoMusicButton_IsAlwaysVisible_NotGated()
         {
             string axaml = ReadSource(Path.Combine("FEBuilderGBA.Avalonia", "Views", "SongTrackView.axaml"));
-            // The button visibility binds to the VM availability flag.
+            // #1815: the button is ALWAYS visible (like the graphics FE-Repo
+            // button), so it is discoverable even before the music submodule is
+            // cloned; the browser then shows the "not found / clone" empty-state.
             Assert.Contains("SongTrack_FERepoMusic_Button", axaml);
-            Assert.Contains("IsVisible=\"{Binding IsFERepoMusicAvailable}\"", axaml);
+            Assert.DoesNotContain("IsVisible=\"{Binding IsFERepoMusicAvailable}\"", axaml);
         }
 
         [Fact]
@@ -67,7 +69,8 @@ namespace FEBuilderGBA.Avalonia.Tests
 
             string axaml = ReadSource(Path.Combine("FEBuilderGBA.Avalonia", "Views", "SongExchangeView.axaml"));
             Assert.Contains("SongExchange_FERepoMusic_Button", axaml);
-            Assert.Contains("IsVisible=\"{Binding IsFERepoMusicAvailable}\"", axaml);
+            // #1815: always visible, not gated on music-submodule availability.
+            Assert.DoesNotContain("IsVisible=\"{Binding IsFERepoMusicAvailable}\"", axaml);
         }
 
         [Fact]

--- a/FEBuilderGBA.Avalonia/Services/FERepoPickHelper.cs
+++ b/FEBuilderGBA.Avalonia/Services/FERepoPickHelper.cs
@@ -40,27 +40,18 @@ namespace FEBuilderGBA.Avalonia.Services
         }
 
         /// <summary>
-        /// True when the FE-Repo-Music submodule is checked out (folder present /
-        /// not an empty placeholder). The Song editors use this to decide whether
-        /// to show/enable the "FE-Repo-Music" button (#1383).
-        /// </summary>
-        public static bool IsMusicSupported()
-            => FERepoResourceBrowser.IsMusicRepoAvailable(
-                CoreState.BaseDirectory ?? System.AppContext.BaseDirectory);
-
-        /// <summary>
         /// Open the FE-Repo-Music browser (music mode) and await the user's chosen
         /// music file path. Optionally pre-navigate to a seed category/subcategory.
-        /// Returns null when the music submodule is unavailable, the dialog was
-        /// cancelled, or nothing was selected. The caller feeds the returned path
+        /// Returns null when the dialog was cancelled or nothing was selected. The
+        /// browser is ALWAYS openable — when the music submodule is absent it shows
+        /// an actionable "not found / clone" empty-state (#1815), so this no longer
+        /// short-circuits on availability. The caller feeds the returned path
         /// through the SAME music-import dispatcher as its file-picker Import —
         /// no second import code path (#1383).
         /// </summary>
         public static async Task<string?> PickMusic(Window owner,
             string seedCategory = null, string seedSubCategory = null)
         {
-            if (!IsMusicSupported()) return null;
-
             var browser = new FERepoResourceBrowserWindow(true, seedCategory, seedSubCategory);
             string result = await browser.ShowDialog<string>(owner);
             return string.IsNullOrEmpty(result) ? null : result;

--- a/FEBuilderGBA.Avalonia/ViewModels/SongExchangeViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SongExchangeViewModel.cs
@@ -19,16 +19,6 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
 
-        /// <summary>
-        /// True when the FE-Repo-Music submodule is checked out, so the
-        /// "FE-Repo-Music" button is shown (#1383). Cached — submodule presence
-        /// does not change at runtime, so the directory probe runs at most once.
-        /// </summary>
-        bool? _isFERepoMusicAvailable;
-        public bool IsFERepoMusicAvailable
-            => _isFERepoMusicAvailable ??= FERepoResourceBrowser.IsMusicRepoAvailable(
-                CoreState.BaseDirectory ?? System.AppContext.BaseDirectory);
-
         // Parsed song lists (Core SongSt) for the current + other ROM.
         public List<SongExchangeCore.SongSt> MySongList { get; private set; } = new();
         public List<SongExchangeCore.SongSt> OtherSongList { get; private set; } = new();

--- a/FEBuilderGBA.Avalonia/ViewModels/SongTrackViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SongTrackViewModel.cs
@@ -163,18 +163,6 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
 
-        /// <summary>
-        /// True when the FE-Repo-Music submodule is checked out, so the
-        /// "FE-Repo-Music" import button should be shown (#1383). The View binds
-        /// the button's IsVisible to this. Resolved once (lazily) from the music
-        /// repo root — the submodule presence does not change at runtime, so the
-        /// directory probe is cached to avoid a filesystem hit on every binding
-        /// evaluation (#1383 review).
-        /// </summary>
-        bool? _isFERepoMusicAvailable;
-        public bool IsFERepoMusicAvailable
-            => _isFERepoMusicAvailable ??= FERepoResourceBrowser.IsMusicRepoAvailable(
-                CoreState.BaseDirectory ?? System.AppContext.BaseDirectory);
         /// <summary>Number of tracks in this song (B0).</summary>
         public uint TrackCount { get => _trackCount; set => SetField(ref _trackCount, value); }
         /// <summary>Number of blocks (B1).</summary>

--- a/FEBuilderGBA.Avalonia/Views/SongExchangeView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SongExchangeView.axaml
@@ -45,13 +45,13 @@
           <Button AutomationProperties.AutomationId="SongExchange_Convert_Button"
                   Name="ConvertButton" Content="Convert (transplant -&gt;)" Click="Convert_Click"
                   HorizontalAlignment="Left" />
-          <!-- #1383: import the selected destination song from the FE-Repo-Music
+          <!-- #1815: import the selected destination song from the FE-Repo-Music
                submodule. Routes through the Song Track Editor's ONE shared import
-               dispatcher (no duplicate importer). Shown only when the music
-               submodule exists. -->
+               dispatcher (no duplicate importer). ALWAYS visible (like the
+               graphics FE-Repo button) so it is discoverable; the browser shows a
+               "not found / clone" empty-state when the music submodule is absent. -->
           <Button AutomationProperties.AutomationId="SongExchange_FERepoMusic_Button"
                   Name="FERepoMusicButton" Content="FE-Repo-Music" Click="FERepoMusic_Click"
-                  IsVisible="{Binding IsFERepoMusicAvailable}"
                   ToolTip.Tip="Browse the FE-Repo-Music submodule and import the selected destination song via the Song Track Editor's import (same import path as Import Music File)." />
         </StackPanel>
       </StackPanel>

--- a/FEBuilderGBA.Avalonia/Views/SongTrackView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SongTrackView.axaml
@@ -94,13 +94,14 @@
                       Name="ImportButton" Content="Import Music File"
                       Width="140" Click="ImportMidi_Click"
                       ToolTip.Tip="Imports by file extension: a MIDI (.mid), a raw RIFF WAV (.wav, builds a one-track song that plays the sample), an instrument set (.instrument), or a SondFont source (.s, pick an instrument set then assemble)." />
-              <!-- #1383: import sourced from the FE-Repo-Music submodule. Routes
+              <!-- #1815: import sourced from the FE-Repo-Music submodule. Routes
                    the chosen music file through the SAME dispatcher as "Import
-                   Music File". Visible only when the music submodule exists. -->
+                   Music File". ALWAYS visible (like the graphics FE-Repo button)
+                   so it is discoverable; the browser shows a "not found / clone"
+                   empty-state when the music submodule is absent. -->
               <Button AutomationProperties.AutomationId="SongTrack_FERepoMusic_Button"
                       Name="FERepoMusicButton" Content="FE-Repo-Music"
                       Width="140" Click="FERepoMusic_Click"
-                      IsVisible="{Binding IsFERepoMusicAvailable}"
                       ToolTip.Tip="Browse the FE-Repo-Music submodule and import the selected music file into the current song (same import path as Import Music File)." />
               <Button AutomationProperties.AutomationId="SongTrack_Export_Button"
                       Name="ExportButton" Content="Export Music File"

--- a/FEBuilderGBA.Avalonia/Views/SongTrackView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SongTrackView.axaml.cs
@@ -491,8 +491,9 @@ namespace FEBuilderGBA.Avalonia.Views
         // #1383: the FE-Repo-Music button opens the music-mode FE-Repo browser
         // and feeds the selected music file through the SAME dispatcher as the
         // "Import Music File" button (ImportMusicPath) — no second import path.
-        // The button is only visible when the music submodule is checked out
-        // (FERepoPickHelper.IsMusicSupported, bound to VM.IsFERepoMusicAvailable).
+        // #1815: the button is ALWAYS visible (like the graphics FE-Repo button);
+        // when the music submodule is absent the browser shows a "not found /
+        // clone" empty-state, so it is discoverable rather than hidden.
         // -----------------------------------------------------------------
         async void FERepoMusic_Click(object? sender, RoutedEventArgs e)
         {

--- a/FEBuilderGBA.Core/FERepoResourceBrowser.cs
+++ b/FEBuilderGBA.Core/FERepoResourceBrowser.cs
@@ -152,9 +152,12 @@ namespace FEBuilderGBA
 
         /// <summary>
         /// True when the FE-Repo-Music submodule is checked out (resolves to a
-        /// real, populated root from <paramref name="baseDir"/>). Shared guard
-        /// used by both GUIs to decide whether to show/enable the
-        /// "FE-Repo-Music" button on the Song editors (#1383). Reuses the #1380
+        /// real, populated root from <paramref name="baseDir"/>). Retained as a
+        /// public, test-covered helper: as of #1815 the Song-editor
+        /// "FE-Repo-Music" button is ALWAYS shown (like the graphics FE-Repo
+        /// button) and its browser surfaces the missing-repo empty-state, so this
+        /// no longer gates the button — but it remains available for callers that
+        /// need to probe music-repo presence. Reuses the #1380
         /// empty-placeholder-as-not-found semantics of
         /// <see cref="FindMusicRepoRoot"/>. Never throws.
         /// </summary>

--- a/FEBuilderGBA.Tests/SongFERepoMusicSinglePathTests.cs
+++ b/FEBuilderGBA.Tests/SongFERepoMusicSinglePathTests.cs
@@ -64,10 +64,15 @@ namespace FEBuilderGBA.Tests
         }
 
         [Fact]
-        public void SongTrackForm_FERepoButton_GuardedByMusicRepoAvailability()
+        public void SongTrackForm_FERepoButton_IsAlwaysCreated_NotGated()
         {
+            // #1815: the FE-Repo-Music button is ALWAYS created (like the graphics
+            // FE-Repo button), so it is discoverable even before the music
+            // submodule is cloned; its browser then shows the "not found / clone"
+            // empty-state. It must NOT be wrapped in an availability gate.
             string src = ReadSource("SongTrackForm.cs");
-            Assert.Contains("FERepoResourceBrowser.IsMusicRepoAvailable", src);
+            Assert.Contains("feRepoMusicButton.Click += FERepoMusicButton_Click", src);
+            Assert.DoesNotContain("if (FERepoResourceBrowser.IsMusicRepoAvailable", src);
         }
 
         [Fact]
@@ -75,9 +80,10 @@ namespace FEBuilderGBA.Tests
         {
             // #1383 review: the existing action row is full, so the button goes on
             // a new row and the (Dock=Top) host panel must be grown to fit it,
-            // otherwise it would be clipped below the panel.
+            // otherwise it would be clipped below the panel. (#1815 re-anchored the
+            // search from the removed availability gate to the button's Name.)
             string src = ReadSource("SongTrackForm.cs");
-            int handler = src.IndexOf("FERepoResourceBrowser.IsMusicRepoAvailable", StringComparison.Ordinal);
+            int handler = src.IndexOf("Name = \"FERepoMusicButton\"", StringComparison.Ordinal);
             Assert.True(handler >= 0);
             string block = src.Substring(handler);
             Assert.Contains("row.Height", block);
@@ -95,10 +101,13 @@ namespace FEBuilderGBA.Tests
         }
 
         [Fact]
-        public void SongExchangeForm_FERepoButton_GuardedByMusicRepoAvailability()
+        public void SongExchangeForm_FERepoButton_IsAlwaysCreated_NotGated()
         {
+            // #1815: always created (consistent with SongTrackForm + the graphics
+            // FE-Repo button), not gated on music-submodule availability.
             string src = ReadSource("SongExchangeForm.cs");
-            Assert.Contains("FERepoResourceBrowser.IsMusicRepoAvailable", src);
+            Assert.Contains("feRepoMusicButton.Click += FERepoMusicButton_Click", src);
+            Assert.DoesNotContain("if (FERepoResourceBrowser.IsMusicRepoAvailable", src);
         }
 
         static string ReadSource(string fileName)

--- a/FEBuilderGBA.Tests/SongFERepoMusicSinglePathTests.cs
+++ b/FEBuilderGBA.Tests/SongFERepoMusicSinglePathTests.cs
@@ -72,7 +72,10 @@ namespace FEBuilderGBA.Tests
             // empty-state. It must NOT be wrapped in an availability gate.
             string src = ReadSource("SongTrackForm.cs");
             Assert.Contains("feRepoMusicButton.Click += FERepoMusicButton_Click", src);
-            Assert.DoesNotContain("if (FERepoResourceBrowser.IsMusicRepoAvailable", src);
+            // Assert the absence of the availability PROBE itself (not just the
+            // "if (...)" wording) so a reintroduced gate — even reformatted or via
+            // a temp variable — is caught (#1845 bot review).
+            Assert.DoesNotContain("FERepoResourceBrowser.IsMusicRepoAvailable", src);
         }
 
         [Fact]
@@ -107,7 +110,8 @@ namespace FEBuilderGBA.Tests
             // FE-Repo button), not gated on music-submodule availability.
             string src = ReadSource("SongExchangeForm.cs");
             Assert.Contains("feRepoMusicButton.Click += FERepoMusicButton_Click", src);
-            Assert.DoesNotContain("if (FERepoResourceBrowser.IsMusicRepoAvailable", src);
+            // Absence of the availability probe itself (#1845 bot review).
+            Assert.DoesNotContain("FERepoResourceBrowser.IsMusicRepoAvailable", src);
         }
 
         static string ReadSource(string fileName)

--- a/FEBuilderGBA/SongExchangeForm.cs
+++ b/FEBuilderGBA/SongExchangeForm.cs
@@ -22,22 +22,26 @@ namespace FEBuilderGBA
             this.SongTable.OwnerDraw(ListBoxEx.DrawTextOnly, DrawMode.OwnerDrawFixed);
             this.OtherROMSongTable.OwnerDraw(ListBoxEx.DrawTextOnly, DrawMode.OwnerDrawFixed);
 
-            // #1383: "FE-Repo-Music" import button — only shown when the
-            // FE-Repo-Music submodule is checked out. Upgraded from the old
-            // clipboard-copy behaviour to actually IMPORT the selected music file
-            // into the currently-selected song, reusing the SAME music-import
-            // dispatcher as the Song Track Editor (SongTrackForm.ImportMusicFileToSong).
-            string baseDir = CoreState.BaseDirectory ?? AppDomain.CurrentDomain.BaseDirectory;
-            if (FERepoResourceBrowser.IsMusicRepoAvailable(baseDir))
+            // #1815: "FE-Repo-Music" import button — ALWAYS shown (like the
+            // graphics FE-Repo button), so it is discoverable even before the
+            // FE-Repo-Music submodule is checked out; its browser then shows the
+            // actionable "not found / clone" empty-state. Imports the selected
+            // music file into the currently-selected song, reusing the SAME
+            // music-import dispatcher as the Song Track Editor
+            // (SongTrackForm.ImportMusicFileToSong). Placed inside panel2 (the
+            // content host) in the clear gap between the sound-table label
+            // (ends x~601) and the "Open other ROM" button (starts x=733) so it
+            // is visible rather than hidden behind the panel at the old form
+            // origin (0,0).
             {
                 var feRepoMusicButton = new Button
                 {
                     Text = R._("FE-Repo-Music"),
                     Size = new System.Drawing.Size(120, 25),
-                    Location = new System.Drawing.Point(5, 5)
+                    Location = new System.Drawing.Point(607, 13)
                 };
                 feRepoMusicButton.Click += FERepoMusicButton_Click;
-                this.Controls.Add(feRepoMusicButton);
+                this.panel2.Controls.Add(feRepoMusicButton);
                 feRepoMusicButton.BringToFront();
             }
         }

--- a/FEBuilderGBA/SongExchangeForm.cs
+++ b/FEBuilderGBA/SongExchangeForm.cs
@@ -29,16 +29,18 @@ namespace FEBuilderGBA
             // music file into the currently-selected song, reusing the SAME
             // music-import dispatcher as the Song Track Editor
             // (SongTrackForm.ImportMusicFileToSong). Placed inside panel2 (the
-            // content host) in the clear gap between the sound-table label
-            // (ends x~601) and the "Open other ROM" button (starts x=733) so it
-            // is visible rather than hidden behind the panel at the old form
+            // content host) in the clear gap just right of the sound-table label
+            // and left of the "Open other ROM" button, positioned RELATIVE to
+            // label3 (not hard-coded) so it stays correct across DPI/designer
+            // changes — rather than hidden behind the panel at the old form
             // origin (0,0).
             {
                 var feRepoMusicButton = new Button
                 {
                     Text = R._("FE-Repo-Music"),
+                    Name = "FERepoMusicButton",
                     Size = new System.Drawing.Size(120, 25),
-                    Location = new System.Drawing.Point(607, 13)
+                    Location = new System.Drawing.Point(this.label3.Right + 6, this.label3.Top)
                 };
                 feRepoMusicButton.Click += FERepoMusicButton_Click;
                 this.panel2.Controls.Add(feRepoMusicButton);

--- a/FEBuilderGBA/SongTrackForm.cs
+++ b/FEBuilderGBA/SongTrackForm.cs
@@ -59,14 +59,15 @@ namespace FEBuilderGBA
                 }
             });
 
-            // #1383: "FE-Repo-Music" import button — only shown when the
-            // FE-Repo-Music submodule is checked out. Imports the chosen file via
-            // the same path as ImportButton (AutoDrag -> ImportButton_Click).
-            // The existing action row (Y=23) is full, so the button goes on a new
-            // row directly under Import; panel5 is Dock=Top, so growing its height
-            // pushes the content below down instead of clipping the button.
-            string baseDir = CoreState.BaseDirectory ?? AppDomain.CurrentDomain.BaseDirectory;
-            if (FERepoResourceBrowser.IsMusicRepoAvailable(baseDir))
+            // #1815: "FE-Repo-Music" import button — ALWAYS shown (like the
+            // graphics FE-Repo button), so it is discoverable even before the
+            // FE-Repo-Music submodule is checked out; its browser
+            // (FERepoMusicBrowserForm) then shows the actionable "not found /
+            // clone" empty-state. Imports the chosen file via the same path as
+            // ImportButton (AutoDrag -> ImportButton_Click). The existing action
+            // row (Y=23) is full, so the button goes on a new row directly under
+            // Import; panel5 is Dock=Top, so growing its height pushes the content
+            // below down instead of clipping the button.
             {
                 System.Windows.Forms.Control row = this.ImportButton.Parent;
                 int newY = this.ImportButton.Location.Y + this.ImportButton.Height + 2;


### PR DESCRIPTION
## Summary
The **FE-Repo-Music** button on the Song editors (added in #1383) was **gated on the FE-Repo-Music submodule being checked out**, so it was **hidden** whenever `resources/FE-Repo-Music-No-Preview` wasn't cloned — which is exactly why the maintainer (issue reporter) couldn't find it. The graphics **FE-Repo** button is *never* gated: it's always visible and its browser shows a clone empty-state. This PR makes FE-Repo-Music behave the same way — a discoverability/consistency **bug fix**.

Root-cause analysis + plan reviewed by a cross-model board on the [issue](https://github.com/laqieer/FEBuilderGBA/issues/1815#issuecomment-4885366719); all blocking items adopted (the 5th gate in `SongExchangeForm`, the 5 gate-asserting test migrations).

## Scope
Closes #1815.

## Changes — un-gated in all 5 places (the whole class)
- **WinForms** `SongTrackForm.cs`, `SongExchangeForm.cs`: always create the button.
- **Avalonia** `SongTrackView.axaml`, `SongExchangeView.axaml`: drop the `IsVisible="{Binding IsFERepoMusicAvailable}"` gate.
- **Avalonia** `FERepoPickHelper.PickMusic`: drop the `!IsMusicSupported()` early-return so the browser opens and shows its empty-state.

The music browsers already handle the missing-repo empty-state (WinForms `FERepoMusicBrowserForm`; Avalonia `FERepoResourceBrowserViewModel` music mode, incl. the Android-aware notice), so un-gating is safe and Android parity holds.

Also fixed a **pre-existing #1383 placement bug** the un-gating exposed: the WinForms `SongExchangeForm` button was added to the *form* at `(5,5)` — behind the content panel, overlapping the sound-table label. It now lives in `panel2`'s clear top gap so it is genuinely visible.

**Dead code removed**: `SongTrackViewModel`/`SongExchangeViewModel.IsFERepoMusicAvailable` + `FERepoPickHelper.IsMusicSupported` (their only consumers were the gates). Core `FERepoResourceBrowser.IsMusicRepoAvailable` kept (public API).

## Screenshots
WinForms Song Track editor (FE8U) — **no music repo cloned in this worktree**, yet the **FE-Repo-Music** button is now visible below "Import Music File" (before this fix it would be hidden):

![Song Track editor with always-visible FE-Repo-Music button](https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/pr1815-songtrack-ferepomusic.png)

## GUI Test Report
| Scenario | Result |
|---|---|
| WinForms Song Track editor: FE-Repo-Music button visible with no music repo cloned (FE8U) | ✅ Pass (screenshot above; rendered via `--screenshot-all`) |
| WinForms Song Exchange editor: button always created + relocated to `panel2`'s visible gap | ✅ Pass (code + `SongExchangeForm_FERepoButton_IsAlwaysCreated_NotGated`; the `--screenshot-all` harness does not capture this form's ctor-added control) |
| Avalonia Song Track + Song Exchange: `IsVisible` gate removed (always visible) | ✅ Pass (`SongTrackFERepoMusicTests` migrated to assert no gate; full Avalonia suite green) |
| Missing-repo empty-state still reachable (un-gating is safe) | ✅ Pass (browsers guard `repoRoot == null`; Android notice preserved) |

## Test plan
- [x] Core builds clean; WinForms x86 builds clean (0 errors); Avalonia builds clean (0 errors)
- [x] Migrated the 5 gate-asserting tests to assert the button is **always** present (WinForms `SongFERepoMusicSinglePathTests` 7/7; Avalonia `SongTrackFERepoMusicTests` 4/4)
- [x] Re-anchored `SongTrackForm_FERepoButton_GrowsHostPanel...` from the removed gate string to the button `Name`
- [x] Preserved the composite Song-Exchange single-import-path assertions (only the `IsVisible` assertion changed)
- [x] Full WinForms unit suite green (`FEBuilderGBA.Tests`: 1954 passed / 0 failed)
- [x] Full Avalonia suite green (`FEBuilderGBA.Avalonia.Tests`: 9357 passed / 0 failed) — confirms removing the VM props caused no regression
- [x] Real WinForms GUI screenshot of the affected editor captured (button visible with no repo cloned)

Copilot CLI: 1.0.69-0
Model: Claude Opus 4.8 (claude-opus-4.8)
