### PR TITLE
docs: add iOS to issue templates, triage, support, and doc cross-links (#1859)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,6 +16,7 @@ body:
         - "macOS Apple Silicon (arm64)"
         - "macOS Intel (x64)"
         - "Android"
+        - "iOS / iPadOS"
         - "Other"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/gui_bug.yml
+++ b/.github/ISSUE_TEMPLATE/gui_bug.yml
@@ -28,6 +28,7 @@ body:
         - "macOS Apple Silicon (arm64)"
         - "macOS Intel (x64)"
         - "Android"
+        - "iOS / iPadOS"
         - "Other"
     validations:
       required: true

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -21,6 +21,7 @@ Every bug issue filed via the structured [Issue Forms](https://github.com/laqiee
 | **Platform** = Linux x64 | `os:linux` |
 | **Platform** = macOS (any) | `os:macos` |
 | **Platform** = Android | `os:android` |
+| **Platform** = iOS / iPadOS | `os:ios` |
 | always | `needs-triage` |
 
 ### Maintainer triage workflow

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -126,7 +126,7 @@ jobs:
             // removed to prevent stale label accumulation.
             // ----------------------------------------------------------------
             const COMPONENT_LABELS = ['avalonia', 'winforms', 'cli', 'core'];
-            const PLATFORM_LABELS  = ['os:windows', 'os:linux', 'os:macos', 'os:android'];
+            const PLATFORM_LABELS  = ['os:windows', 'os:linux', 'os:macos', 'os:android', 'os:ios'];
 
             // Label definitions for labels this workflow may need to create.
             // Every label that can appear in labelsToAdd must be listed here
@@ -144,6 +144,7 @@ jobs:
               { name: 'os:linux',     color: 'cfd3d7', description: 'Reported on Linux' },
               { name: 'os:macos',     color: 'cfd3d7', description: 'Reported on macOS' },
               { name: 'os:android',   color: 'cfd3d7', description: 'Reported on Android' },
+              { name: 'os:ios',       color: 'cfd3d7', description: 'Reported on iOS' },
             ];
 
             // ----------------------------------------------------------------
@@ -216,6 +217,8 @@ jobs:
                   labelsToAdd.push('os:macos');
                 } else if (/android/i.test(platform)) {
                   labelsToAdd.push('os:android');
+                } else if (/ios|ipados|iphone|ipad/i.test(platform)) {
+                  labelsToAdd.push('os:ios');
                 }
                 // "Other" → no OS label applied.
               }

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -689,6 +689,7 @@ device) is still on-device-unvalidated, so it is not yet a full ROM-editing app.
 
 ## See also
 
+- iOS sibling head: [docs/IOS.md](IOS.md)
 - [docs/CROSS_PLATFORM.md → Running on Android](CROSS_PLATFORM.md#running-on-android)
 - Epic [#1070](https://github.com/laqieer/FEBuilderGBA/issues/1070) (this exploration)
 - Emulation/Winlator route: [#1069](https://github.com/laqieer/FEBuilderGBA/issues/1069)

--- a/docs/REPORTING-BUGS.md
+++ b/docs/REPORTING-BUGS.md
@@ -18,7 +18,7 @@ Select the appropriate template and fill in all fields.
 
 - **App version** — shown in Help → About, or from `--version` on CLI
 - **ROM version** — shown in the bottom status bar (e.g., FE8U)
-- **Platform** — Windows/Linux/macOS/Android and architecture
+- **Platform** — Windows/Linux/macOS/Android/iOS and architecture
 - **Screenshot** — drag-and-drop, do not link external services
 - **report.7z** (optional) — use File → Problem Report Tool; contains version + CRC32, **no ROM data**
 


### PR DESCRIPTION
## Summary

Docs/intake follow-up after the native **iOS** release ([#1860](https://github.com/laqieer/FEBuilderGBA/pull/1860), closing #1859): the code, in-repo docs (`docs/IOS.md`, README, DEPLOYMENT/RELEASE/CROSS_PLATFORM), and the **[wiki](https://github.com/laqieer/FEBuilderGBA/wiki/Native-iOS)** are already updated; this PR closes the remaining **contributor-facing intake** gaps so mobile bug reports route correctly.

Ref #1859.

## What changed
- **`.github/ISSUE_TEMPLATE/bug_report.yml` + `gui_bug.yml`** — add an **"iOS / iPadOS"** option to the Platform dropdown (previously Android was the only mobile option).
- **`.github/workflows/issue-triage.yml`** — add the **`os:ios`** label (definition + `PLATFORM_LABELS`) and map `Platform` = iOS / iPadOS / iPhone / iPad → `os:ios`, so the new dropdown option is actually auto-labeled (matching the existing `os:android` handling).
- **`.github/SUPPORT.md`** — add the `Platform = iOS / iPadOS → os:ios` triage-table row.
- **`docs/ANDROID.md`** — cross-link the iOS sibling head (`docs/IOS.md`) in *See also*.
- **`docs/REPORTING-BUGS.md`** — include iOS in the Platform field guidance.

## Test plan
- [x] All three YAML files (`bug_report.yml`, `gui_bug.yml`, `issue-triage.yml`) parse cleanly (`yaml.safe_load`).
- [x] The triage-workflow JS change is consistent with the existing pattern: `os:ios` is added to the create-list `PLATFORM_LABELS`, has a label definition, and the regex `/ios|ipados|iphone|ipad/i` matches the new dropdown value while not colliding with `macOS`/`Android`/`Windows`/`Linux` (checked earlier in the else-if chain).
- [x] Docs-only + issue-config change — no code/build/unit-test impact (no `FEBuilderGBA.*` source or GUI files touched).

> `docs`/`chore` PR — screenshots optional.

---
Copilot CLI: 1.0.69-1
Model: Claude Opus 4.8 (claude-opus-4.8)
