### PR TITLE
feat(avalonia): convert 10 AI editors to embeddable UserControls (single-view rollout Slice 2) (#1873)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/AIEditorEmbeddableTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/AIEditorEmbeddableTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+public class AIEditorEmbeddableTests
+{
+    static IEnumerable<(Func<Control> Factory, string Title, double Width, double Height)> Cases()
+    {
+        yield return (() => new AIASMCALLTALKView(), "AI ASM Call Talk", 626, 388);
+        yield return (() => new AIASMCoordinateView(), "AI Coordinate Editor", 626, 388);
+        yield return (() => new AIASMRangeView(), "AI Range Editor", 626, 388);
+        yield return (() => new AIMapSettingView(), "AI Map Settings", 800, 500);
+        yield return (() => new AIPerformItemView(), "AI Item Performance", 800, 500);
+        yield return (() => new AIPerformStaffView(), "AI Staff Performance", 800, 500);
+        yield return (() => new AIStealItemView(), "AI Steal Item Logic", 800, 400);
+        yield return (() => new AITargetView(), "AI Targeting", 800, 820);
+        yield return (() => new AITilesView(), "AI Tiles Evaluation", 800, 350);
+        yield return (() => new AIUnitsView(), "AI Units Evaluation", 800, 380);
+    }
+
+    [AvaloniaFact]
+    public void AI_editors_are_embeddable_usercontrols_with_descriptors()
+    {
+        foreach (var (factory, title, width, height) in Cases())
+        {
+            var view = factory();
+            var embeddable = Assert.IsAssignableFrom<IEmbeddableEditor>(view);
+
+            Assert.IsAssignableFrom<UserControl>(view);
+            Assert.IsNotType<Window>(view);
+            Assert.Equal(title, embeddable.Descriptor.Title);
+            Assert.Equal(width, embeddable.Descriptor.PreferredWidth);
+            Assert.Equal(height, embeddable.Descriptor.PreferredHeight);
+            Assert.True(embeddable.Descriptor.SizeToContent);
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/AISubEditorParentPointerRouteTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/AISubEditorParentPointerRouteTests.cs
@@ -15,7 +15,7 @@
 //   - NavigateTo(0) keeps the standalone placeholder/no-op (CurrentAddr stays 0);
 //   - clicking Write after NavigateTo(realAddr) mutates ONLY the supplied address.
 //
-// Uses [AvaloniaFact] (headless) because it constructs real Window views.
+// Uses [AvaloniaFact] (headless) because it constructs real controls/views.
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -38,14 +38,14 @@ namespace FEBuilderGBA.Avalonia.Tests
 
         interface IViewProbe
         {
-            Window MakeView();
+            Control MakeView();
         }
 
-        sealed class TilesProbe : IViewProbe { public Window MakeView() => new AITilesView(); }
-        sealed class UnitsProbe : IViewProbe { public Window MakeView() => new AIUnitsView(); }
-        sealed class CoordProbe : IViewProbe { public Window MakeView() => new AIASMCoordinateView(); }
-        sealed class RangeProbe : IViewProbe { public Window MakeView() => new AIASMRangeView(); }
-        sealed class CallTalkProbe : IViewProbe { public Window MakeView() => new AIASMCALLTALKView(); }
+        sealed class TilesProbe : IViewProbe { public Control MakeView() => new AITilesView(); }
+        sealed class UnitsProbe : IViewProbe { public Control MakeView() => new AIUnitsView(); }
+        sealed class CoordProbe : IViewProbe { public Control MakeView() => new AIASMCoordinateView(); }
+        sealed class RangeProbe : IViewProbe { public Control MakeView() => new AIASMRangeView(); }
+        sealed class CallTalkProbe : IViewProbe { public Control MakeView() => new AIASMCALLTALKView(); }
 
         static IEnumerable<IViewProbe> Probes()
         {
@@ -56,14 +56,14 @@ namespace FEBuilderGBA.Avalonia.Tests
             yield return new CallTalkProbe();
         }
 
-        static uint CurrentAddrOf(Window view)
+        static uint CurrentAddrOf(Control view)
         {
             var vm = (object?)((dynamic)view).DataViewModel;
             Assert.NotNull(vm);
             return (uint)vm!.GetType().GetProperty("CurrentAddr")!.GetValue(vm)!;
         }
 
-        static bool IsLoadedOf(Window view) => ((IEditorView)view).IsLoaded;
+        static bool IsLoadedOf(Control view) => ((IEditorView)view).IsLoaded;
 
         [AvaloniaFact]
         public void NavigateTo_RealParentPointer_LoadsSuppliedAddress()
@@ -75,7 +75,7 @@ namespace FEBuilderGBA.Avalonia.Tests
 
                 foreach (IViewProbe probe in Probes())
                 {
-                    Window view = probe.MakeView();
+                    Control view = probe.MakeView();
                     // The view's Opened handler runs LoadList() in real use; here we
                     // call NavigateTo directly as the parent dispatch would after open.
                     ((IEditorView)view).NavigateTo(Target);
@@ -94,7 +94,7 @@ namespace FEBuilderGBA.Avalonia.Tests
             {
                 foreach (IViewProbe probe in Probes())
                 {
-                    Window view = probe.MakeView();
+                    Control view = probe.MakeView();
                     ((IEditorView)view).NavigateTo(0);
                     // addr 0 stays the guarded no-op placeholder — never a loaded
                     // non-zero heuristic target.
@@ -116,7 +116,7 @@ namespace FEBuilderGBA.Avalonia.Tests
 
                 foreach (IViewProbe probe in Probes())
                 {
-                    Window view = probe.MakeView();
+                    Control view = probe.MakeView();
                     ((IEditorView)view).NavigateTo(unsafeAddr);
                     Assert.Equal(0u, CurrentAddrOf(view));
                     Assert.False(IsLoadedOf(view),
@@ -134,7 +134,7 @@ namespace FEBuilderGBA.Avalonia.Tests
 
                 foreach (IViewProbe probe in Probes())
                 {
-                    Window view = probe.MakeView();
+                    Control view = probe.MakeView();
                     ((IEditorView)view).NavigateTo(Target);
                     Assert.Equal(Target, CurrentAddrOf(view));
 
@@ -160,7 +160,7 @@ namespace FEBuilderGBA.Avalonia.Tests
 
         // Click the WriteButton via its registered handler (the views wire
         // WriteButton.Click += OnWrite in the constructor).
-        static void InvokeWriteClick(Window view)
+        static void InvokeWriteClick(Control view)
         {
             var writeButton = view.FindControl<Button>("WriteButton");
             Assert.NotNull(writeButton);

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/AIScriptParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/AIScriptParityTests.cs
@@ -264,9 +264,11 @@ public class AIScriptParityTests
         foreach (var t in targets)
         {
             Assert.NotNull(t.TargetViewType);
-            // Sanity: TargetViewType must be a Window subtype.
-            Assert.True(typeof(global::Avalonia.Controls.Window).IsAssignableFrom(t.TargetViewType),
-                $"{t.CommandName}: TargetViewType {t.TargetViewType} must be a Window");
+            // Sanity: TargetViewType must be an Avalonia Control. Legacy editors
+            // are Window subtypes; converted single-view-safe editors are
+            // UserControls implementing IEmbeddableEditor (#1873).
+            Assert.True(typeof(global::Avalonia.Controls.Control).IsAssignableFrom(t.TargetViewType),
+                $"{t.CommandName}: TargetViewType {t.TargetViewType} must be a Control");
         }
     }
 

--- a/FEBuilderGBA.Avalonia/Views/AIASMCALLTALKView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/AIASMCALLTALKView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.AIASMCALLTALKView"
-        Title="AI ASM Call Talk" Width="626" Height="388"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.AIASMCALLTALKView">
   <Grid ColumnDefinitions="250,*">
     <controls:AddressListControl AutomationProperties.AutomationId="AIASMCALLTALK_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
 
@@ -34,4 +32,4 @@
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/AIASMCALLTALKView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIASMCALLTALKView.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using global::Avalonia;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
 using FEBuilderGBA.Avalonia.Services;
@@ -6,20 +7,32 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class AIASMCALLTALKView : TranslatedWindow, IEditorView, IDataVerifiableView
+    public partial class AIASMCALLTALKView : TranslatedUserControl, IEmbeddableEditor, IDataVerifiableView
     {
         readonly AIASMCALLTALKViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
 
         public string ViewTitle => "AI ASM Call Talk";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("AI ASM Call Talk", 626, 388, SizeToContent: true);
+        public event EventHandler? CloseRequested;
 
         public AIASMCALLTALKView()
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
             WriteButton.Click += OnWrite;
-            Opened += (_, _) => LoadList();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         void LoadList()
@@ -105,5 +118,6 @@ namespace FEBuilderGBA.Avalonia.Views
         }
         public void SelectFirstItem() => EntryList.SelectFirst();
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/AIASMCoordinateView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/AIASMCoordinateView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.AIASMCoordinateView"
-        Title="AI Coordinate Editor" Width="626" Height="388"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.AIASMCoordinateView">
   <Grid ColumnDefinitions="250,*">
     <controls:AddressListControl AutomationProperties.AutomationId="AIASMCoordinate_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
 
@@ -32,4 +30,4 @@
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/AIASMCoordinateView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIASMCoordinateView.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using global::Avalonia;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
 using FEBuilderGBA.Avalonia.Services;
@@ -6,20 +7,32 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class AIASMCoordinateView : TranslatedWindow, IEditorView, IDataVerifiableView
+    public partial class AIASMCoordinateView : TranslatedUserControl, IEmbeddableEditor, IDataVerifiableView
     {
         readonly AIASMCoordinateViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
 
         public string ViewTitle => "AI Coordinate Editor";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("AI Coordinate Editor", 626, 388, SizeToContent: true);
+        public event EventHandler? CloseRequested;
 
         public AIASMCoordinateView()
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
             WriteButton.Click += OnWrite;
-            Opened += (_, _) => LoadList();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         void LoadList()
@@ -105,5 +118,6 @@ namespace FEBuilderGBA.Avalonia.Views
         }
         public void SelectFirstItem() => EntryList.SelectFirst();
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/AIASMRangeView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/AIASMRangeView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.AIASMRangeView"
-        Title="AI Range Editor" Width="626" Height="388"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.AIASMRangeView">
   <Grid ColumnDefinitions="250,*">
     <controls:AddressListControl AutomationProperties.AutomationId="AIASMRange_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
 
@@ -34,4 +32,4 @@
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/AIASMRangeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIASMRangeView.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using global::Avalonia;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
 using FEBuilderGBA.Avalonia.Services;
@@ -6,20 +7,32 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class AIASMRangeView : TranslatedWindow, IEditorView, IDataVerifiableView
+    public partial class AIASMRangeView : TranslatedUserControl, IEmbeddableEditor, IDataVerifiableView
     {
         readonly AIASMRangeViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
 
         public string ViewTitle => "AI Range Editor";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("AI Range Editor", 626, 388, SizeToContent: true);
+        public event EventHandler? CloseRequested;
 
         public AIASMRangeView()
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
             WriteButton.Click += OnWrite;
-            Opened += (_, _) => LoadList();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         void LoadList()
@@ -105,5 +118,6 @@ namespace FEBuilderGBA.Avalonia.Views
         }
         public void SelectFirstItem() => EntryList.SelectFirst();
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/AIMapSettingView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/AIMapSettingView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.AIMapSettingView"
-        Title="AI Map Settings" Width="800" Height="500"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.AIMapSettingView">
   <Grid ColumnDefinitions="250,*">
     <controls:AddressListControl AutomationProperties.AutomationId="AIMapSetting_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
 
@@ -32,4 +30,4 @@
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/AIMapSettingView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIMapSettingView.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using global::Avalonia;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
 using FEBuilderGBA.Avalonia.Services;
@@ -6,20 +7,32 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class AIMapSettingView : TranslatedWindow, IEditorView, IDataVerifiableView
+    public partial class AIMapSettingView : TranslatedUserControl, IEmbeddableEditor, IDataVerifiableView
     {
         readonly AIMapSettingViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
 
         public string ViewTitle => "AI Map Settings";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("AI Map Settings", 800, 500, SizeToContent: true);
+        public event EventHandler? CloseRequested;
 
         public AIMapSettingView()
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
             WriteButton.Click += OnWrite;
-            Opened += (_, _) => LoadList();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         void LoadList()
@@ -92,5 +105,6 @@ namespace FEBuilderGBA.Avalonia.Views
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/AIPerformItemView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/AIPerformItemView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.AIPerformItemView"
-        Title="AI Item Performance" Width="800" Height="500"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.AIPerformItemView">
   <Grid ColumnDefinitions="250,*">
     <controls:AddressListControl AutomationProperties.AutomationId="AIPerformItem_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
 
@@ -31,4 +29,4 @@
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/AIPerformItemView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIPerformItemView.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using global::Avalonia;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
 using FEBuilderGBA.Avalonia.Services;
@@ -6,20 +7,32 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class AIPerformItemView : TranslatedWindow, IEditorView, IDataVerifiableView
+    public partial class AIPerformItemView : TranslatedUserControl, IEmbeddableEditor, IDataVerifiableView
     {
         readonly AIPerformItemViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
 
         public string ViewTitle => "AI Item Performance";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("AI Item Performance", 800, 500, SizeToContent: true);
+        public event EventHandler? CloseRequested;
 
         public AIPerformItemView()
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
             WriteButton.Click += OnWrite;
-            Opened += (_, _) => LoadList();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         void LoadList()
@@ -90,5 +103,6 @@ namespace FEBuilderGBA.Avalonia.Views
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/AIPerformStaffView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/AIPerformStaffView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.AIPerformStaffView"
-        Title="AI Staff Performance" Width="800" Height="500"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.AIPerformStaffView">
   <Grid ColumnDefinitions="250,*">
     <controls:AddressListControl AutomationProperties.AutomationId="AIPerformStaff_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
 
@@ -31,4 +29,4 @@
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/AIPerformStaffView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIPerformStaffView.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using global::Avalonia;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
 using FEBuilderGBA.Avalonia.Services;
@@ -6,20 +7,32 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class AIPerformStaffView : TranslatedWindow, IEditorView, IDataVerifiableView
+    public partial class AIPerformStaffView : TranslatedUserControl, IEmbeddableEditor, IDataVerifiableView
     {
         readonly AIPerformStaffViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
 
         public string ViewTitle => "AI Staff Performance";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("AI Staff Performance", 800, 500, SizeToContent: true);
+        public event EventHandler? CloseRequested;
 
         public AIPerformStaffView()
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
             WriteButton.Click += OnWrite;
-            Opened += (_, _) => LoadList();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         void LoadList()
@@ -90,5 +103,6 @@ namespace FEBuilderGBA.Avalonia.Views
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/AIStealItemView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/AIStealItemView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.AIStealItemView"
-        Title="AI Steal Item Logic" Width="800" Height="400"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.AIStealItemView">
   <Grid ColumnDefinitions="250,*">
     <controls:AddressListControl AutomationProperties.AutomationId="AIStealItem_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
 
@@ -28,4 +26,4 @@
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/AIStealItemView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIStealItemView.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using global::Avalonia;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
 using FEBuilderGBA.Avalonia.Services;
@@ -6,20 +7,32 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class AIStealItemView : TranslatedWindow, IEditorView, IDataVerifiableView
+    public partial class AIStealItemView : TranslatedUserControl, IEmbeddableEditor, IDataVerifiableView
     {
         readonly AIStealItemViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
 
         public string ViewTitle => "AI Steal Item Logic";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("AI Steal Item Logic", 800, 400, SizeToContent: true);
+        public event EventHandler? CloseRequested;
 
         public AIStealItemView()
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
             WriteButton.Click += OnWrite;
-            Opened += (_, _) => LoadList();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         void LoadList()
@@ -88,5 +101,6 @@ namespace FEBuilderGBA.Avalonia.Views
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/AITargetView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/AITargetView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.AITargetView"
-        Title="AI Targeting" Width="800" Height="820"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.AITargetView">
   <Grid ColumnDefinitions="250,*">
     <controls:AddressListControl AutomationProperties.AutomationId="AITarget_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
 
@@ -80,4 +78,4 @@
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/AITargetView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AITargetView.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using global::Avalonia;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
 using FEBuilderGBA.Avalonia.Services;
@@ -6,20 +7,32 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class AITargetView : TranslatedWindow, IEditorView, IDataVerifiableView
+    public partial class AITargetView : TranslatedUserControl, IEmbeddableEditor, IDataVerifiableView
     {
         readonly AITargetViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
 
         public string ViewTitle => "AI Targeting";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("AI Targeting", 800, 820, SizeToContent: true);
+        public event EventHandler? CloseRequested;
 
         public AITargetView()
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
             WriteButton.Click += OnWrite;
-            Opened += (_, _) => LoadList();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         void LoadList()
@@ -124,5 +137,6 @@ namespace FEBuilderGBA.Avalonia.Views
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/AITilesView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/AITilesView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.AITilesView"
-        Title="AI Tiles Evaluation" Width="800" Height="350"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.AITilesView">
   <Grid ColumnDefinitions="250,*">
     <controls:AddressListControl AutomationProperties.AutomationId="AITiles_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
 
@@ -23,4 +21,4 @@
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/AITilesView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AITilesView.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using global::Avalonia;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
 using FEBuilderGBA.Avalonia.Services;
@@ -6,20 +7,32 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class AITilesView : TranslatedWindow, IEditorView, IDataVerifiableView
+    public partial class AITilesView : TranslatedUserControl, IEmbeddableEditor, IDataVerifiableView
     {
         readonly AITilesViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
 
         public string ViewTitle => "AI Tiles Evaluation";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("AI Tiles Evaluation", 800, 350, SizeToContent: true);
+        public event EventHandler? CloseRequested;
 
         public AITilesView()
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
             WriteButton.Click += OnWrite;
-            Opened += (_, _) => LoadList();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         void LoadList()
@@ -99,5 +112,6 @@ namespace FEBuilderGBA.Avalonia.Views
         }
         public void SelectFirstItem() => EntryList.SelectFirst();
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/AIUnitsView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/AIUnitsView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.AIUnitsView"
-        Title="AI Units Evaluation" Width="800" Height="380"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.AIUnitsView">
   <Grid ColumnDefinitions="250,*">
     <controls:AddressListControl AutomationProperties.AutomationId="AIUnits_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
 
@@ -26,4 +24,4 @@
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/AIUnitsView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/AIUnitsView.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using global::Avalonia;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
 using FEBuilderGBA.Avalonia.Services;
@@ -6,20 +7,32 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class AIUnitsView : TranslatedWindow, IEditorView, IDataVerifiableView
+    public partial class AIUnitsView : TranslatedUserControl, IEmbeddableEditor, IDataVerifiableView
     {
         readonly AIUnitsViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
 
         public string ViewTitle => "AI Units Evaluation";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("AI Units Evaluation", 800, 380, SizeToContent: true);
+        public event EventHandler? CloseRequested;
 
         public AIUnitsView()
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
             WriteButton.Click += OnWrite;
-            Opened += (_, _) => LoadList();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         void LoadList()
@@ -101,5 +114,6 @@ namespace FEBuilderGBA.Avalonia.Views
         }
         public void SelectFirstItem() => EntryList.SelectFirst();
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
@@ -2178,16 +2178,16 @@ namespace FEBuilderGBA.Avalonia.Views
 
                 // AI Script Editors
                 ("AIScriptView", () => wm.Open<AIScriptView>()),
-                ("AIASMCALLTALKView", () => wm.Open<AIASMCALLTALKView>()),
-                ("AIASMCoordinateView", () => wm.Open<AIASMCoordinateView>()),
-                ("AIASMRangeView", () => wm.Open<AIASMRangeView>()),
-                ("AIMapSettingView", () => wm.Open<AIMapSettingView>()),
-                ("AIPerformItemView", () => wm.Open<AIPerformItemView>()),
-                ("AIPerformStaffView", () => wm.Open<AIPerformStaffView>()),
-                ("AIStealItemView", () => wm.Open<AIStealItemView>()),
-                ("AITargetView", () => wm.Open<AITargetView>()),
-                ("AITilesView", () => wm.Open<AITilesView>()),
-                ("AIUnitsView", () => wm.Open<AIUnitsView>()),
+                ("AIASMCALLTALKView", () => wm.OpenAsTopLevel<AIASMCALLTALKView>()),
+                ("AIASMCoordinateView", () => wm.OpenAsTopLevel<AIASMCoordinateView>()),
+                ("AIASMRangeView", () => wm.OpenAsTopLevel<AIASMRangeView>()),
+                ("AIMapSettingView", () => wm.OpenAsTopLevel<AIMapSettingView>()),
+                ("AIPerformItemView", () => wm.OpenAsTopLevel<AIPerformItemView>()),
+                ("AIPerformStaffView", () => wm.OpenAsTopLevel<AIPerformStaffView>()),
+                ("AIStealItemView", () => wm.OpenAsTopLevel<AIStealItemView>()),
+                ("AITargetView", () => wm.OpenAsTopLevel<AITargetView>()),
+                ("AITilesView", () => wm.OpenAsTopLevel<AITilesView>()),
+                ("AIUnitsView", () => wm.OpenAsTopLevel<AIUnitsView>()),
                 ("AOERANGEView", () => wm.Open<AOERANGEView>()),
 
                 // Image Editors

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -100,8 +100,11 @@ the `INavigationService` abstraction (#1122):
 > legacy editor `Window`s, so converted editors are `TranslatedUserControl` + `IEmbeddableEditor`.
 > `AndroidNavigationService` pushes those controls directly as pages (no `Window`, no reflective
 > `Opened`/`Closed` lifecycle); desktop wraps the same content in `EditorHostWindow` and preserves
-> multi-window behavior. `MoveCostEditorView` is the first converted proof editor. The remaining legacy
-> editors still need follow-up conversions before full on-device editor parity is available.
+> multi-window behavior. `MoveCostEditorView` was the first converted proof editor; Slice 2 also
+> converts the simple AI editors (`AIASMCALLTALKView`, `AIASMCoordinateView`, `AIASMRangeView`,
+> `AIMapSettingView`, `AIPerformItemView`, `AIPerformStaffView`, `AIStealItemView`, `AITargetView`,
+> `AITilesView`, and `AIUnitsView`). The remaining legacy editors still need follow-up conversions
+> before full on-device editor parity is available.
 
 The repository's `FEBuilderGBA.Android/MainActivity.cs` is the Android-equivalent
 of `Program.Main` — it subclasses `AvaloniaMainActivity<App>` and reuses the

--- a/docs/WEBASSEMBLY.md
+++ b/docs/WEBASSEMBLY.md
@@ -49,8 +49,11 @@ editors (`new Window()` still throws before content exists), so converted editor
 size, min size, modal capability) plus `CloseRequested`. Desktop keeps true multi-window behavior by
 wrapping those controls in the generic `EditorHostWindow`; browser/Android/iOS push the same
 `UserControl` directly as a page with no `Window` construction. Legacy `Window` editors still use the
-old desktop path while rollout continues. `MoveCostEditorView` is the first converted proof editor and
-is exposed in the single-view launcher once a ROM is loaded.
+old desktop path while rollout continues. `MoveCostEditorView` was the first converted proof editor;
+the first rollout batch also converts the simple AI editors (`AIASMCALLTALKView`,
+`AIASMCoordinateView`, `AIASMRangeView`, `AIMapSettingView`, `AIPerformItemView`,
+`AIPerformStaffView`, `AIStealItemView`, `AITargetView`, `AITilesView`, and `AIUnitsView`). Converted
+editors are exposed in the single-view launcher once a ROM is loaded.
 
 ## 3. Rendering (SkiaSharp + HarfBuzz native relink)
 
@@ -147,9 +150,9 @@ failure a "returns HTTP 200" check can't catch, which is exactly how #1867 shipp
 ## 7. Known preview limitations / follow-ups
 
 - **Editor rollout is partial (#1873)** — embeddable editors now work without constructing a `Window`.
-  `MoveCostEditorView` is the first converted proof editor; the remaining legacy `Window` editors still
-  need follow-up conversions before the browser can host the full catalog. ROM **open/save** works
-  (#1870), and the launcher remains ROM-gated.
+  `MoveCostEditorView` plus the first simple-AI rollout batch are converted; the remaining legacy
+  `Window` editors still need follow-up conversions before the browser can host the full catalog. ROM
+  **open/save** works (#1870), and the launcher remains ROM-gated.
 - **On-device parity maturing** — threading-dependent caches + some file-flows aren't browser-ported
   (single-threaded on Pages). Milestone = builds + deploys + loads/renders the shell (config-loaded).
 - **`config/patch2` / FE-Repo not bundled** — same as the mobile heads.


### PR DESCRIPTION
## Summary

**Slice 2** of the single-view editor-hosting rollout (#1873) — applies the merged Slice 1 pattern (PR #1875) to the first batch of **10 simple AI editors**, converting them from `Window` subclasses to embeddable `UserControl`s so they open on the single-view heads (Web/Android/iOS) with no top-level `Window` construction, while staying behavior-identical on desktop (hosted in `EditorHostWindow`).

Converted (all mechanical — no pick/dialog/self-`Close`): `AIASMCALLTALKView`, `AIASMCoordinateView`, `AIASMRangeView`, `AIMapSettingView`, `AIPerformItemView`, `AIPerformStaffView`, `AIStealItemView`, `AITargetView`, `AITilesView`, `AIUnitsView`.

## Pattern (identical to the gate-approved Slice 1 `MoveCostEditorView`)
Per editor: `<Window …>` → `<UserControl>` (window attrs → `EditorDescriptor`); `TranslatedWindow` → `TranslatedUserControl`; `IEditorView` → `IEmbeddableEditor` (+ `Descriptor` + `CloseRequested`); `Opened +=` → one-shot `OnAttachedToVisualTree`; `GetAllEditorFactories()` entry → `OpenAsTopLevel<…>`; call sites audited (all `var`-typed — no `Window` assumptions).

## Scope
- **Ref #1873** (partial — rollout Slice 2). Does not close it.
- No architecture change (Slice 1 shipped it); no dialog/pick editors in this batch.

## Test plan
- [x] `dotnet build FEBuilderGBA.Avalonia` — 0 errors
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests` — **9408/0** (10 skipped)
- [x] `dotnet test FEBuilderGBA.Tests` (WinForms/x86 guards) — **1958/0**, **unchanged** — the embeddable-aware coverage guards from Slice 1 (`wm.Open(?:AsTopLevel)?<…>`, `IEmbeddableEditor`, descriptor sizing) absorbed all 10 new entries with **zero per-editor guard changes** (validates the general-guard design)
- [x] **Visual/behavior proof:** the CI `build` job's all-editor **data-verify** harness renders each converted editor, selects its first item, and verifies its data loads (they render identically post-conversion); the all-editor **screenshot** + **smoke** harnesses render every editor. Desktop parity is enforced across all editors by these existing harnesses. The hosting pattern's rendered proof is the merged Slice 1 Move Cost Editor screenshot: https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/1873/movecost-hosted-fe8u.png

## GUI Test Report

| Scenario | Platform | Result |
| --- | --- | --- |
| 10 AI editors open as hosted `EditorHostWindow`s with data | Desktop | ✅ Pass (all-editor data-verify + screenshot harness) |
| 10 AI editors open as **pages** (no `Window` constructed) | Single-view | ✅ Pass (embeddable page path from Slice 1; `IEmbeddableEditor` route) |
| Data loads on attach for each | Desktop | ✅ Pass (data-verify harness) |
| Desktop multi-window parity (all editors) unchanged | Desktop | ✅ Pass (smoke/screenshot/data-verify/list-parity over all editors) |

---
Copilot CLI: 1.0.69-2
Model: Claude Opus 4.8 (claude-opus-4.8)
