### PR TITLE
fix(browser): remove the loading splash once Avalonia mounts (#1869)

### DIFF
--- a/FEBuilderGBA.Browser/tests/smoke/smoke.mjs
+++ b/FEBuilderGBA.Browser/tests/smoke/smoke.mjs
@@ -136,10 +136,14 @@ try {
   // #1869: Avalonia does NOT replace #out's content — it appends its <canvas>, leaving the HTML
   // .app-splash overlaying the app. main.js now removes .app-splash once the canvas mounts; assert
   // it's gone (give the MutationObserver a beat), else the loading spinner sticks over the app.
-  await page.waitForTimeout(1500);
-  const splashCount = await page.evaluate(() => document.querySelectorAll('.app-splash').length);
-  if (splashCount > 0) failures.push(`.app-splash was NOT removed after the canvas mounted (#1869 — the loading spinner overlays the app)`);
-  else console.log('[smoke] .app-splash removed after boot (#1869).');
+  // Wait (bounded) for the splash to be removed rather than a fixed sleep — resolves as soon as it's
+  // gone, and fails fast if it never is. #1869.
+  try {
+    await page.waitForFunction(() => document.querySelectorAll('#out .app-splash').length === 0, undefined, { timeout: 15000 });
+    console.log('[smoke] .app-splash removed after boot (#1869).');
+  } catch {
+    failures.push(`.app-splash was NOT removed after the canvas mounted (#1869 — the loading spinner overlays the app)`);
+  }
 } catch (e) {
   failures.push(`app did not render a canvas within ${BOOT_TIMEOUT_MS} ms: ${e.message}`);
 }

--- a/FEBuilderGBA.Browser/tests/smoke/smoke.mjs
+++ b/FEBuilderGBA.Browser/tests/smoke/smoke.mjs
@@ -141,8 +141,8 @@ try {
   try {
     await page.waitForFunction(() => document.querySelectorAll('#out .app-splash').length === 0, undefined, { timeout: 15000 });
     console.log('[smoke] .app-splash removed after boot (#1869).');
-  } catch {
-    failures.push(`.app-splash was NOT removed after the canvas mounted (#1869 — the loading spinner overlays the app)`);
+  } catch (e) {
+    failures.push(`.app-splash was NOT removed after the canvas mounted (#1869 — the loading spinner overlays the app): ${e.message}`);
   }
 } catch (e) {
   failures.push(`app did not render a canvas within ${BOOT_TIMEOUT_MS} ms: ${e.message}`);

--- a/FEBuilderGBA.Browser/tests/smoke/smoke.mjs
+++ b/FEBuilderGBA.Browser/tests/smoke/smoke.mjs
@@ -133,6 +133,12 @@ try {
   // boot, so a canvas existing proves the app actually rendered — not merely that assets loaded).
   await page.waitForSelector('canvas', { state: 'attached', timeout: BOOT_TIMEOUT_MS });
   console.log('[smoke] canvas mounted — app booted.');
+  // #1869: the HTML loading splash must be removed once the canvas mounts, else it overlays the
+  // rendered app and looks "always loading". Give the MutationObserver a beat, then assert it's gone.
+  await page.waitForTimeout(1500);
+  const splashCount = await page.evaluate(() => document.querySelectorAll('.app-splash').length);
+  if (splashCount > 0) failures.push(`.app-splash was NOT removed after the canvas mounted (#1869 — the loading spinner overlays the app)`);
+  else console.log('[smoke] .app-splash removed after boot (#1869).');
 } catch (e) {
   failures.push(`app did not render a canvas within ${BOOT_TIMEOUT_MS} ms: ${e.message}`);
 }

--- a/FEBuilderGBA.Browser/tests/smoke/smoke.mjs
+++ b/FEBuilderGBA.Browser/tests/smoke/smoke.mjs
@@ -129,12 +129,13 @@ page.on('console', (msg) => {
 
 try {
   await page.goto(url, { waitUntil: 'load', timeout: BOOT_TIMEOUT_MS });
-  // Success signal: Avalonia mounted its Skia <canvas> (the splash lives in #out and is replaced on
-  // boot, so a canvas existing proves the app actually rendered — not merely that assets loaded).
+  // Success signal: Avalonia mounted its Skia <canvas> into #out (it APPENDS the canvas rather than
+  // replacing #out's content — see the .app-splash removal below), proving the app actually rendered.
   await page.waitForSelector('canvas', { state: 'attached', timeout: BOOT_TIMEOUT_MS });
   console.log('[smoke] canvas mounted — app booted.');
-  // #1869: the HTML loading splash must be removed once the canvas mounts, else it overlays the
-  // rendered app and looks "always loading". Give the MutationObserver a beat, then assert it's gone.
+  // #1869: Avalonia does NOT replace #out's content — it appends its <canvas>, leaving the HTML
+  // .app-splash overlaying the app. main.js now removes .app-splash once the canvas mounts; assert
+  // it's gone (give the MutationObserver a beat), else the loading spinner sticks over the app.
   await page.waitForTimeout(1500);
   const splashCount = await page.evaluate(() => document.querySelectorAll('.app-splash').length);
   if (splashCount > 0) failures.push(`.app-splash was NOT removed after the canvas mounted (#1869 — the loading spinner overlays the app)`);

--- a/FEBuilderGBA.Browser/wwwroot/main.js
+++ b/FEBuilderGBA.Browser/wwwroot/main.js
@@ -3,6 +3,24 @@ import { dotnet } from './_framework/dotnet.js'
 const is_browser = typeof window != "undefined";
 if (!is_browser) throw new Error(`Expected to be running in a browser`);
 
+// #1869: the HTML loading splash (.app-splash) lives inside #out; Avalonia's StartBrowserAppAsync
+// mounts its <canvas class="avalonia-canvas"> into #out but does NOT remove the pre-existing splash,
+// so the spinner stays over the rendered app forever ("always loading"). Remove the splash as soon
+// as Avalonia's canvas is attached — keyed on the canvas (NOT a timer / not after runMain), so a
+// genuine boot failure (no canvas) keeps the splash + its message visible instead of masking it.
+const _out = document.getElementById('out');
+if (_out) {
+    const _removeSplash = () => { for (const s of _out.querySelectorAll('.app-splash')) s.remove(); };
+    if (_out.querySelector('canvas.avalonia-canvas')) {
+        _removeSplash();
+    } else {
+        const _obs = new MutationObserver(() => {
+            if (_out.querySelector('canvas.avalonia-canvas')) { _removeSplash(); _obs.disconnect(); }
+        });
+        _obs.observe(_out, { childList: true, subtree: true });
+    }
+}
+
 const dotnetRuntime = await dotnet
     .withDiagnosticTracing(false)
     .withApplicationArgumentsFromQuery()

--- a/FEBuilderGBA.Browser/wwwroot/main.js
+++ b/FEBuilderGBA.Browser/wwwroot/main.js
@@ -11,11 +11,11 @@ if (!is_browser) throw new Error(`Expected to be running in a browser`);
 const _out = document.getElementById('out');
 if (_out) {
     const _removeSplash = () => { for (const s of _out.querySelectorAll('.app-splash')) s.remove(); };
-    if (_out.querySelector('canvas.avalonia-canvas')) {
+    if (_out.querySelector('canvas')) {
         _removeSplash();
     } else {
         const _obs = new MutationObserver(() => {
-            if (_out.querySelector('canvas.avalonia-canvas')) { _removeSplash(); _obs.disconnect(); }
+            if (_out.querySelector('canvas')) { _removeSplash(); _obs.disconnect(); }
         });
         _obs.observe(_out, { childList: true, subtree: true });
     }


### PR DESCRIPTION
## Summary

Fixes **#1869** — the web app (https://laqieer.github.io/FEBuilderGBA/) looked **"always loading"** even
though it had actually booted and rendered.

### Root cause (live-DOM confirmed)

The HTML loading splash `<div class="app-splash">` (spinner) lives inside `#out`.
`StartBrowserAppAsync("out")` mounts Avalonia's `<canvas class="avalonia-canvas">` into `#out` but
does **not** remove the pre-existing splash. After boot `#out` =
`[canvas.avalonia-canvas, div.avalonia-native-host, input.avalonia-input-element, div.app-splash]` — the
`.app-splash` remains the last child, still `display:flex` / full-viewport, so its spinner shows over
the rendered app → perpetual "loading". (It does **not** block clicks — `elementFromPoint` returns the
`avalonia-native-host` above it — so this is purely the stuck spinner.)

### Fix

`FEBuilderGBA.Browser/wwwroot/main.js` removes `.app-splash` as soon as `canvas.avalonia-canvas` is
attached (a `MutationObserver` on `#out`, set up before boot; immediate removal if the canvas already
exists). It's **keyed on the canvas** — not a timer or an after-`runMain` fallback — so a genuine boot
failure (no canvas) keeps the splash + its message visible instead of masking the error.

### Regression guard

The pages.yml boot smoke test (`FEBuilderGBA.Browser/tests/smoke/smoke.mjs`) now asserts `.app-splash`
is gone once the canvas mounts — so a future regression fails the PR.

## Plan & review

Combined plan for #1869 + #1870 posted on the issues; cross-model board reviewed it (gpt-5.5
ACCEPT-WITH-CHANGES). #1869 is the trivial, independent half split out here; #1870 (ROM open/save) follows
separately. Plan: https://github.com/laqieer/FEBuilderGBA/issues/1870#issuecomment-4894282351

## Scope

`Closes #1869`. Touches only `FEBuilderGBA.Browser/wwwroot/main.js` + `.../tests/smoke/smoke.mjs`.
No Core/Avalonia/WinForms changes.

## Test plan

- [x] `main.js` valid ES-module syntax (`node --input-type=module --check`); `smoke.mjs` passes `node --check`.
- [x] Root cause reproduced via live-DOM inspection (`.app-splash` present + visible over the canvas after boot).
- [x] Boot smoke test asserts `.app-splash` removed after the canvas mounts (runs in CI, gates the deploy).

---
Copilot CLI: 1.0.69-1
Model: Claude Opus 4.8 (claude-opus-4.8)
