### PR TITLE
feat(avalonia): convert pick targets + Closed-event editors (rollout Slice 10) (#1873)

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/SkillAssignmentUnitCSkillSysScreenshotTest.cs
+++ b/FEBuilderGBA.Avalonia.Tests/SkillAssignmentUnitCSkillSysScreenshotTest.cs
@@ -185,7 +185,7 @@ namespace FEBuilderGBA.Avalonia.Tests
             b[a + 3] = (byte)((v >> 24) & 0xFF);
         }
 
-        void SaveRender(Window view, int w, int h, string outPath)
+        void SaveRender(IEmbeddableEditor view, int w, int h, string outPath)
         {
             // Use the Avalonia.Headless frame capture (CaptureRenderedFrame) +
             // a dependency-free BGRA8888 -> PNG encoder. This is the same path
@@ -194,15 +194,17 @@ namespace FEBuilderGBA.Avalonia.Tests
             // worktree environments.
             try
             {
-                view.Width = w;
-                view.Height = h;
-                view.Measure(new Size(w, h));
-                view.Arrange(new Rect(0, 0, w, h));
-                view.Show();
+                var host = view.GetHeadlessHost();
+                host.Width = w;
+                host.Height = h;
+                host.Measure(new Size(w, h));
+                host.Arrange(new Rect(0, 0, w, h));
+                host.Show();
                 global::Avalonia.Threading.Dispatcher.UIThread.RunJobs();
-                using var frame = view.CaptureRenderedFrame();
+                using var frame = host.CaptureRenderedFrame();
                 Assert.NotNull(frame);
                 SavePng(frame!, outPath);
+                view.Close();
                 _output.WriteLine($"Saved screenshot to: {outPath} ({new FileInfo(outPath).Length} bytes)");
             }
             catch (Exception ex)

--- a/FEBuilderGBA.Avalonia.Tests/SkillEditorLayoutTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/SkillEditorLayoutTests.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+﻿// SPDX-License-Identifier: GPL-3.0-or-later
 // Layout regression tests for the CSkillSys / FE8N skill editors (#1728-#1732).
 //
 // Root cause: Avalonia 11.2.3 NumericUpDown has a ~120px effective minimum
@@ -51,7 +51,7 @@ namespace FEBuilderGBA.Avalonia.Tests
         // Helpers
         // ==================================================================
 
-        static NumericUpDown Nud(Window view, string name)
+        static NumericUpDown Nud(Control view, string name)
         {
             var nud = view.FindControl<NumericUpDown>(name);
             Assert.True(nud != null, $"NumericUpDown '{name}' must exist in the view's name scope.");
@@ -63,7 +63,7 @@ namespace FEBuilderGBA.Avalonia.Tests
         /// (strategy (1)/(3)). AllowSpin must stay true so the keyboard /
         /// wheel editing path still works.
         /// </summary>
-        static void AssertSpinnerCollapsed(Window view, params string[] names)
+        static void AssertSpinnerCollapsed(Control view, params string[] names)
         {
             foreach (var name in names)
             {
@@ -103,7 +103,7 @@ namespace FEBuilderGBA.Avalonia.Tests
             return double.NaN;
         }
 
-        static void AssertEffectiveMinWidthAtLeast120(Window view, params string[] names)
+        static void AssertEffectiveMinWidthAtLeast120(Control view, params string[] names)
         {
             foreach (var name in names)
             {
@@ -116,7 +116,7 @@ namespace FEBuilderGBA.Avalonia.Tests
             }
         }
 
-        static void ForceLayout(Window view)
+        static void ForceLayout(Control view)
         {
             view.UpdateLayout();
             var size = new Size(1600, 1200);
@@ -169,7 +169,7 @@ namespace FEBuilderGBA.Avalonia.Tests
         /// geometric check"). The set is a local value applied after Show(); no
         /// data update re-asserts the binding during the synchronous test pass.
         /// </summary>
-        static void ForceVisible(Window view, params string[] controlNames)
+        static void ForceVisible(Control view, params string[] controlNames)
         {
             foreach (var n in controlNames)
             {
@@ -184,7 +184,7 @@ namespace FEBuilderGBA.Avalonia.Tests
         /// (Bounds.Width>0) so the check can never pass vacuously, then that no
         /// NUD-involved adjacent pair overlaps.
         /// </summary>
-        void AssertRowsHaveNoNudOverflow(Window view, string tag, params string[] nudNames)
+        void AssertRowsHaveNoNudOverflow(Control view, string tag, params string[] nudNames)
         {
             foreach (var name in nudNames)
             {

--- a/FEBuilderGBA.Avalonia.Tests/ToolAllWorkSupportViewHeadlessTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ToolAllWorkSupportViewHeadlessTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.IO;
 using System.Linq;
@@ -87,10 +87,15 @@ namespace FEBuilderGBA.Avalonia.Tests
 
             var view = new ToolAllWorkSupportView();
             view.Show();
-            view.Hide();
-
-            var ic = TilesList(view);
-            Assert.Equal(2, ItemCount(ic));
+            try
+            {
+                var ic = TilesList(view);
+                Assert.Equal(2, ItemCount(ic));
+            }
+            finally
+            {
+                view.Close();
+            }
         }
 
         [AvaloniaFact]
@@ -103,10 +108,15 @@ namespace FEBuilderGBA.Avalonia.Tests
             {
                 var view = new ToolAllWorkSupportView();
                 view.Show();
-                view.Hide();
-
-                var ic = TilesList(view);
-                Assert.Equal(0, ItemCount(ic));
+                try
+                {
+                    var ic = TilesList(view);
+                    Assert.Equal(0, ItemCount(ic));
+                }
+                finally
+                {
+                    view.Close();
+                }
             });
             Assert.Null(ex);
         }
@@ -119,7 +129,7 @@ namespace FEBuilderGBA.Avalonia.Tests
 
             var view = new ToolAllWorkSupportView();
             view.Show();
-            view.Hide();
+            view.Close();
 
             var ids = view.GetLogicalDescendants().OfType<Control>()
                 .Select(AutomationProperties.GetAutomationId)

--- a/FEBuilderGBA.Avalonia.Tests/ToolDiffViewHeadlessTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ToolDiffViewHeadlessTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Avalonia.Automation;
 using Avalonia.Controls;
@@ -47,7 +47,7 @@ namespace FEBuilderGBA.Avalonia.Tests
         {
             var view = new ToolDiffView();
             view.Show();
-            view.Hide();
+            view.Close();
             var items = view.GetLogicalDescendants().OfType<TabItem>().ToList();
             Assert.Equal(2, items.Count);
         }
@@ -57,7 +57,7 @@ namespace FEBuilderGBA.Avalonia.Tests
         {
             var view = new ToolDiffView();
             view.Show();
-            view.Hide();
+            view.Close();
             var headers = view.GetLogicalDescendants().OfType<TabItem>()
                 .Select(t => t.Header?.ToString()).ToList();
             Assert.Contains("2-ROM Diff", headers);
@@ -69,7 +69,7 @@ namespace FEBuilderGBA.Avalonia.Tests
         {
             var view = new ToolDiffView();
             view.Show();
-            view.Hide();
+            view.Close();
             var ids = CollectAutomationIds(view);
 
             // Diff2 tab

--- a/FEBuilderGBA.Avalonia.Tests/ToolLZ77ViewHeadlessTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ToolLZ77ViewHeadlessTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Avalonia.Automation;
 using Avalonia.Controls;
@@ -52,7 +52,7 @@ namespace FEBuilderGBA.Avalonia.Tests
             Assert.NotNull(tabs);
             // Force template realization
             view.Show();
-            view.Hide();
+            view.Close();
             var items = tabs.GetLogicalDescendants().OfType<TabItem>().ToList();
             Assert.Equal(6, items.Count);
         }
@@ -62,7 +62,7 @@ namespace FEBuilderGBA.Avalonia.Tests
         {
             var view = new ToolLZ77View();
             view.Show();
-            view.Hide();
+            view.Close();
             var tabs = view.GetLogicalDescendants().OfType<TabItem>().ToList();
             var headers = tabs.Select(t => t.Header?.ToString()).ToList();
             Assert.Contains("Decompress", headers);
@@ -78,7 +78,7 @@ namespace FEBuilderGBA.Avalonia.Tests
         {
             var view = new ToolLZ77View();
             view.Show();
-            view.Hide();
+            view.Close();
             var ids = CollectAutomationIds(view);
 
             // Per-tab "fire" buttons — these are the user-facing actions and MUST exist.
@@ -116,7 +116,7 @@ namespace FEBuilderGBA.Avalonia.Tests
         {
             var view = new ToolLZ77View();
             view.Show();
-            view.Hide();
+            view.Close();
             var statusLabel = view.GetLogicalDescendants()
                 .OfType<TextBlock>()
                 .FirstOrDefault(c => AutomationProperties.GetAutomationId(c) == "ToolLZ77_Status_Label");

--- a/FEBuilderGBA.Avalonia.Tests/ViewTranslationHelperTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ViewTranslationHelperTests.cs
@@ -1,4 +1,4 @@
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
@@ -268,9 +268,9 @@ namespace FEBuilderGBA.Avalonia.Tests
         }
 
         [AvaloniaFact]
-        public void AllViews_InheritTranslatedWindow()
+        public void AllViews_InheritTranslatedBase()
         {
-            // Verify that views inherit from TranslatedWindow base class
+            // Converted editor views inherit from TranslatedUserControl and implement IEmbeddableEditor.
             var viewTypes = new[]
             {
                 typeof(FEBuilderGBA.Avalonia.Views.UnitEditorView),
@@ -280,8 +280,10 @@ namespace FEBuilderGBA.Avalonia.Tests
 
             foreach (var vt in viewTypes)
             {
-                Assert.True(typeof(TranslatedWindow).IsAssignableFrom(vt),
-                    $"{vt.Name} should inherit from TranslatedWindow");
+                Assert.True(typeof(TranslatedUserControl).IsAssignableFrom(vt),
+                    $"{vt.Name} should inherit from TranslatedUserControl");
+                Assert.True(typeof(FEBuilderGBA.Avalonia.Services.IEmbeddableEditor).IsAssignableFrom(vt),
+                    $"{vt.Name} should implement IEmbeddableEditor");
             }
         }
 

--- a/FEBuilderGBA.Avalonia/App.axaml.cs
+++ b/FEBuilderGBA.Avalonia/App.axaml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -375,7 +375,7 @@ namespace FEBuilderGBA.Avalonia
             {
                 global::Avalonia.Controls.Window window = viewName switch
                 {
-                    "LogViewerView" => new Views.LogViewerView(),
+                    "LogViewerView" => new Services.EditorHostWindow(new Views.LogViewerView()),
                     // #1700 PR proof: render the two cosmetic-fix editors with the
                     // real desktop Skia rasterizer (the empty editor already lays
                     // out the geometry under test — AIScript's MinWidth address

--- a/FEBuilderGBA.Avalonia/Dialogs/FileDialogHelper.cs
+++ b/FEBuilderGBA.Avalonia/Dialogs/FileDialogHelper.cs
@@ -1,10 +1,11 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using global::Avalonia;
 using global::Avalonia.Controls;
 using global::Avalonia.Platform.Storage;
+using FEBuilderGBA;
 
 namespace FEBuilderGBA.Avalonia.Dialogs
 {
@@ -226,6 +227,16 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         static readonly string[] TxtPatterns = new[] { "*.txt" };
         static readonly string[] AllPalettePatterns = new[] { "*.pal", "*.gbapal", "*.act", "*.gpl", "*.txt" };
 
+        static IStorageProvider? GetStorageProvider(TopLevel? owner, string operation)
+        {
+            var provider = owner?.StorageProvider;
+            if (provider == null)
+            {
+                Log.Error($"FileDialogHelper.{operation}: TopLevel or StorageProvider is unavailable.");
+            }
+            return provider;
+        }
+
         static FilePickerFileType MakeGbaFileType() => new(R._("GBA ROM Files"))
         {
             Patterns = GbaPatterns,
@@ -249,9 +260,11 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         /// retain the SAF handle for write-back (the main ROM open/save) use
         /// <see cref="OpenRomFilePick"/> instead.
         /// </summary>
-        public static async Task<string?> OpenRomFile(Window owner)
+        public static async Task<string?> OpenRomFile(TopLevel? owner)
         {
-            var files = await owner.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+            var provider = GetStorageProvider(owner, nameof(OpenRomFile));
+            if (provider == null) return null;
+            var files = await provider.OpenFilePickerAsync(new FilePickerOpenOptions
             {
                 Title = R._("Open ROM"),
                 AllowMultiple = false,
@@ -262,9 +275,11 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         }
 
         /// <summary>Save a GBA ROM file.</summary>
-        public static async Task<string?> SaveRomFile(Window owner, string? suggestedName = null)
+        public static async Task<string?> SaveRomFile(TopLevel? owner, string? suggestedName = null)
         {
-            var file = await owner.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            var provider = GetStorageProvider(owner, nameof(SaveRomFile));
+            if (provider == null) return null;
+            var file = await provider.SaveFilePickerAsync(new FilePickerSaveOptions
             {
                 Title = R._("Save ROM"),
                 SuggestedFileName = suggestedName ?? "rom.gba",
@@ -275,16 +290,18 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         }
 
         /// <summary>Save a UPS patch file (#1194 Save-as-UPS tool).</summary>
-        public static async Task<string?> SaveUpsFile(Window owner, string? suggestedName = null)
+        public static async Task<string?> SaveUpsFile(TopLevel? owner, string? suggestedName = null)
         {
             var file = await SaveUpsFilePick(owner, suggestedName);
             return file?.TryGetLocalPath();
         }
 
         /// <summary>Save a UPS patch file and return the picked IStorageFile handle (#1639).</summary>
-        public static async Task<IStorageFile?> SaveUpsFilePick(Window owner, string? suggestedName = null)
+        public static async Task<IStorageFile?> SaveUpsFilePick(TopLevel? owner, string? suggestedName = null)
         {
-            return await owner.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            var provider = GetStorageProvider(owner, nameof(SaveUpsFilePick));
+            if (provider == null) return null;
+            return await provider.SaveFilePickerAsync(new FilePickerSaveOptions
             {
                 Title = R._("Save UPS Patch"),
                 SuggestedFileName = suggestedName ?? "patch.ups",
@@ -298,18 +315,9 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         /// local path, so callers must read it via the stream API (#1124). Desktop
         /// callers can still call TryGetLocalPath() on the returned handle.
         /// </summary>
-        public static Task<IStorageFile?> OpenRomFilePick(Window owner)
-            => OpenRomFilePick((Visual)owner);
-
-        /// <summary>
-        /// Visual/TopLevel-owner overload (#1870): resolves the StorageProvider via
-        /// <see cref="TopLevel.GetTopLevel"/> so it works from the single-view
-        /// (WebAssembly / Android) shell, whose owner Visual is NOT a Window. Returns
-        /// null when the owner is not yet attached to a TopLevel or the user cancels.
-        /// </summary>
-        public static async Task<IStorageFile?> OpenRomFilePick(Visual owner)
+        public static async Task<IStorageFile?> OpenRomFilePick(TopLevel? owner)
         {
-            var provider = TopLevel.GetTopLevel(owner)?.StorageProvider;
+            var provider = GetStorageProvider(owner, nameof(OpenRomFilePick));
             if (provider == null) return null;
             var files = await provider.OpenFilePickerAsync(new FilePickerOpenOptions
             {
@@ -321,17 +329,9 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         }
 
         /// <summary>Save a GBA ROM and return the picked IStorageFile (#1124).</summary>
-        public static Task<IStorageFile?> SaveRomFilePick(Window owner, string? suggestedName = null)
-            => SaveRomFilePick((Visual)owner, suggestedName);
-
-        /// <summary>
-        /// Visual/TopLevel-owner overload (#1870): resolves the StorageProvider via
-        /// <see cref="TopLevel.GetTopLevel"/> for the single-view shell. Returns null
-        /// when the owner is not yet attached to a TopLevel or the user cancels.
-        /// </summary>
-        public static async Task<IStorageFile?> SaveRomFilePick(Visual owner, string? suggestedName = null)
+        public static async Task<IStorageFile?> SaveRomFilePick(TopLevel? owner, string? suggestedName = null)
         {
-            var provider = TopLevel.GetTopLevel(owner)?.StorageProvider;
+            var provider = GetStorageProvider(owner, nameof(SaveRomFilePick));
             if (provider == null) return null;
             return await provider.SaveFilePickerAsync(new FilePickerSaveOptions
             {
@@ -345,9 +345,11 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         /// Open a decomp project folder (#1129 slice 1). Returns the chosen
         /// directory's local path, or null when cancelled / unavailable.
         /// </summary>
-        public static async Task<string?> OpenProjectFolder(Window owner)
+        public static async Task<string?> OpenProjectFolder(TopLevel? owner)
         {
-            var folders = await owner.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+            var provider = GetStorageProvider(owner, nameof(OpenProjectFolder));
+            if (provider == null) return null;
+            var folders = await provider.OpenFolderPickerAsync(new FolderPickerOpenOptions
             {
                 Title = R._("Open Decomp Project"),
                 AllowMultiple = false,
@@ -357,9 +359,11 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         }
 
         /// <summary>Open a UPS patch file.</summary>
-        public static async Task<string?> OpenPatchFile(Window owner)
+        public static async Task<string?> OpenPatchFile(TopLevel? owner)
         {
-            var files = await owner.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+            var provider = GetStorageProvider(owner, nameof(OpenPatchFile));
+            if (provider == null) return null;
+            var files = await provider.OpenFilePickerAsync(new FilePickerOpenOptions
             {
                 Title = R._("Open Patch"),
                 AllowMultiple = false,
@@ -375,9 +379,11 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         };
 
         /// <summary>Save a PNG image file.</summary>
-        public static async Task<string?> SaveImageFile(Window owner, string? suggestedName = null)
+        public static async Task<string?> SaveImageFile(TopLevel? owner, string? suggestedName = null)
         {
-            var file = await owner.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            var provider = GetStorageProvider(owner, nameof(SaveImageFile));
+            if (provider == null) return null;
+            var file = await provider.SaveFilePickerAsync(new FilePickerSaveOptions
             {
                 Title = R._("Export Image"),
                 SuggestedFileName = suggestedName ?? "image.png",
@@ -393,9 +399,11 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         };
 
         /// <summary>Open an image file (PNG, BMP) for import.</summary>
-        public static async Task<string?> OpenImageFile(Window owner)
+        public static async Task<string?> OpenImageFile(TopLevel? owner)
         {
-            var files = await owner.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+            var provider = GetStorageProvider(owner, nameof(OpenImageFile));
+            if (provider == null) return null;
+            var files = await provider.OpenFilePickerAsync(new FilePickerOpenOptions
             {
                 Title = R._("Import Image"),
                 AllowMultiple = false,
@@ -406,7 +414,7 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         }
 
         /// <summary>Save an Animation Creator script file (.txt).</summary>
-        public static async Task<string?> SaveAnimationScriptFile(Window owner, string? suggestedName = null)
+        public static async Task<string?> SaveAnimationScriptFile(TopLevel? owner, string? suggestedName = null)
         {
             var file = await SaveAnimationScriptFilePick(owner, suggestedName);
             return file?.TryGetLocalPath();
@@ -419,10 +427,12 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         /// (#1639). NOTE: callers whose export ALSO writes sibling PNGs must NOT
         /// bridge — they require a local path and Android-disable.
         /// </summary>
-        public static async Task<IStorageFile?> SaveAnimationScriptFilePick(Window owner, string? suggestedName = null)
+        public static async Task<IStorageFile?> SaveAnimationScriptFilePick(TopLevel? owner, string? suggestedName = null)
         {
+            var provider = GetStorageProvider(owner, nameof(SaveAnimationScriptFilePick));
+            if (provider == null) return null;
             var fileType = new FilePickerFileType(R._("Animation Script (.txt)")) { Patterns = TxtPatterns };
-            return await owner.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            return await provider.SaveFilePickerAsync(new FilePickerSaveOptions
             {
                 Title = R._("Save Animation Script"),
                 SuggestedFileName = suggestedName ?? "anim.txt",
@@ -431,7 +441,7 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         }
 
         /// <summary>Open any file with custom filter.</summary>
-        public static async Task<string?> OpenFile(Window owner, string title, string pattern, bool requireLocalPath = false)
+        public static async Task<string?> OpenFile(TopLevel? owner, string title, string pattern, bool requireLocalPath = false)
             => await OpenFile(owner, title, new[] { pattern }, requireLocalPath);
 
         /// <summary>
@@ -446,10 +456,12 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         /// returns null — the caller then shows an explicit Android message — and
         /// the bridge is NEVER used for multi-file flows.
         /// </summary>
-        public static async Task<string?> OpenFile(Window owner, string title, string[] patterns, bool requireLocalPath = false)
+        public static async Task<string?> OpenFile(TopLevel? owner, string title, string[] patterns, bool requireLocalPath = false)
         {
+            var provider = GetStorageProvider(owner, nameof(OpenFile));
+            if (provider == null) return null;
             var fileType = new FilePickerFileType(title) { Patterns = patterns };
-            var files = await owner.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+            var files = await provider.OpenFilePickerAsync(new FilePickerOpenOptions
             {
                 Title = title,
                 AllowMultiple = false,
@@ -470,10 +482,12 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         /// Used by the Map Action Animation Export button (#499) plus any
         /// future caller that needs a generic single-format SaveFilePicker.
         /// </summary>
-        public static async Task<string?> SaveFile(Window owner, string title, string filterName, string pattern, string? suggestedName = null)
+        public static async Task<string?> SaveFile(TopLevel? owner, string title, string filterName, string pattern, string? suggestedName = null)
         {
+            var provider = GetStorageProvider(owner, nameof(SaveFile));
+            if (provider == null) return null;
             var fileType = new FilePickerFileType(filterName) { Patterns = new[] { pattern } };
-            var file = await owner.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            var file = await provider.SaveFilePickerAsync(new FilePickerSaveOptions
             {
                 Title = title,
                 SuggestedFileName = suggestedName,
@@ -490,9 +504,11 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         /// Used by the Map Action Animation Export button (#499 Copilot bot
         /// inline review fix: single-pattern picker hid the .gif export path).
         /// </summary>
-        public static async Task<string?> SaveFile(Window owner, string title,
+        public static async Task<string?> SaveFile(TopLevel? owner, string title,
             (string Name, string Pattern)[] filters, string? suggestedName = null)
         {
+            var provider = GetStorageProvider(owner, nameof(SaveFile));
+            if (provider == null) return null;
             var choices = new System.Collections.Generic.List<FilePickerFileType>(filters.Length + 1);
             foreach (var (name, pattern) in filters)
             {
@@ -500,7 +516,7 @@ namespace FEBuilderGBA.Avalonia.Dialogs
             }
             choices.Add(MakeAllFileType());
 
-            var file = await owner.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            var file = await provider.SaveFilePickerAsync(new FilePickerSaveOptions
             {
                 Title = title,
                 SuggestedFileName = suggestedName,
@@ -517,9 +533,11 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         /// Returns (-1) as filterIndex when the dialog is cancelled.
         /// </summary>
         public static async Task<(string? Path, int FilterIndex)> SaveFileWithFilterIndex(
-            Window owner, string title,
+            TopLevel? owner, string title,
             (string Name, string Pattern)[] filters, string? suggestedName = null)
         {
+            var provider = GetStorageProvider(owner, nameof(SaveFileWithFilterIndex));
+            if (provider == null) return (null, -1);
             var choices = new System.Collections.Generic.List<FilePickerFileType>(filters.Length + 1);
             foreach (var (name, pattern) in filters)
             {
@@ -527,7 +545,7 @@ namespace FEBuilderGBA.Avalonia.Dialogs
             }
             choices.Add(MakeAllFileType());
 
-            var file = await owner.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            var file = await provider.SaveFilePickerAsync(new FilePickerSaveOptions
             {
                 Title = title,
                 SuggestedFileName = suggestedName,
@@ -586,9 +604,11 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         };
 
         /// <summary>Save a palette file with multi-format choices.</summary>
-        public static async Task<string?> SavePaletteFile(Window owner, string? suggestedName = null)
+        public static async Task<string?> SavePaletteFile(TopLevel? owner, string? suggestedName = null)
         {
-            var file = await owner.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            var provider = GetStorageProvider(owner, nameof(SavePaletteFile));
+            if (provider == null) return null;
+            var file = await provider.SaveFilePickerAsync(new FilePickerSaveOptions
             {
                 Title = R._("Export Palette"),
                 SuggestedFileName = suggestedName ?? "palette.pal",
@@ -599,9 +619,11 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         }
 
         /// <summary>Open a palette file (any supported format) for import.</summary>
-        public static async Task<string?> OpenPaletteFile(Window owner)
+        public static async Task<string?> OpenPaletteFile(TopLevel? owner)
         {
-            var files = await owner.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+            var provider = GetStorageProvider(owner, nameof(OpenPaletteFile));
+            if (provider == null) return null;
+            var files = await provider.OpenFilePickerAsync(new FilePickerOpenOptions
             {
                 Title = R._("Import Palette"),
                 AllowMultiple = false,
@@ -619,9 +641,11 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         // ===================================================================
 
         /// <summary>Pick a PNG save target and run <paramref name="writer"/> via the SAF bridge.</summary>
-        public static async Task<string?> SaveImageFileVia(Window owner, string? suggestedName, Func<string, Task> writer)
+        public static async Task<string?> SaveImageFileVia(TopLevel? owner, string? suggestedName, Func<string, Task> writer)
         {
-            var file = await owner.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            var provider = GetStorageProvider(owner, nameof(SaveImageFileVia));
+            if (provider == null) return null;
+            var file = await provider.SaveFilePickerAsync(new FilePickerSaveOptions
             {
                 Title = R._("Export Image"),
                 SuggestedFileName = suggestedName ?? "image.png",
@@ -631,7 +655,7 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         }
 
         /// <summary>Synchronous-writer overload of <see cref="SaveImageFileVia(Window, string, Func{string, Task})"/>.</summary>
-        public static Task<string?> SaveImageFileVia(Window owner, string? suggestedName, Action<string> writer)
+        public static Task<string?> SaveImageFileVia(TopLevel? owner, string? suggestedName, Action<string> writer)
             => SaveImageFileVia(owner, suggestedName, p => { writer(p); return Task.CompletedTask; });
 
         /// <summary>
@@ -640,9 +664,11 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         /// writing (e.g. the desktop overwrite-confirmation in ImageExportService)
         /// and then bridge the write via <see cref="WriteViaAsync(IStorageFile, Func{string, Task})"/>. #1639.
         /// </summary>
-        public static async Task<IStorageFile?> SaveImageFilePick(Window owner, string? suggestedName = null)
+        public static async Task<IStorageFile?> SaveImageFilePick(TopLevel? owner, string? suggestedName = null)
         {
-            return await owner.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            var provider = GetStorageProvider(owner, nameof(SaveImageFilePick));
+            if (provider == null) return null;
+            return await provider.SaveFilePickerAsync(new FilePickerSaveOptions
             {
                 Title = R._("Export Image"),
                 SuggestedFileName = suggestedName ?? "image.png",
@@ -651,9 +677,11 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         }
 
         /// <summary>Pick a palette save target (multi-format) and run <paramref name="writer"/> via the SAF bridge.</summary>
-        public static async Task<string?> SavePaletteFileVia(Window owner, string? suggestedName, Func<string, Task> writer)
+        public static async Task<string?> SavePaletteFileVia(TopLevel? owner, string? suggestedName, Func<string, Task> writer)
         {
-            var file = await owner.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            var provider = GetStorageProvider(owner, nameof(SavePaletteFileVia));
+            if (provider == null) return null;
+            var file = await provider.SaveFilePickerAsync(new FilePickerSaveOptions
             {
                 Title = R._("Export Palette"),
                 SuggestedFileName = suggestedName ?? "palette.pal",
@@ -663,14 +691,16 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         }
 
         /// <summary>Synchronous-writer overload of <see cref="SavePaletteFileVia(Window, string, Func{string, Task})"/>.</summary>
-        public static Task<string?> SavePaletteFileVia(Window owner, string? suggestedName, Action<string> writer)
+        public static Task<string?> SavePaletteFileVia(TopLevel? owner, string? suggestedName, Action<string> writer)
             => SavePaletteFileVia(owner, suggestedName, p => { writer(p); return Task.CompletedTask; });
 
         /// <summary>Pick a single-format save target and run <paramref name="writer"/> via the SAF bridge.</summary>
-        public static async Task<string?> SaveFileVia(Window owner, string title, string filterName, string pattern, string? suggestedName, Func<string, Task> writer)
+        public static async Task<string?> SaveFileVia(TopLevel? owner, string title, string filterName, string pattern, string? suggestedName, Func<string, Task> writer)
         {
+            var provider = GetStorageProvider(owner, nameof(SaveFileVia));
+            if (provider == null) return null;
             var fileType = new FilePickerFileType(filterName) { Patterns = new[] { pattern } };
-            var file = await owner.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            var file = await provider.SaveFilePickerAsync(new FilePickerSaveOptions
             {
                 Title = title,
                 SuggestedFileName = suggestedName,
@@ -680,7 +710,7 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         }
 
         /// <summary>Synchronous-writer overload of <see cref="SaveFileVia(Window, string, string, string, string, Func{string, Task})"/>.</summary>
-        public static Task<string?> SaveFileVia(Window owner, string title, string filterName, string pattern, string? suggestedName, Action<string> writer)
+        public static Task<string?> SaveFileVia(TopLevel? owner, string title, string filterName, string pattern, string? suggestedName, Action<string> writer)
             => SaveFileVia(owner, title, filterName, pattern, suggestedName, p => { writer(p); return Task.CompletedTask; });
 
         /// <summary>
@@ -689,10 +719,12 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         /// awaited write and then bridge it via <see cref="WriteViaAsync(IStorageFile, Func{string, Task})"/>
         /// themselves (#1639).
         /// </summary>
-        public static async Task<IStorageFile?> SaveFilePick(Window owner, string title, string filterName, string pattern, string? suggestedName = null)
+        public static async Task<IStorageFile?> SaveFilePick(TopLevel? owner, string title, string filterName, string pattern, string? suggestedName = null)
         {
+            var provider = GetStorageProvider(owner, nameof(SaveFilePick));
+            if (provider == null) return null;
             var fileType = new FilePickerFileType(filterName) { Patterns = new[] { pattern } };
-            return await owner.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            return await provider.SaveFilePickerAsync(new FilePickerSaveOptions
             {
                 Title = title,
                 SuggestedFileName = suggestedName,
@@ -706,14 +738,16 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         /// (bridgeable) and others write siblings (must require a local path), so
         /// they branch by the chosen extension themselves (#1639).
         /// </summary>
-        public static async Task<IStorageFile?> SaveFilePick(Window owner, string title,
+        public static async Task<IStorageFile?> SaveFilePick(TopLevel? owner, string title,
             (string Name, string Pattern)[] filters, string? suggestedName = null)
         {
+            var provider = GetStorageProvider(owner, nameof(SaveFilePick));
+            if (provider == null) return null;
             var choices = new System.Collections.Generic.List<FilePickerFileType>(filters.Length + 1);
             foreach (var (name, pattern) in filters)
                 choices.Add(new FilePickerFileType(name) { Patterns = new[] { pattern } });
             choices.Add(MakeAllFileType());
-            return await owner.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            return await provider.SaveFilePickerAsync(new FilePickerSaveOptions
             {
                 Title = title,
                 SuggestedFileName = suggestedName,
@@ -728,15 +762,17 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         /// index, so callers can branch by format (e.g. .txt vs .gif). Single-file
         /// writers only — multi-file/sibling exports must require a local path.
         /// </summary>
-        public static async Task<string?> SaveFileVia(Window owner, string title,
+        public static async Task<string?> SaveFileVia(TopLevel? owner, string title,
             (string Name, string Pattern)[] filters, string? suggestedName, Func<string, int, Task> writer)
         {
+            var provider = GetStorageProvider(owner, nameof(SaveFileVia));
+            if (provider == null) return null;
             var choices = new System.Collections.Generic.List<FilePickerFileType>(filters.Length + 1);
             foreach (var (name, pattern) in filters)
                 choices.Add(new FilePickerFileType(name) { Patterns = new[] { pattern } });
             choices.Add(MakeAllFileType());
 
-            var file = await owner.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            var file = await provider.SaveFilePickerAsync(new FilePickerSaveOptions
             {
                 Title = title,
                 SuggestedFileName = suggestedName,

--- a/FEBuilderGBA.Avalonia/Services/RomFileService.cs
+++ b/FEBuilderGBA.Avalonia/Services/RomFileService.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+﻿// SPDX-License-Identifier: GPL-3.0-or-later
 // #1870 — shared ROM open/save for the single-view (web / Android) shell.
 //
 // The desktop MainWindow owns ROM open/save today (OpenRom_Click / SaveAsRom_Click
@@ -26,6 +26,7 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using global::Avalonia;
+using global::Avalonia.Controls;
 using global::Avalonia.Platform.Storage;
 using FEBuilderGBA.Avalonia.Dialogs;
 
@@ -161,7 +162,7 @@ namespace FEBuilderGBA.Avalonia.Services
         /// </summary>
         public static async Task<RomOpenOutcome> OpenRomAsync(Visual owner)
         {
-            var file = await FileDialogHelper.OpenRomFilePick(owner);
+            var file = await FileDialogHelper.OpenRomFilePick(TopLevel.GetTopLevel(owner));
             if (file == null) return RomOpenOutcome.Cancelled;
 
             // Opening a plain ROM clears any active decomp project (#1129), matching
@@ -203,7 +204,7 @@ namespace FEBuilderGBA.Avalonia.Services
             if (CoreState.IsDecompMode) return null;
 
             string suggestedName = Path.GetFileName(CoreState.ROM.Filename ?? "rom.gba");
-            var file = await FileDialogHelper.SaveRomFilePick(owner, suggestedName);
+            var file = await FileDialogHelper.SaveRomFilePick(TopLevel.GetTopLevel(owner), suggestedName);
             if (file == null) return null;
 
             string? localPath = file.TryGetLocalPath();

--- a/FEBuilderGBA.Avalonia/Views/BattleBGViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/BattleBGViewerView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.IO;
 using global::Avalonia.Controls;
@@ -98,7 +98,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
         async void ImportPng_Click(object? sender, RoutedEventArgs e)
         {
-            string? filePath = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this) as Window);
+            string? filePath = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this));
             if (string.IsNullOrEmpty(filePath)) return; // cancelled
             ImportImageFromFile(filePath);
         }
@@ -164,7 +164,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // BattleBG palette is LZ77-compressed
                 byte[] pal = LZ77.decompress(rom.Data, palAddr);
                 if (pal == null || pal.Length < 32) { CoreState.Services.ShowError("Failed to read palette"); return; }
-                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this) as Window, "battle_bg_palette.pal", p =>
+                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this), "battle_bg_palette.pal", p =>
                 {
                     // #1639: write via the SAF bridge so Android content:// targets work.
                     PaletteFormat fmt = PaletteFormatConverter.FormatFromExtension(System.IO.Path.GetExtension(p));
@@ -180,7 +180,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 ROM rom = CoreState.ROM;
                 if (rom == null) return;
-                string path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this) as Window);
+                string path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this));
                 if (string.IsNullOrEmpty(path)) return;
                 byte[] fileData = File.ReadAllBytes(path);
                 PaletteFormat fmt = PaletteFormatConverter.DetectFormat(fileData, System.IO.Path.GetExtension(path));

--- a/FEBuilderGBA.Avalonia/Views/BattleTerrainViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/BattleTerrainViewerView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.IO;
 using global::Avalonia.Controls;
@@ -165,7 +165,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // BattleTerrain palette is stored RAW (0x20 bytes), NOT LZ77.
                 byte[] pal = _vm.ExportPaletteBytes();
                 if (pal == null || pal.Length < 32) { CoreState.Services.ShowError("Failed to read palette"); return; }
-                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this) as Window, "battle_terrain_palette.pal", p =>
+                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this), "battle_terrain_palette.pal", p =>
                 {
                     // #1639: write via the SAF bridge so Android content:// targets work.
                     PaletteFormat fmt = PaletteFormatConverter.FormatFromExtension(System.IO.Path.GetExtension(p));
@@ -181,7 +181,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 ROM rom = CoreState.ROM;
                 if (rom == null) return;
-                string? path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this) as Window);
+                string? path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this));
                 if (string.IsNullOrEmpty(path)) return;
                 byte[] fileData = File.ReadAllBytes(path);
                 PaletteFormat fmt = PaletteFormatConverter.DetectFormat(fileData, System.IO.Path.GetExtension(path));

--- a/FEBuilderGBA.Avalonia/Views/BigCGViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/BigCGViewerView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.IO;
 using global::Avalonia.Controls;
@@ -208,7 +208,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 uint palAddr = U.toOffset(palPtr);
                 byte[] pal = ImageUtilCore.GetPalette(palAddr, 256);
                 if (pal == null || pal.Length < 32) { CoreState.Services.ShowError("Failed to read palette"); return; }
-                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this) as Window, "big_cg_palette.pal", p =>
+                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this), "big_cg_palette.pal", p =>
                 {
                     // #1639: write via the SAF bridge so Android content:// targets work.
                     PaletteFormat fmt = PaletteFormatConverter.FormatFromExtension(System.IO.Path.GetExtension(p));
@@ -224,7 +224,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 ROM rom = CoreState.ROM;
                 if (rom == null) return;
-                string path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this) as Window);
+                string path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this));
                 if (string.IsNullOrEmpty(path)) return;
                 byte[] fileData = File.ReadAllBytes(path);
                 PaletteFormat fmt = PaletteFormatConverter.DetectFormat(fileData, System.IO.Path.GetExtension(path));

--- a/FEBuilderGBA.Avalonia/Views/ChapterTitleViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ChapterTitleViewerView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.IO;
 using global::Avalonia.Controls;
@@ -107,7 +107,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (palAddr == 0 || !U.isSafetyOffset(palAddr)) { CoreState.Services.ShowError("No palette address"); return; }
                 byte[] pal = ImageUtilCore.GetPalette(palAddr, 16);
                 if (pal == null || pal.Length < 32) { CoreState.Services.ShowError("Failed to read palette"); return; }
-                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this) as Window, "chapter_title_palette.pal", p =>
+                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this), "chapter_title_palette.pal", p =>
                 {
                     // #1639: write via the SAF bridge so Android content:// targets work.
                     PaletteFormat fmt = PaletteFormatConverter.FormatFromExtension(System.IO.Path.GetExtension(p));

--- a/FEBuilderGBA.Avalonia/Views/ClassEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ClassEditorView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.ClassEditorView"
-        Title="Class Editor" Width="1200" Height="900"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.ClassEditorView">
   <Grid ColumnDefinitions="250,*">
     <!-- Address List with icon preview -->
     <Grid Grid.Column="0" RowDefinitions="*,Auto">
@@ -452,4 +450,4 @@
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/ClassEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ClassEditorView.axaml.cs
@@ -1,3 +1,4 @@
+﻿using global::Avalonia;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,13 +11,16 @@ using FEBuilderGBA.Core;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ClassEditorView : TranslatedWindow, IPickableEditor, IDataVerifiableView
+    public partial class ClassEditorView : TranslatedUserControl, IEmbeddableEditor, IPickableEditor, IDataVerifiableView
     {
         readonly ClassEditorViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
 
         public string ViewTitle => R._("Class Editor");
-        public bool IsLoaded => _vm.CanWrite;
+        public new bool IsLoaded => _vm.CanWrite;
+        public EditorDescriptor Descriptor => new("Class Editor", 1200, 900, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
 
         public event Action<PickResult>? SelectionConfirmed;
 
@@ -25,7 +29,6 @@ namespace FEBuilderGBA.Avalonia.Views
             InitializeComponent();
             ClassList.SelectedAddressChanged += OnClassSelected;
             ClassList.SelectionConfirmed += result => SelectionConfirmed?.Invoke(result);
-            Opened += (_, _) => LoadList();
 
             // Ability flag names are set in LoadList() based on ROM version
 
@@ -63,6 +66,16 @@ namespace FEBuilderGBA.Avalonia.Views
             // the portrait or wait-icon field, refresh the card images.
             PortraitIdBox.ValueChanged += OnClassCardInputChanged;
             WaitIconBox.ValueChanged   += OnClassCardInputChanged;
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         void LoadList()
@@ -837,6 +850,7 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         void CalculateGrowth_Click(object? sender, RoutedEventArgs e)
         {
@@ -966,7 +980,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (rom == null) return;
                 var addrs = GetAllClassAddresses();
                 if (addrs.Length == 0) return;
-                await MakeCsvManager().ExportAllAsync(this, rom, addrs);
+                await MakeCsvManager().ExportAllAsync(TopLevel.GetTopLevel(this) as Window, rom, addrs);
             }
             catch (Exception ex) { Log.ErrorF("ExportAll_Click failed: {0}", ex.Message); }
         }
@@ -984,7 +998,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // when no selection is resolvable.
                 int idx = ClassList.SelectedOriginalIndex;
                 uint uid = idx >= 0 ? (uint)idx : 0u;
-                await MakeCsvManager().ExportSelectedAsync(this, rom, _vm.CurrentAddr, uid);
+                await MakeCsvManager().ExportSelectedAsync(TopLevel.GetTopLevel(this) as Window, rom, _vm.CurrentAddr, uid);
             }
             catch (Exception ex) { Log.ErrorF("ExportSelected_Click failed: {0}", ex.Message); }
         }
@@ -1000,7 +1014,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var mgr = MakeCsvManager();
                 // Read the CSV FIRST so the undo scope only wraps the
                 // actual ROM writes (matches PR #559 / UnitEditorView).
-                string? csv = await mgr.ReadCsvForUiAsync(this);
+                string? csv = await mgr.ReadCsvForUiAsync(TopLevel.GetTopLevel(this) as Window);
                 if (csv == null) return;
                 _undoService.Begin(R._("Import Classes CSV"));
                 int written;
@@ -1026,7 +1040,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (rom == null) return;
                 if (_vm.CurrentAddr == 0) return;
                 var mgr = MakeCsvManager();
-                string? csv = await mgr.ReadCsvForUiAsync(this);
+                string? csv = await mgr.ReadCsvForUiAsync(TopLevel.GetTopLevel(this) as Window);
                 if (csv == null) return;
                 // #1016: thread the SELECTED class id (0-based AddressList
                 // index) so the FE8U MagicSplit MAG column is read into the

--- a/FEBuilderGBA.Avalonia/Views/ClassFE6View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ClassFE6View.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.ClassFE6View"
-        Title="Class Editor (FE6)" Width="1200" Height="900"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.ClassFE6View">
   <Grid ColumnDefinitions="250,*">
     <controls:AddressListControl AutomationProperties.AutomationId="ClassFE6_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
 
@@ -344,4 +342,4 @@
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/ClassFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ClassFE6View.axaml.cs
@@ -1,3 +1,4 @@
+﻿using global::Avalonia;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,13 +11,16 @@ using FEBuilderGBA.Core;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ClassFE6View : TranslatedWindow, IPickableEditor, IDataVerifiableView
+    public partial class ClassFE6View : TranslatedUserControl, IEmbeddableEditor, IPickableEditor, IDataVerifiableView
     {
         readonly ClassFE6ViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
 
         public string ViewTitle => "Class Editor (FE6)";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("Class Editor (FE6)", 1200, 900, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
 
         public event Action<PickResult>? SelectionConfirmed;
 
@@ -25,7 +29,6 @@ namespace FEBuilderGBA.Avalonia.Views
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
             EntryList.SelectionConfirmed += result => SelectionConfirmed?.Invoke(result);
-            Opened += (_, _) => LoadList();
 
             // Auto-recalculate growth sim when SimLevel or growth/base stat boxes change.
             SimLevelBox.ValueChanged += OnGrowthInputChanged;
@@ -52,6 +55,16 @@ namespace FEBuilderGBA.Avalonia.Views
             B45Box.ValueChanged += OnWeaponValueChanged;
             B46Box.ValueChanged += OnWeaponValueChanged;
             B47Box.ValueChanged += OnWeaponValueChanged;
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         void LoadList()
@@ -529,7 +542,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var addrs = GetAllClassAddresses();
                 if (addrs.Length == 0) return;
                 var mgr = BuildCsvManager();
-                await mgr.ExportAllAsync(this, rom, addrs);
+                await mgr.ExportAllAsync(TopLevel.GetTopLevel(this) as Window, rom, addrs);
             }
             catch (Exception ex) { Log.Error($"ClassFE6View.ExportAll failed: {ex.Message}"); }
         }
@@ -543,7 +556,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var mgr = BuildCsvManager();
                 int idx = EntryList.SelectedOriginalIndex;
                 uint uid = idx >= 0 ? (uint)idx : 0;
-                await mgr.ExportSelectedAsync(this, rom, _vm.CurrentAddr, uid);
+                await mgr.ExportSelectedAsync(TopLevel.GetTopLevel(this) as Window, rom, _vm.CurrentAddr, uid);
             }
             catch (Exception ex) { Log.Error($"ClassFE6View.ExportSelected failed: {ex.Message}"); }
         }
@@ -557,7 +570,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var addrs = GetAllClassAddresses();
                 if (addrs.Length == 0) return;
                 var mgr = BuildCsvManager();
-                string? csv = await mgr.ReadCsvForUiAsync(this);
+                string? csv = await mgr.ReadCsvForUiAsync(TopLevel.GetTopLevel(this) as Window);
                 if (csv == null) return;
                 _undoService.Begin("Import Classes (FE6) CSV");
                 int written;
@@ -584,7 +597,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var rom = CoreState.ROM;
                 if (rom == null || _vm.CurrentAddr == 0) return;
                 var mgr = BuildCsvManager();
-                string? csv = await mgr.ReadCsvForUiAsync(this);
+                string? csv = await mgr.ReadCsvForUiAsync(TopLevel.GetTopLevel(this) as Window);
                 if (csv == null) return;
                 _undoService.Begin("Import Class (FE6) CSV");
                 int written;
@@ -611,6 +624,7 @@ namespace FEBuilderGBA.Avalonia.Views
         public void EnablePickMode() => EntryList.EnablePickMode();
 
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         static uint ParseHexText(string? text)
         {

--- a/FEBuilderGBA.Avalonia/Views/DevTranslateView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/DevTranslateView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.IO;
 using System.Threading.Tasks;
@@ -57,7 +57,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // so it needs a real local directory. OpenProjectFolder returns
                 // null on Android SAF (no local path) → surface a clear message
                 // instead of silently doing nothing.
-                string? folder = await FileDialogHelper.OpenProjectFolder(TopLevel.GetTopLevel(this) as Window);
+                string? folder = await FileDialogHelper.OpenProjectFolder(TopLevel.GetTopLevel(this));
                 if (string.IsNullOrEmpty(folder) && OperatingSystem.IsAndroid())
                     _vm.StatusMessage = R._("Dev Translate reads a folder tree and requires desktop file-system access; it is not available on this device.");
                 return folder;

--- a/FEBuilderGBA.Avalonia/Views/EventAssemblerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventAssemblerView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.Threading.Tasks;
 using global::Avalonia.Controls;
@@ -233,7 +233,7 @@ namespace FEBuilderGBA.Avalonia.Views
             // Prompt for the CLEAN ORIGINAL ROM (the ROM as it was before the patch).
             // Faithful to WF UnInstallPatch, which asks the user for a ROM that does
             // NOT contain the patch and restores the traced ranges from it.
-            string? cleanRomPath = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this) as Window);
+            string? cleanRomPath = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this));
             if (string.IsNullOrEmpty(cleanRomPath))
                 return; // cancelled
 

--- a/FEBuilderGBA.Avalonia/Views/FE8SpellMenuExtendsView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/FE8SpellMenuExtendsView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.FE8SpellMenuExtendsView"
-        Title="Spell Menu Extensions" Width="1189" Height="849"
-        SizeToContent="Manual">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.FE8SpellMenuExtendsView">
   <Grid ColumnDefinitions="250,250,*" RowDefinitions="Auto,*">
 
     <!-- Row 0: master-write bar (spans all columns) -->
@@ -134,4 +132,4 @@
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/FE8SpellMenuExtendsView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/FE8SpellMenuExtendsView.axaml.cs
@@ -14,6 +14,7 @@
 // PreviewIconHelper.LoadItemIconByItemId (a detail-panel preview, NOT a per-row
 // list-icon loader), so the master-list rows stay icon-free per the #939
 // Category-B contract.
+using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -24,14 +25,18 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class FE8SpellMenuExtendsView : TranslatedWindow, IEditorView, IDataVerifiableView
+    public partial class FE8SpellMenuExtendsView : TranslatedUserControl, IEmbeddableEditor, IDataVerifiableView
     {
         readonly FE8SpellMenuExtendsViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
         Bitmap _n1IconBitmap;
 
         public string ViewTitle => "Spell Menu Extensions";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("Spell Menu Extensions", 1189, 849);
+        public event EventHandler? CloseRequested;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
         public ViewModelBase DataViewModel => _vm;
 
         public FE8SpellMenuExtendsView()
@@ -40,8 +45,22 @@ namespace FEBuilderGBA.Avalonia.Views
             // Bind DataContext so AXAML {Binding SpellEntries} resolves.
             DataContext = _vm;
             EntryList.SelectedAddressChanged += OnSelected;
-            Opened += (_, _) => LoadList();
-            Closed += (_, _) => DisposeBitmap(ref _n1IconBitmap);
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromVisualTree(e);
+            DisposeBitmap(ref _n1IconBitmap);
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         static void DisposeBitmap(ref Bitmap bmp)
@@ -236,7 +255,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 uint defaultCount = currentCount + 1;
                 if (defaultCount > maxCount) defaultCount = maxCount;
                 uint? chosen = await NumberInputDialog.Show(
-                    this,
+                    TopLevel.GetTopLevel(this) as Window,
                     R._("Enter the new spell-list entry count for this unit (current: {0}, max: {1}).",
                         currentCount, maxCount),
                     R._("List Expansion"),

--- a/FEBuilderGBA.Avalonia/Views/FontEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/FontEditorView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.IO;
 using global::Avalonia.Controls;
@@ -209,7 +209,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // #1639: ExportAll writes sibling glyph PNGs next to the manifest,
                 // so require a real local path; a SAF pick (no local path) cannot
                 // place siblings → message on Android, never silent.
-                string? path = await FileDialogHelper.SaveFile(TopLevel.GetTopLevel(this) as Window,
+                string? path = await FileDialogHelper.SaveFile(TopLevel.GetTopLevel(this),
                     R._("Export All Fonts"), "fontall.txt", "*.fontall.txt", "font.fontall.txt");
                 if (string.IsNullOrEmpty(path))
                 {
@@ -246,7 +246,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // #1639: ImportAll resolves sibling glyph PNGs from the manifest's
                 // own directory, so require a real local path; a SAF pick (no local
                 // path) cannot resolve siblings → message on Android, never silent.
-                string? path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this) as Window,
+                string? path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this),
                     R._("Import All Fonts"), "*.fontall.txt", requireLocalPath: true);
                 if (string.IsNullOrEmpty(path))
                 {
@@ -293,7 +293,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                string? path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this) as Window,
+                string? path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this),
                     R._("Load Font File"), new[] { "*.ttf", "*.otf" });
                 if (string.IsNullOrEmpty(path)) return;
                 _fontFilePath = path;

--- a/FEBuilderGBA.Avalonia/Views/FontZHView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/FontZHView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.IO;
 using global::Avalonia.Controls;
@@ -215,7 +215,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // #1639: ExportAll writes sibling glyph PNGs next to the manifest,
                 // so require a real local path; a SAF pick (no local path) cannot
                 // place siblings → message on Android, never silent.
-                string? path = await FileDialogHelper.SaveFile(TopLevel.GetTopLevel(this) as Window,
+                string? path = await FileDialogHelper.SaveFile(TopLevel.GetTopLevel(this),
                     R._("Export All Fonts"), "fontall.txt", "*.fontall.txt", "font.fontall.txt");
                 if (string.IsNullOrEmpty(path))
                 {
@@ -261,7 +261,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // #1639: ImportAll resolves sibling glyph PNGs from the manifest's
                 // own directory, so require a real local path; a SAF pick (no local
                 // path) cannot resolve siblings → message on Android, never silent.
-                string? path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this) as Window,
+                string? path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this),
                     R._("Import All Fonts"), "*.fontall.txt", requireLocalPath: true);
                 if (string.IsNullOrEmpty(path))
                 {
@@ -311,7 +311,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                string? path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this) as Window,
+                string? path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this),
                     R._("Load Font File"), new[] { "*.ttf", "*.otf" });
                 if (string.IsNullOrEmpty(path)) return;
                 _fontFilePath = path;

--- a/FEBuilderGBA.Avalonia/Views/GraphicsToolPatchMakerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/GraphicsToolPatchMakerView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -33,14 +33,14 @@ namespace FEBuilderGBA.Avalonia.Views
 
         async void BrowseOriginal_Click(object? sender, RoutedEventArgs e)
         {
-            var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this) as Window);
+            var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this));
             if (!string.IsNullOrEmpty(path))
                 _vm.OriginalRomPath = path;
         }
 
         async void BrowseModified_Click(object? sender, RoutedEventArgs e)
         {
-            var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this) as Window);
+            var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this));
             if (!string.IsNullOrEmpty(path))
                 _vm.ModifiedRomPath = path;
         }

--- a/FEBuilderGBA.Avalonia/Views/ImageBGView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBGView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -507,7 +507,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (safeColorCount < 16) { CoreState.Services.ShowError("Palette pointer is too close to end of ROM"); return; }
                 byte[] pal = ImageUtilCore.GetPalette(palAddr, safeColorCount);
                 if (pal == null || pal.Length < 32) { CoreState.Services.ShowError("Failed to read palette"); return; }
-                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this) as Window, "bg_palette.pal", p =>
+                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this), "bg_palette.pal", p =>
                 {
                     // #1639: write via the SAF bridge so Android content:// targets work.
                     PaletteFormat fmt = PaletteFormatConverter.FormatFromExtension(System.IO.Path.GetExtension(p));
@@ -530,7 +530,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     CoreState.Services?.ShowError("No BG entry is selected. Select an entry in the list before importing.");
                     return;
                 }
-                string path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this) as Window);
+                string path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this));
                 if (string.IsNullOrEmpty(path)) return;
                 byte[] fileData = File.ReadAllBytes(path);
                 PaletteFormat fmt = PaletteFormatConverter.DetectFormat(fileData, System.IO.Path.GetExtension(path));

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+﻿// SPDX-License-Identifier: GPL-3.0-or-later
 // ImageBattleAnimePalletView — Avalonia parity rebuild for #399. Mirrors
 // `ImageBattleAnimePalletForm` (panel1: 16 R/G/B + swatches + write +
 // zoom + clipboard + import/export + undo/redo). Uses the
@@ -447,7 +447,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
 
             // Open file dialog — mirrors WF ImageFormRef.OpenFilenameDialogFullColor.
-            string filePath = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this) as Window);
+            string filePath = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this));
             if (string.IsNullOrEmpty(filePath))
             {
                 return; // User cancelled.

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleAnimeView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleAnimeView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.ImageBattleAnimeView"
-        Title="Battle Animation Editor" Width="900" Height="600"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.ImageBattleAnimeView">
   <Grid ColumnDefinitions="250,*">
     <controls:AddressListControl AutomationProperties.AutomationId="ImageBattleAnime_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
 
@@ -161,4 +159,4 @@
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleAnimeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleAnimeView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -277,7 +277,7 @@ namespace FEBuilderGBA.Avalonia.Views
             // the .txt script, so a SAF pick (no local path) can't place them.
             // SaveAnimationScriptFile returns null without a local path; on Android
             // message instead of silently exporting siblings into a temp dir.
-            string? path = await Dialogs.FileDialogHelper.SaveAnimationScriptFile(TopLevel.GetTopLevel(this) as Window, $"{name}.txt");
+            string? path = await Dialogs.FileDialogHelper.SaveAnimationScriptFile(TopLevel.GetTopLevel(this), $"{name}.txt");
             if (string.IsNullOrEmpty(path))
             {
                 if (OperatingSystem.IsAndroid())

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleAnimeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleAnimeView.axaml.cs
@@ -1,3 +1,4 @@
+using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -8,29 +9,46 @@ using FEBuilderGBA.Core;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ImageBattleAnimeView : TranslatedWindow, IEditorView, IDataVerifiableView
+    public partial class ImageBattleAnimeView : TranslatedUserControl, IEmbeddableEditor, IDataVerifiableView
     {
         readonly ImageBattleAnimeViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
         bool _suppressFrameEvents;
         DispatcherTimer? _animTimer;
         bool _isPlaying;
         bool _listLoaded;
 
         public string ViewTitle => "Battle Animation Editor";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("Battle Animation Editor", 900, 600, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
 
         public ImageBattleAnimeView()
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
-            Opened += (_, _) => LoadList();
-            Closed += (_, _) => StopAnimation();
 
             // Populate section combo with mode names
             for (int i = 0; i < BattleAnimeRendererCore.SectionNames.Length; i++)
                 SectionCombo.Items.Add(BattleAnimeRendererCore.SectionNames[i]);
             SectionCombo.SelectedIndex = 0;
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromVisualTree(e);
+            StopAnimation();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         void LoadList()
@@ -186,7 +204,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 string name = _vm.AnimeName.Replace("\0", "").Trim();
                 if (string.IsNullOrEmpty(name)) name = "tilesheet";
-                await TileSheetImage.ExportPng(this, $"{name}_tilesheet");
+                await TileSheetImage.ExportPng(TopLevel.GetTopLevel(this) as Window, $"{name}_tilesheet");
             }
         }
 
@@ -206,7 +224,7 @@ namespace FEBuilderGBA.Avalonia.Views
             // real local path; on Android (no local path) message instead of silently
             // importing a sibling-less temp copy. Matches the Magic FEditor import.
             string? path = await Dialogs.FileDialogHelper.OpenFile(
-                this, R._("Import Battle Animation"), new[] { "*.txt", "*.bin" },
+                TopLevel.GetTopLevel(this) as Window, R._("Import Battle Animation"), new[] { "*.txt", "*.bin" },
                 requireLocalPath: true);
             if (string.IsNullOrEmpty(path))
             {
@@ -259,7 +277,7 @@ namespace FEBuilderGBA.Avalonia.Views
             // the .txt script, so a SAF pick (no local path) can't place them.
             // SaveAnimationScriptFile returns null without a local path; on Android
             // message instead of silently exporting siblings into a temp dir.
-            string? path = await Dialogs.FileDialogHelper.SaveAnimationScriptFile(this, $"{name}.txt");
+            string? path = await Dialogs.FileDialogHelper.SaveAnimationScriptFile(TopLevel.GetTopLevel(this) as Window, $"{name}.txt");
             if (string.IsNullOrEmpty(path))
             {
                 if (OperatingSystem.IsAndroid())
@@ -515,5 +533,6 @@ namespace FEBuilderGBA.Avalonia.Views
         }
         public void SelectFirstItem() => EntryList.SelectFirst();
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleBGView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleBGView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -248,7 +248,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var img = _vm.TryLoadImage();
                 if (img == null) { CoreState.Services.ShowError("No image to export"); return; }
                 // #1639: write via the SAF bridge so Android content:// targets work.
-                await FileDialogHelper.SaveImageFileVia(TopLevel.GetTopLevel(this) as Window, $"battle_bg_{_vm.CurrentIndex:X02}.png", p => img.Save(p));
+                await FileDialogHelper.SaveImageFileVia(TopLevel.GetTopLevel(this), $"battle_bg_{_vm.CurrentIndex:X02}.png", p => img.Save(p));
             }
             catch (Exception ex) { CoreState.Services.ShowError($"Export image failed: {ex.Message}"); }
         }
@@ -276,7 +276,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // BattleBG palette is LZ77-compressed
                 byte[] pal = LZ77.decompress(rom.Data, palAddr);
                 if (pal == null || pal.Length < 32) { CoreState.Services.ShowError("Failed to read palette"); return; }
-                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this) as Window, "battle_bg_palette.pal", p =>
+                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this), "battle_bg_palette.pal", p =>
                 {
                     // #1639: write via the SAF bridge so Android content:// targets work.
                     PaletteFormat fmt = PaletteFormatConverter.FormatFromExtension(System.IO.Path.GetExtension(p));
@@ -292,7 +292,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 ROM rom = CoreState.ROM;
                 if (rom == null) return;
-                string path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this) as Window);
+                string path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this));
                 if (string.IsNullOrEmpty(path)) return;
                 byte[] fileData = File.ReadAllBytes(path);
                 PaletteFormat fmt = PaletteFormatConverter.DetectFormat(fileData, System.IO.Path.GetExtension(path));

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleScreenView.axaml.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+﻿// SPDX-License-Identifier: GPL-3.0-or-later
 // ImageBattleScreenView -- Avalonia parity rebuild for #393. Mirrors the WF
 // `ImageBattleScreenForm` 5-tab battle-screen layout editor. Uses the
 // `ImageBattleScreenCore` helper (which delegates palette I/O to PaletteCore)
@@ -631,7 +631,7 @@ namespace FEBuilderGBA.Avalonia.Views
             // needs more than one palette bank (ColorCount > BULK_MAX_COLORS) and
             // reject it cleanly -- rather than silently downgrading a multi-bank
             // image to a single bank with the wrong colors (#989).
-            string? filePath = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this) as Window);
+            string? filePath = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this));
             if (string.IsNullOrEmpty(filePath)) return;
 
             var loadResult = ImageImportService.LoadAndQuantizeFromFile(
@@ -796,7 +796,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
             // Open file dialog and load+quantize (remap to existing palette so
             // the user's image is forced to use the current battle-screen colors).
-            string? filePath = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this) as Window);
+            string? filePath = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this));
             if (string.IsNullOrEmpty(filePath)) return;
 
             var loadResult = ImageImportService.LoadAndRemapFromFile(

--- a/FEBuilderGBA.Avalonia/Views/ImageCGFE7UView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageCGFE7UView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.IO;
 using global::Avalonia.Controls;
@@ -137,7 +137,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 uint palAddr = U.toOffset(palPtr);
                 byte[] pal = LZ77.decompress(rom.Data, palAddr);
                 if (pal == null || pal.Length < 32) { CoreState.Services.ShowError("Failed to read palette"); return; }
-                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this) as Window, "cg_fe7u_palette.pal", p =>
+                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this), "cg_fe7u_palette.pal", p =>
                 {
                     // #1639: write via the SAF bridge so Android content:// targets work.
                     PaletteFormat fmt = PaletteFormatConverter.FormatFromExtension(System.IO.Path.GetExtension(p));
@@ -153,7 +153,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 ROM rom = CoreState.ROM;
                 if (rom == null) return;
-                string path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this) as Window);
+                string path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this));
                 if (string.IsNullOrEmpty(path)) return;
                 byte[] fileData = File.ReadAllBytes(path);
                 PaletteFormat fmt = PaletteFormatConverter.DetectFormat(fileData, System.IO.Path.GetExtension(path));

--- a/FEBuilderGBA.Avalonia/Views/ImageCGView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageCGView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.IO;
 using global::Avalonia.Controls;
@@ -182,7 +182,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 uint palAddr = U.toOffset(palPtr);
                 byte[] pal = LZ77.decompress(rom.Data, palAddr);
                 if (pal == null || pal.Length < 32) { CoreState.Services.ShowError("Failed to read palette"); return; }
-                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this) as Window, "cg_palette.pal", p =>
+                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this), "cg_palette.pal", p =>
                 {
                     // #1639: write via the SAF bridge so Android content:// targets work.
                     PaletteFormat fmt = PaletteFormatConverter.FormatFromExtension(System.IO.Path.GetExtension(p));
@@ -198,7 +198,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 ROM rom = CoreState.ROM;
                 if (rom == null) return;
-                string path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this) as Window);
+                string path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this));
                 if (string.IsNullOrEmpty(path)) return;
                 byte[] fileData = File.ReadAllBytes(path);
                 PaletteFormat fmt = PaletteFormatConverter.DetectFormat(fileData, System.IO.Path.GetExtension(path));

--- a/FEBuilderGBA.Avalonia/Views/ImageChapterTitleFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageChapterTitleFE7View.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.IO;
 using global::Avalonia.Controls;
@@ -104,7 +104,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (palAddr == 0 || !U.isSafetyOffset(palAddr)) { CoreState.Services.ShowError("No palette address"); return; }
                 byte[] pal = ImageUtilCore.GetPalette(palAddr, 16);
                 if (pal == null || pal.Length < 32) { CoreState.Services.ShowError("Failed to read palette"); return; }
-                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this) as Window, "chapter_title_fe7_palette.pal", p =>
+                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this), "chapter_title_fe7_palette.pal", p =>
                 {
                     // #1639: write via the SAF bridge so Android content:// targets work.
                     PaletteFormat fmt = PaletteFormatConverter.FormatFromExtension(System.IO.Path.GetExtension(p));

--- a/FEBuilderGBA.Avalonia/Views/ImageGenericEnemyPortraitView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageGenericEnemyPortraitView.axaml.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+﻿// SPDX-License-Identifier: GPL-3.0-or-later
 // ImageGenericEnemyPortraitView code-behind — Image Import/Export parity (#907).
 //
 // Adds a read-only preview render of the selected 32x32 4bpp portrait plus
@@ -134,7 +134,7 @@ namespace FEBuilderGBA.Avalonia.Views
         async void ImportButton_Click(object? sender, RoutedEventArgs e)
         {
             if (!_vm.IsLoaded) return;
-            string? filePath = await FEBuilderGBA.Avalonia.Dialogs.FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this) as Window);
+            string? filePath = await FEBuilderGBA.Avalonia.Dialogs.FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this));
             if (string.IsNullOrEmpty(filePath)) return;
             RunPortraitImport(filePath);
         }

--- a/FEBuilderGBA.Avalonia/Views/ImageMapActionAnimationView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageMapActionAnimationView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.ImageMapActionAnimationView"
-        Title="Map Action Animation" Width="1024" Height="640"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.ImageMapActionAnimationView">
   <Grid ColumnDefinitions="260,*" RowDefinitions="Auto,Auto,*">
 
     <!-- Row 0: top read-config bar — unified via EditorTopBar (#649). -->
@@ -152,4 +150,4 @@
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/ImageMapActionAnimationView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageMapActionAnimationView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.IO;
 using System.Threading.Tasks;
@@ -441,7 +441,7 @@ namespace FEBuilderGBA.Avalonia.Views
             // #1639: pick the handle so we can branch by format — the single-file
             // .gif export routes through the SAF bridge, while the .txt script
             // (which writes sibling PNGs) requires a real local path.
-            var file = await FileDialogHelper.SaveFilePick(TopLevel.GetTopLevel(this) as Window,
+            var file = await FileDialogHelper.SaveFilePick(TopLevel.GetTopLevel(this),
                 R._("Save Map Action Animation"),
                 new[]
                 {
@@ -494,7 +494,7 @@ namespace FEBuilderGBA.Avalonia.Views
             // #1639: ImportScript resolves sibling frame PNGs from the script's
             // own directory, so require a real local path; a SAF pick (no local
             // path) cannot resolve siblings → message on Android, never silent.
-            string? path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this) as Window,
+            string? path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this),
                 R._("Open Map Action Animation Script"),
                 "*.MapActionAnimation.txt", requireLocalPath: true);
             if (string.IsNullOrEmpty(path))

--- a/FEBuilderGBA.Avalonia/Views/ImageMapActionAnimationView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageMapActionAnimationView.axaml.cs
@@ -1,3 +1,4 @@
+using global::Avalonia;
 using System;
 using System.IO;
 using System.Threading.Tasks;
@@ -21,10 +22,11 @@ namespace FEBuilderGBA.Avalonia.Views
     /// (#499, #500, #501) — see the navigation manifest in
     /// `ImageMapActionAnimationViewModel.NavigationTargets.cs`.
     /// </summary>
-    public partial class ImageMapActionAnimationView : TranslatedWindow, IEditorView, IDataVerifiableView
+    public partial class ImageMapActionAnimationView : TranslatedUserControl, IEmbeddableEditor, IDataVerifiableView
     {
         readonly ImageMapActionAnimationViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
         bool _suppressZoomChange;
         // Set true while UpdateUI syncs `ShowFrameUpDown.Value` from the VM
         // — the SelectionChanged handler short-circuits so the compute+render
@@ -36,25 +38,39 @@ namespace FEBuilderGBA.Avalonia.Views
         Bitmap? _currentPreviewBitmap;
 
         public string ViewTitle => "Map Action Animation";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("Map Action Animation", 1024, 640, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         public ImageMapActionAnimationView()
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
-            Opened += (_, _) => LoadList();
             // Dispose the last preview Bitmap when the window closes so
             // unmanaged memory is released — Copilot CLI inline review on
             // PR #506.
-            Closed += (_, _) =>
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromVisualTree(e);
+            if (_currentPreviewBitmap != null)
             {
-                if (_currentPreviewBitmap != null)
-                {
-                    try { _currentPreviewBitmap.Dispose(); } catch { /* swallow */ }
-                    _currentPreviewBitmap = null;
-                }
-            };
+                try { _currentPreviewBitmap.Dispose(); } catch { /* swallow */ }
+                _currentPreviewBitmap = null;
+            }
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         void LoadList()
@@ -232,7 +248,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 uint defaultCount = _vm.ReadCount + 1;
                 if (defaultCount > 255) defaultCount = 255;
                 uint? chosen = await NumberInputDialog.Show(
-                    this,
+                    TopLevel.GetTopLevel(this) as Window,
                     R._("Enter the new entry count for the map action animation list (current: {0}, max: 255).",
                         _vm.ReadCount),
                     R._("List Expansion"),
@@ -425,7 +441,7 @@ namespace FEBuilderGBA.Avalonia.Views
             // #1639: pick the handle so we can branch by format — the single-file
             // .gif export routes through the SAF bridge, while the .txt script
             // (which writes sibling PNGs) requires a real local path.
-            var file = await FileDialogHelper.SaveFilePick(this,
+            var file = await FileDialogHelper.SaveFilePick(TopLevel.GetTopLevel(this) as Window,
                 R._("Save Map Action Animation"),
                 new[]
                 {
@@ -478,7 +494,7 @@ namespace FEBuilderGBA.Avalonia.Views
             // #1639: ImportScript resolves sibling frame PNGs from the script's
             // own directory, so require a real local path; a SAF pick (no local
             // path) cannot resolve siblings → message on Android, never silent.
-            string? path = await FileDialogHelper.OpenFile(this,
+            string? path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this) as Window,
                 R._("Open Map Action Animation Script"),
                 "*.MapActionAnimation.txt", requireLocalPath: true);
             if (string.IsNullOrEmpty(path))

--- a/FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImagePalletView.axaml.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+﻿// SPDX-License-Identifier: GPL-3.0-or-later
 // Avalonia counterpart of WinForms ImagePalletForm (#400 gap-sweep).
 // Provides a WF-equivalent JumpTo(...) entry point so callers like
 // ImagePortraitView.JumpToPalette_Click can carry the palette
@@ -760,7 +760,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (!_vm.IsLoaded) return;
                 // Pack the 16 displayed colors (incl. unsaved NUD edits).
                 byte[] gbaBytes = ComputeExportBytes();
-                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this) as Window, "palette.pal", p =>
+                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this), "palette.pal", p =>
                 {
                     // #1639: write via the SAF bridge so Android content:// targets work.
                     PaletteFormat fmt = PaletteFormatConverter.FormatFromExtension(Path.GetExtension(p));
@@ -784,7 +784,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // checks it. The IsLoaded gate alone refuses imports when
                 // no entry has been opened.
                 if (!_vm.IsLoaded) return;
-                string? path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this) as Window);
+                string? path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this));
                 if (string.IsNullOrEmpty(path)) return; // cancel = no change
                 byte[] fileData = File.ReadAllBytes(path);
                 PaletteFormat fmt = PaletteFormatConverter.DetectFormat(fileData, Path.GetExtension(path));

--- a/FEBuilderGBA.Avalonia/Views/ImagePortraitFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImagePortraitFE6View.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.IO;
 using global::Avalonia.Controls;
@@ -334,7 +334,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
         async void ImportPng_Click(object? sender, RoutedEventArgs e)
         {
-            string? filePath = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this) as Window);
+            string? filePath = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this));
             if (string.IsNullOrEmpty(filePath)) return;
             ImportImageFromFile(filePath);
         }
@@ -419,7 +419,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // FE6 portrait palette is raw (not compressed), 16 colors = 32 bytes
                 byte[] pal = ImageUtilCore.GetPalette(palAddr, 16);
                 if (pal == null || pal.Length < 32) { CoreState.Services.ShowError("Failed to read palette"); return; }
-                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this) as Window, "portrait_fe6_palette.pal", p =>
+                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this), "portrait_fe6_palette.pal", p =>
                 {
                     // #1639: write via the SAF bridge so Android content:// targets work.
                     PaletteFormat fmt = PaletteFormatConverter.FormatFromExtension(System.IO.Path.GetExtension(p));
@@ -435,7 +435,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 ROM rom = CoreState.ROM;
                 if (rom == null) return;
-                string? path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this) as Window);
+                string? path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this));
                 if (string.IsNullOrEmpty(path)) return;
                 byte[] fileData = File.ReadAllBytes(path);
                 PaletteFormat fmt = PaletteFormatConverter.DetectFormat(fileData, System.IO.Path.GetExtension(path));

--- a/FEBuilderGBA.Avalonia/Views/ImagePortraitView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImagePortraitView.axaml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using global::Avalonia;
 using global::Avalonia.Controls;
@@ -466,7 +466,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 }
 
                 // #1639: write via the SAF bridge so Android content:// targets work.
-                await FileDialogHelper.SaveImageFileVia(TopLevel.GetTopLevel(this) as Window, "portrait_sheet.png", p =>
+                await FileDialogHelper.SaveImageFileVia(TopLevel.GetTopLevel(this), "portrait_sheet.png", p =>
                 {
                     using var stream = File.Create(p);
                     wb.Save(stream);
@@ -490,7 +490,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 uint palAddr = U.toOffset(palPtr);
                 byte[] pal = ImageUtilCore.GetPalette(palAddr, 16);
                 if (pal == null || pal.Length < 32) { CoreState.Services.ShowError("Failed to read palette"); return; }
-                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this) as Window, "portrait_palette.pal", p =>
+                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this), "portrait_palette.pal", p =>
                 {
                     // #1639: write via the SAF bridge so Android content:// targets work.
                     PaletteFormat fmt = PaletteFormatConverter.FormatFromExtension(System.IO.Path.GetExtension(p));
@@ -506,7 +506,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 ROM rom = CoreState.ROM;
                 if (rom == null) return;
-                string? path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this) as Window);
+                string? path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this));
                 if (string.IsNullOrEmpty(path)) return;
                 byte[] fileData = File.ReadAllBytes(path);
                 PaletteFormat fmt = PaletteFormatConverter.DetectFormat(fileData, System.IO.Path.GetExtension(path));

--- a/FEBuilderGBA.Avalonia/Views/ImageRomAnimeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageRomAnimeView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -134,7 +134,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     return;
                 }
 
-                string? path = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this) as Window);
+                string? path = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this));
                 if (string.IsNullOrEmpty(path)) return;
 
                 int width = _vm.FrameWidthPx;
@@ -195,7 +195,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // returns null on Android SAF (no local path) → disable with a
                 // clear message instead of silently returning. (Use Export GIF for
                 // a single-file animation export on Android.)
-                string? path = await FileDialogHelper.SaveAnimationScriptFile(TopLevel.GetTopLevel(this) as Window,
+                string? path = await FileDialogHelper.SaveAnimationScriptFile(TopLevel.GetTopLevel(this),
                     "romanime_" + U.ToHexString(_vm.CurrentId) + ".txt");
                 if (string.IsNullOrEmpty(path))
                 {
@@ -226,7 +226,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 }
                 // #1639: single-file GIF export → SAF bridge.
                 string err = "";
-                string? written = await FileDialogHelper.SaveFileVia(TopLevel.GetTopLevel(this) as Window,
+                string? written = await FileDialogHelper.SaveFileVia(TopLevel.GetTopLevel(this),
                     R._("Save Animation GIF"), R._("Animated GIF (.gif)"), "*.gif",
                     "romanime_" + U.ToHexString(_vm.CurrentId) + ".gif",
                     p => { err = _vm.ExportGif(p); });
@@ -253,7 +253,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // #1639: ImportScript resolves sibling frame PNGs from the
                 // script's own directory, so require a real local path; a SAF pick
                 // (no local path) cannot resolve siblings → message on Android.
-                string? path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this) as Window,
+                string? path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this),
                     R._("Open Animation Script"), "*.txt", requireLocalPath: true);
                 if (string.IsNullOrEmpty(path))
                 {

--- a/FEBuilderGBA.Avalonia/Views/ImageTSAAnimeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageTSAAnimeView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.IO;
 using global::Avalonia.Controls;
@@ -130,7 +130,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // near the ROM end) rather than exporting a partial 8-bank palette.
                 byte[] pal = rom.getBinaryData(palAddr, PALETTE_BYTES);
                 if (pal == null || pal.Length < PALETTE_BYTES) { CoreState.Services.ShowError("Failed to read palette (expected 256 bytes)"); return; }
-                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this) as Window, "tsa_anime_palette.pal", p =>
+                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this), "tsa_anime_palette.pal", p =>
                 {
                     // #1639: write via the SAF bridge so Android content:// targets work.
                     PaletteFormat fmt = PaletteFormatConverter.FormatFromExtension(System.IO.Path.GetExtension(p));
@@ -146,7 +146,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 ROM rom = CoreState.ROM;
                 if (rom == null) return;
-                string path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this) as Window);
+                string path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this));
                 if (string.IsNullOrEmpty(path)) return;
                 byte[] fileData = File.ReadAllBytes(path);
                 PaletteFormat fmt = PaletteFormatConverter.DetectFormat(fileData, System.IO.Path.GetExtension(path));

--- a/FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageTSAEditorView.axaml.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+﻿// SPDX-License-Identifier: GPL-3.0-or-later
 // ImageTSAEditorView code-behind — Avalonia parity raise (gap-sweep #398).
 //
 // The view exposes the WinForms Init(...) entry point so future callers
@@ -709,7 +709,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 return;
             }
 
-            string? filePath = await FEBuilderGBA.Avalonia.Dialogs.FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this) as Window);
+            string? filePath = await FEBuilderGBA.Avalonia.Dialogs.FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this));
             if (string.IsNullOrEmpty(filePath)) return;
 
             var loadResult = ImageImportService.LoadAndRemapFromFile(

--- a/FEBuilderGBA.Avalonia/Views/ImageUnitMoveIconView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageUnitMoveIconView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.IO;
 using global::Avalonia.Controls;
@@ -344,7 +344,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 string suggested = $"move_icon_{_vm.CurrentIndex:X02}.png";
                 // #1639: both .png and .gif are single-file → SAF bridge.
                 bool ok = false;
-                string? written = await FileDialogHelper.SaveFileVia(TopLevel.GetTopLevel(this) as Window, "Export Move Icon",
+                string? written = await FileDialogHelper.SaveFileVia(TopLevel.GetTopLevel(this), "Export Move Icon",
                     new[]
                     {
                         ("PNG Image", "*.png"),
@@ -370,7 +370,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (rom == null) return;
                 if (_vm.CurrentAddr == 0) { CoreState.Services?.ShowError(R._("No move icon selected.")); return; }
 
-                string? path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this) as Window, "Import AP", "*.romtcs.ap.bin");
+                string? path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this), "Import AP", "*.romtcs.ap.bin");
                 if (string.IsNullOrEmpty(path)) return;
 
                 byte[] apBytes;
@@ -425,7 +425,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
                 string suggested = $"move_icon_{_vm.CurrentIndex:X02}.romtcs.ap.bin";
                 // #1639: single-file AP export → SAF bridge.
-                string? written = await FileDialogHelper.SaveFileVia(TopLevel.GetTopLevel(this) as Window, "Export AP",
+                string? written = await FileDialogHelper.SaveFileVia(TopLevel.GetTopLevel(this), "Export AP",
                     "AP", "*.romtcs.ap.bin", suggested, p => File.WriteAllBytes(p, ap));
                 if (written == null) return;
                 CoreState.Services?.ShowInfo($"Exported to: {written}");

--- a/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -555,7 +555,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     return;
                 }
 
-                string? path = await Dialogs.FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this) as Window);
+                string? path = await Dialogs.FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this));
                 if (string.IsNullOrEmpty(path)) return; // user cancelled
 
                 ImportFromFile(path);

--- a/FEBuilderGBA.Avalonia/Views/ImageUnitWaitIconView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageUnitWaitIconView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -245,7 +245,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 string suggested = $"wait_icon_{_vm.CurrentIndex:X02}.png";
                 // #1639: both .png and .gif are single-file → SAF bridge.
                 bool ok = false;
-                string? written = await FileDialogHelper.SaveFileVia(TopLevel.GetTopLevel(this) as Window, "Export Wait Icon",
+                string? written = await FileDialogHelper.SaveFileVia(TopLevel.GetTopLevel(this), "Export Wait Icon",
                     new[]
                     {
                         ("PNG Image", "*.png"),

--- a/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.ItemEditorView"
-        Title="Item Editor" Width="1408" Height="856"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.ItemEditorView">
   <Grid ColumnDefinitions="250,*">
     <!-- Address List with icon preview -->
     <Grid Grid.Column="0" RowDefinitions="*,Auto">
@@ -364,4 +362,4 @@
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml.cs
@@ -1,3 +1,4 @@
+using global::Avalonia;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,15 +11,18 @@ using FEBuilderGBA.Core;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ItemEditorView : TranslatedWindow, IPickableEditor, IDataVerifiableView
+    public partial class ItemEditorView : TranslatedUserControl, IEmbeddableEditor, IPickableEditor, IDataVerifiableView
     {
         readonly ItemEditorViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
 
         List<(uint id, string name)> _weaponTypeList = new();
 
         public string ViewTitle => R._("Item Editor");
-        public bool IsLoaded => _vm.CanWrite;
+        public new bool IsLoaded => _vm.CanWrite;
+        public EditorDescriptor Descriptor => new("Item Editor", 1408, 856, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
 
         public event Action<PickResult>? SelectionConfirmed;
 
@@ -27,7 +31,6 @@ namespace FEBuilderGBA.Avalonia.Views
             InitializeComponent();
             ItemList.SelectedAddressChanged += OnItemSelected;
             ItemList.SelectionConfirmed += result => SelectionConfirmed?.Invoke(result);
-            Opened += (_, _) => LoadList();
 
             // Set trait flag names
             Trait1Flags.SetBitNames(AbilityFlagNames.ItemTrait1);
@@ -42,7 +45,22 @@ namespace FEBuilderGBA.Avalonia.Views
             // would otherwise reset Unk33Label.Text back to the original
             // "Unk33 (B33):" literal (Copilot bot review on PR #569).
             CoreState.LanguageChanged += UpdateWeaponDebuffsLink;
-            Closed += (_, _) => CoreState.LanguageChanged -= UpdateWeaponDebuffsLink;
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromVisualTree(e);
+            CoreState.LanguageChanged -= UpdateWeaponDebuffsLink;
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         void LoadList()
@@ -656,6 +674,7 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         static uint ParseHexText(string? text)
         {
@@ -700,12 +719,12 @@ namespace FEBuilderGBA.Avalonia.Views
 
         async void ExportTSV_Click(object? sender, RoutedEventArgs e)
         {
-            await TableExportImportHelper.ExportTableAsync(this, "items");
+            await TableExportImportHelper.ExportTableAsync(TopLevel.GetTopLevel(this) as Window, "items");
         }
 
         async void ImportTSV_Click(object? sender, RoutedEventArgs e)
         {
-            await TableExportImportHelper.ImportTableAsync(this, "items", _undoService, () =>
+            await TableExportImportHelper.ImportTableAsync(TopLevel.GetTopLevel(this) as Window, "items", _undoService, () =>
             {
                 // Reload the current entry after import
                 if (_vm.CurrentAddr != 0)

--- a/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -44,7 +44,6 @@ namespace FEBuilderGBA.Avalonia.Views
             // changes — TranslatedWindow's helper re-scans the AXAML, which
             // would otherwise reset Unk33Label.Text back to the original
             // "Unk33 (B33):" literal (Copilot bot review on PR #569).
-            CoreState.LanguageChanged += UpdateWeaponDebuffsLink;
         }
 
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
@@ -56,6 +55,8 @@ namespace FEBuilderGBA.Avalonia.Views
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {
             base.OnAttachedToVisualTree(e);
+            CoreState.LanguageChanged -= UpdateWeaponDebuffsLink;
+            CoreState.LanguageChanged += UpdateWeaponDebuffsLink;
             if (!_hasLoadedList)
             {
                 _hasLoadedList = true;

--- a/FEBuilderGBA.Avalonia/Views/ItemFE6View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ItemFE6View.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.ItemFE6View"
-        Title="Item Editor (FE6)" Width="1408" Height="856"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.ItemFE6View">
   <Grid ColumnDefinitions="250,*">
     <!-- Address List with icon preview -->
     <Grid Grid.Column="0" RowDefinitions="Auto,*,Auto,Auto">
@@ -342,4 +340,4 @@
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/ItemFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemFE6View.axaml.cs
@@ -1,3 +1,4 @@
+using global::Avalonia;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,15 +12,18 @@ using FEBuilderGBA.Core;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ItemFE6View : TranslatedWindow, IPickableEditor, IDataVerifiableView
+    public partial class ItemFE6View : TranslatedUserControl, IEmbeddableEditor, IPickableEditor, IDataVerifiableView
     {
         readonly ItemFE6ViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
 
         List<(uint id, string name)> _weaponTypeList = new();
 
         public string ViewTitle => "Items (FE6)";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("Item Editor (FE6)", 1408, 856, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
 
         public event Action<PickResult>? SelectionConfirmed;
 
@@ -28,7 +32,6 @@ namespace FEBuilderGBA.Avalonia.Views
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
             EntryList.SelectionConfirmed += result => SelectionConfirmed?.Invoke(result);
-            Opened += (_, _) => LoadList();
 
             // Set trait flag names (FE6 shares the same trait1/trait2 bit
             // semantics as FE7/FE8 - mirrors PR #569 wiring).
@@ -44,6 +47,16 @@ namespace FEBuilderGBA.Avalonia.Views
             // editable but inert). Mirrors WF `LabelFilter` text field.
             // #649: filter is now an inline slot on the EditorTopBar; the
             // routed FilterTextChanged event handler is wired in AXAML.
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         void LoadList()
@@ -567,6 +580,7 @@ namespace FEBuilderGBA.Avalonia.Views
         public void EnablePickMode() => EntryList.EnablePickMode();
         public void SelectFirstItem() => EntryList.SelectFirst();
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         static uint ParseHexText(string? text)
         {

--- a/FEBuilderGBA.Avalonia/Views/ItemIconViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemIconViewerView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.IO;
 using global::Avalonia.Controls;
@@ -89,7 +89,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 byte[] pal = _vm.CachedPalette;
                 if (pal == null || pal.Length < 32) { CoreState.Services.ShowError("No palette loaded"); return; }
-                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this) as Window, "item_icon_palette.pal", p =>
+                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this), "item_icon_palette.pal", p =>
                 {
                     // #1639: write via the SAF bridge so Android content:// targets work.
                     PaletteFormat fmt = PaletteFormatConverter.FormatFromExtension(System.IO.Path.GetExtension(p));

--- a/FEBuilderGBA.Avalonia/Views/LogViewerView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/LogViewerView.axaml
@@ -1,10 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:vm="clr-namespace:FEBuilderGBA.Avalonia.ViewModels"
-        x:Class="FEBuilderGBA.Avalonia.Views.LogViewerView"
-        x:DataType="vm:LogViewerViewModel"
-        Title="Log Viewer" Width="800" Height="560"
-        SizeToContent="Manual">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:FEBuilderGBA.Avalonia.ViewModels"
+             x:Class="FEBuilderGBA.Avalonia.Views.LogViewerView">
   <DockPanel Margin="8" LastChildFill="True">
 
     <TextBlock DockPanel.Dock="Top" Text="Log Viewer" FontSize="18" FontWeight="Bold" Margin="0,0,0,4" />
@@ -45,4 +42,4 @@
       </Border>
     </ScrollViewer>
   </DockPanel>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/LogViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/LogViewerView.axaml.cs
@@ -1,3 +1,4 @@
+using global::Avalonia;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -18,14 +19,18 @@ namespace FEBuilderGBA.Avalonia.Views
     /// Save / Copy-to-clipboard / Open-log-folder / Refresh button row.
     /// Read-only — no ROM writes, no undo.
     /// </summary>
-    public partial class LogViewerView : TranslatedWindow, IEditorView
+    public partial class LogViewerView : TranslatedUserControl, IEmbeddableEditor
     {
         readonly LogViewerViewModel _vm = new();
+        bool _hasLoadedList;
         EventHandler? _logUpdateHandler;
         bool _reloadPending;
 
         public string ViewTitle => "Log Viewer";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("Log Viewer", 800, 560);
+        public event EventHandler? CloseRequested;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         /// <summary>Test/diagnostic accessor for the bound view-model.</summary>
         public ViewModelBase DataViewModel => _vm;
@@ -40,8 +45,22 @@ namespace FEBuilderGBA.Avalonia.Views
             CopyButton.Click += OnCopy;
             OpenDirButton.Click += OnOpenDir;
 
-            Opened += OnOpened;
-            Closed += OnClosed;
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromVisualTree(e);
+            OnClosed(this, EventArgs.Empty);
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                OnOpened(this, EventArgs.Empty);
+            }
         }
 
         void OnOpened(object? sender, EventArgs e)
@@ -113,7 +132,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 // #1639: single-file log save → SAF bridge.
                 string? written = await FileDialogHelper.SaveFileVia(
-                    this, R._("Save"), R._("TEXT"), "*.txt", "log.txt", p => _vm.SaveToFile(p));
+                    TopLevel.GetTopLevel(this) as Window, R._("Save"), R._("TEXT"), "*.txt", "log.txt", p => _vm.SaveToFile(p));
                 if (written == null) return;
                 StatusLabel.Text = R._("Saved to {0}", written);
             }

--- a/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -2097,10 +2097,10 @@ namespace FEBuilderGBA.Avalonia.Views
             return new List<(string, Func<Window>)>
             {
                 // Data Editors
-                ("UnitEditorView", () => wm.Open<UnitEditorView>()),
-                ("ItemEditorView", () => wm.Open<ItemEditorView>()),
-                ("ClassEditorView", () => wm.Open<ClassEditorView>()),
-                ("ClassFE6View", () => wm.Open<ClassFE6View>()),
+                ("UnitEditorView", () => wm.OpenAsTopLevel<UnitEditorView>()),
+                ("ItemEditorView", () => wm.OpenAsTopLevel<ItemEditorView>()),
+                ("ClassEditorView", () => wm.OpenAsTopLevel<ClassEditorView>()),
+                ("ClassFE6View", () => wm.OpenAsTopLevel<ClassFE6View>()),
                 ("CCBranchEditorView", () => wm.OpenAsTopLevel<CCBranchEditorView>()),
                 ("MoveCostEditorView", () => wm.OpenAsTopLevel<MoveCostEditorView>()),
                 ("TerrainNameEditorView", () => wm.OpenAsTopLevel<TerrainNameEditorView>()),
@@ -2110,7 +2110,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 ("UnitFE6View", () => wm.OpenAsTopLevel<UnitFE6View>()),
                 ("UnitActionPointerView", () => wm.OpenAsTopLevel<UnitActionPointerView>()),
                 ("UnitCustomBattleAnimeView", () => wm.OpenAsTopLevel<UnitCustomBattleAnimeView>()),
-                ("UnitIncreaseHeightView", () => wm.Open<UnitIncreaseHeightView>()),
+                ("UnitIncreaseHeightView", () => wm.OpenAsTopLevel<UnitIncreaseHeightView>()),
                 ("UnitPaletteView", () => wm.OpenAsTopLevel<UnitPaletteView>()),
                 ("ClassOPDemoView", () => wm.OpenAsTopLevel<ClassOPDemoView>()),
                 ("ClassOPFontView", () => wm.OpenAsTopLevel<ClassOPFontView>()),
@@ -2192,12 +2192,12 @@ namespace FEBuilderGBA.Avalonia.Views
 
                 // Image Editors
                 ("ImageViewerView", () => wm.Open<ImageViewerView>()),
-                ("PortraitViewerView", () => wm.Open<PortraitViewerView>()),
+                ("PortraitViewerView", () => wm.OpenAsTopLevel<PortraitViewerView>()),
                 ("ImagePortraitView", () => wm.OpenAsTopLevel<ImagePortraitView>()),
                 ("ImagePortraitFE6View", () => wm.OpenAsTopLevel<ImagePortraitFE6View>()),
                 ("ImagePortraitImporterView", () => wm.Open<ImagePortraitImporterView>()),
                 ("ImageBGView", () => wm.OpenAsTopLevel<ImageBGView>()),
-                ("ImageBattleAnimeView", () => wm.Open<ImageBattleAnimeView>()),
+                ("ImageBattleAnimeView", () => wm.OpenAsTopLevel<ImageBattleAnimeView>()),
                 ("ImageBattleAnimePalletView", () => wm.OpenAsTopLevel<ImageBattleAnimePalletView>()),
                 ("ImageBattleBGView", () => wm.OpenAsTopLevel<ImageBattleBGView>()),
                 ("ImageBattleScreenView", () => wm.OpenAsTopLevel<ImageBattleScreenView>()),
@@ -2215,9 +2215,9 @@ namespace FEBuilderGBA.Avalonia.Views
                 ("ImagePalletView", () => wm.OpenAsTopLevel<ImagePalletView>()),
                 ("ImageMagicFEditorView", () => wm.OpenAsTopLevel<ImageMagicFEditorView>()),
                 ("ImageMagicCSACreatorView", () => wm.OpenAsTopLevel<ImageMagicCSACreatorView>()),
-                ("ImageMapActionAnimationView", () => wm.Open<ImageMapActionAnimationView>()),
+                ("ImageMapActionAnimationView", () => wm.OpenAsTopLevel<ImageMapActionAnimationView>()),
                 ("DecreaseColorTSAToolView", () => wm.OpenAsTopLevel<DecreaseColorTSAToolView>()),
-                ("SystemIconViewerView", () => wm.Open<SystemIconViewerView>()),
+                ("SystemIconViewerView", () => wm.OpenAsTopLevel<SystemIconViewerView>()),
                 ("SystemHoverColorViewerView", () => wm.OpenAsTopLevel<SystemHoverColorViewerView>()),
                 ("BattleBGViewerView", () => wm.OpenAsTopLevel<BattleBGViewerView>()),
                 ("BattleTerrainViewerView", () => wm.OpenAsTopLevel<BattleTerrainViewerView>()),
@@ -2229,12 +2229,12 @@ namespace FEBuilderGBA.Avalonia.Views
                 ("OPPrologueViewerView", () => wm.OpenAsTopLevel<OPPrologueViewerView>()),
 
                 // Audio Editors
-                ("SongTableView", () => wm.Open<SongTableView>()),
-                ("SongTrackView", () => wm.Open<SongTrackView>()),
+                ("SongTableView", () => wm.OpenAsTopLevel<SongTableView>()),
+                ("SongTrackView", () => wm.OpenAsTopLevel<SongTrackView>()),
                 ("SongInstrumentView", () => wm.OpenAsTopLevel<SongInstrumentView>()),
                 ("SongInstrumentDirectSoundView", () => wm.OpenAsTopLevel<SongInstrumentDirectSoundView>()),
                 ("SongInstrumentImportWaveView", () => wm.Open<SongInstrumentImportWaveView>()),
-                ("SongTrackImportMidiView", () => wm.Open<SongTrackImportMidiView>()),
+                ("SongTrackImportMidiView", () => wm.OpenAsTopLevel<SongTrackImportMidiView>()),
                 ("SongExchangeView", () => wm.Open<SongExchangeView>()),
                 ("SoundBossBGMViewerView", () => wm.OpenAsTopLevel<SoundBossBGMViewerView>()),
                 ("SoundFootStepsViewerView", () => wm.OpenAsTopLevel<SoundFootStepsViewerView>()),
@@ -2262,14 +2262,14 @@ namespace FEBuilderGBA.Avalonia.Views
                 ("WorldMapEventPointerView", () => wm.OpenAsTopLevel<WorldMapEventPointerView>()),
                 ("WorldMapPathView", () => wm.OpenAsTopLevel<WorldMapPathView>()),
                 ("WorldMapPathEditorView", () => wm.OpenAsTopLevel<WorldMapPathEditorView>()),
-                ("WorldMapImageView", () => wm.Open<WorldMapImageView>()),
-                ("WorldMapImageFE6View", () => wm.Open<WorldMapImageFE6View>()),
-                ("WorldMapImageFE7View", () => wm.Open<WorldMapImageFE7View>()),
+                ("WorldMapImageView", () => wm.OpenAsTopLevel<WorldMapImageView>()),
+                ("WorldMapImageFE6View", () => wm.OpenAsTopLevel<WorldMapImageFE6View>()),
+                ("WorldMapImageFE7View", () => wm.OpenAsTopLevel<WorldMapImageFE7View>()),
                 ("WorldMapEventPointerFE6View", () => wm.OpenAsTopLevel<WorldMapEventPointerFE6View>()),
                 ("WorldMapEventPointerFE7View", () => wm.OpenAsTopLevel<WorldMapEventPointerFE7View>()),
 
                 // Text / Translation Editors
-                ("TextViewerView", () => wm.Open<TextViewerView>()),
+                ("TextViewerView", () => wm.OpenAsTopLevel<TextViewerView>()),
                 ("TextMainView", () => wm.OpenAsTopLevel<TextMainView>()),
                 ("OtherTextView", () => wm.OpenAsTopLevel<OtherTextView>()),
                 ("CStringView", () => wm.OpenAsTopLevel<CStringView>()),
@@ -2281,7 +2281,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
                 // Structural Data
                 ("Command85PointerView", () => wm.OpenAsTopLevel<Command85PointerView>()),
-                ("FE8SpellMenuExtendsView", () => wm.Open<FE8SpellMenuExtendsView>()),
+                ("FE8SpellMenuExtendsView", () => wm.OpenAsTopLevel<FE8SpellMenuExtendsView>()),
                 ("StatusOptionView", () => wm.OpenAsTopLevel<StatusOptionView>()),
                 ("OAMSPView", () => wm.Open<OAMSPView>()),
                 ("DumpStructSelectDialogView", () => wm.OpenAsTopLevel<DumpStructSelectDialogView>()),
@@ -2289,16 +2289,16 @@ namespace FEBuilderGBA.Avalonia.Views
                 // Patch / Skill Systems
                 ("PatchManagerView", () => wm.Open<PatchManagerView>()),
                 ("ToolCustomBuildView", () => wm.Open<ToolCustomBuildView>()),
-                ("SkillAssignmentUnitSkillSystemView", () => wm.Open<SkillAssignmentUnitSkillSystemView>()),
-                ("SkillAssignmentClassSkillSystemView", () => wm.Open<SkillAssignmentClassSkillSystemView>()),
-                ("SkillConfigSkillSystemView", () => wm.Open<SkillConfigSkillSystemView>()),
+                ("SkillAssignmentUnitSkillSystemView", () => wm.OpenAsTopLevel<SkillAssignmentUnitSkillSystemView>()),
+                ("SkillAssignmentClassSkillSystemView", () => wm.OpenAsTopLevel<SkillAssignmentClassSkillSystemView>()),
+                ("SkillConfigSkillSystemView", () => wm.OpenAsTopLevel<SkillConfigSkillSystemView>()),
 
                 // Tools
                 ("ToolUndoView", () => wm.Open<ToolUndoView>()),
                 ("ToolFELintView", () => wm.OpenAsTopLevel<ToolFELintView>()),
                 ("ToolROMRebuildView", () => wm.OpenAsTopLevel<ToolROMRebuildView>()),
-                ("ToolLZ77View", () => wm.Open<ToolLZ77View>()),
-                ("ToolDiffView", () => wm.Open<ToolDiffView>()),
+                ("ToolLZ77View", () => wm.OpenAsTopLevel<ToolLZ77View>()),
+                ("ToolDiffView", () => wm.OpenAsTopLevel<ToolDiffView>()),
                 ("ToolUPSPatchSimpleView", () => wm.OpenAsTopLevel<ToolUPSPatchSimpleView>()),
                 ("ToolUPSOpenSimpleView", () => wm.OpenAsTopLevel<ToolUPSOpenSimpleView>()),
                 ("ToolFlagNameView", () => wm.OpenAsTopLevel<ToolFlagNameView>()),
@@ -2307,7 +2307,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 ("ToolASMInsertView", () => wm.Open<ToolASMInsertView>()),
                 ("HexEditorView", () => wm.OpenAsTopLevel<HexEditorView>()),
                 ("DisASMView", () => wm.OpenAsTopLevel<DisASMView>()),
-                ("LogViewerView", () => wm.Open<LogViewerView>()),
+                ("LogViewerView", () => wm.OpenAsTopLevel<LogViewerView>()),
                 ("GrowSimulatorView", () => wm.OpenAsTopLevel<GrowSimulatorView>()),
                 ("OptionsView", () => wm.Open<OptionsView>()),
 
@@ -2320,13 +2320,13 @@ namespace FEBuilderGBA.Avalonia.Views
                 ("StatusOptionOrderView", () => wm.OpenAsTopLevel<StatusOptionOrderView>()),
 
                 // Skill System Editors (WU3)
-                ("SkillAssignmentUnitCSkillSysView", () => wm.Open<SkillAssignmentUnitCSkillSysView>()),
-                ("SkillAssignmentClassCSkillSysView", () => wm.Open<SkillAssignmentClassCSkillSysView>()),
+                ("SkillAssignmentUnitCSkillSysView", () => wm.OpenAsTopLevel<SkillAssignmentUnitCSkillSysView>()),
+                ("SkillAssignmentClassCSkillSysView", () => wm.OpenAsTopLevel<SkillAssignmentClassCSkillSysView>()),
                 ("SkillAssignmentUnitFE8NView", () => wm.Open<SkillAssignmentUnitFE8NView>()),
-                ("SkillConfigFE8NSkillView", () => wm.Open<SkillConfigFE8NSkillView>()),
-                ("SkillConfigFE8NVer2SkillView", () => wm.Open<SkillConfigFE8NVer2SkillView>()),
-                ("SkillConfigFE8NVer3SkillView", () => wm.Open<SkillConfigFE8NVer3SkillView>()),
-                ("SkillConfigFE8UCSkillSys09xView", () => wm.Open<SkillConfigFE8UCSkillSys09xView>()),
+                ("SkillConfigFE8NSkillView", () => wm.OpenAsTopLevel<SkillConfigFE8NSkillView>()),
+                ("SkillConfigFE8NVer2SkillView", () => wm.OpenAsTopLevel<SkillConfigFE8NVer2SkillView>()),
+                ("SkillConfigFE8NVer3SkillView", () => wm.OpenAsTopLevel<SkillConfigFE8NVer3SkillView>()),
+                ("SkillConfigFE8UCSkillSys09xView", () => wm.OpenAsTopLevel<SkillConfigFE8UCSkillSys09xView>()),
 
                 // Song/Audio Dialogs (WU4)
                 ("ToolBGMMuteDialogView", () => wm.OpenAsTopLevel<ToolBGMMuteDialogView>()),
@@ -2367,7 +2367,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 ("HexEditorJumpView", () => wm.Open<HexEditorJumpView>()),
                 ("HexEditorMarkView", () => wm.Open<HexEditorMarkView>()),
                 ("HexEditorSearchView", () => wm.Open<HexEditorSearchView>()),
-                ("PointerToolView", () => wm.Open<PointerToolView>()),
+                ("PointerToolView", () => wm.OpenAsTopLevel<PointerToolView>()),
                 ("PointerToolBatchInputView", () => wm.Open<PointerToolBatchInputView>()),
                 ("PointerToolCopyToView", () => wm.Open<PointerToolCopyToView>()),
                 ("PackedMemorySlotView", () => wm.Open<PackedMemorySlotView>()),
@@ -2378,7 +2378,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 ("ToolAnimationCreatorView", () => wm.Open<ToolAnimationCreatorView>()),
                 ("ToolThreeMargeView", () => wm.OpenAsTopLevel<ToolThreeMargeView>()),
                 ("ToolASMEditView", () => wm.OpenAsTopLevel<ToolASMEditView>()),
-                ("ToolExportEAEventView", () => wm.Open<ToolExportEAEventView>()),
+                ("ToolExportEAEventView", () => wm.OpenAsTopLevel<ToolExportEAEventView>()),
                 ("ToolDecompileResultView", () => wm.OpenAsTopLevel<ToolDecompileResultView>()),
                 ("ToolChangeProjectnameView", () => wm.Open<ToolChangeProjectnameView>()),
                 ("ToolAutomaticRecoveryROMHeaderView", () => wm.OpenAsTopLevel<ToolAutomaticRecoveryROMHeaderView>()),
@@ -2401,7 +2401,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 ("PatchFormUninstallDialogView", () => wm.Open<PatchFormUninstallDialogView>()),
 
                 // Version-Specific / Specialized Forms (WU11)
-                ("ItemFE6View", () => wm.Open<ItemFE6View>()),
+                ("ItemFE6View", () => wm.OpenAsTopLevel<ItemFE6View>()),
                 ("MoveCostFE6View", () => wm.OpenAsTopLevel<MoveCostFE6View>()),
                 ("SupportUnitFE6View", () => wm.OpenAsTopLevel<SupportUnitFE6View>()),
                 ("SupportTalkFE6View", () => wm.OpenAsTopLevel<SupportTalkFE6View>()),
@@ -2435,7 +2435,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // === Audio Sub-Forms (WU16) ===
                 ("SongTrackChangeTrackView", () => wm.OpenAsTopLevel<SongTrackChangeTrackView>()),
                 ("SongTrackAllChangeTrackView", () => wm.OpenAsTopLevel<SongTrackAllChangeTrackView>()),
-                ("SongTrackImportSelectInstrumentView", () => wm.Open<SongTrackImportSelectInstrumentView>()),
+                ("SongTrackImportSelectInstrumentView", () => wm.OpenAsTopLevel<SongTrackImportSelectInstrumentView>()),
 
                 // === ED/Credits + Item Variants (WU17) ===
                 ("EDFE6View", () => wm.OpenAsTopLevel<EDFE6View>()),
@@ -2457,7 +2457,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 ("ToolUpdateDialogView", () => wm.OpenAsTopLevel<ToolUpdateDialogView>()),
 
                 // === Previously Unregistered On-Disk Views (WU19) ===
-                ("ToolAllWorkSupportView", () => wm.Open<ToolAllWorkSupportView>()),
+                ("ToolAllWorkSupportView", () => wm.OpenAsTopLevel<ToolAllWorkSupportView>()),
                 ("ToolProblemReportView", () => wm.Open<ToolProblemReportView>()),
                 ("WorldMapPathMoveEditorView", () => wm.OpenAsTopLevel<WorldMapPathMoveEditorView>()),
                 ("MantAnimationView", () => wm.OpenAsTopLevel<MantAnimationView>()),

--- a/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapStyleEditorView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -846,7 +846,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 byte[] gbaBytes = PackPaletteToBytes();
                 // #1639: write via the SAF bridge so Android content:// targets work.
-                string? written = await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this) as Window, "map_style_palette.pal", p =>
+                string? written = await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this), "map_style_palette.pal", p =>
                 {
                     PaletteFormat fmt = PaletteFormatConverter.FormatFromExtension(System.IO.Path.GetExtension(p));
                     byte[] output = PaletteFormatConverter.ExportToFormat(gbaBytes, fmt);
@@ -870,7 +870,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
             try
             {
-                string? path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this) as Window);
+                string? path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this));
                 if (string.IsNullOrEmpty(path)) return;
 
                 byte[] fileData = File.ReadAllBytes(path);
@@ -982,7 +982,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     return;
                 }
                 // #1639: write via the SAF bridge so Android content:// targets work.
-                string? written = await FileDialogHelper.SaveImageFileVia(TopLevel.GetTopLevel(this) as Window, $"map_style_obj_{_vm.ConfigNo}.png", p =>
+                string? written = await FileDialogHelper.SaveImageFileVia(TopLevel.GetTopLevel(this), $"map_style_obj_{_vm.ConfigNo}.png", p =>
                 {
                     using var stream = File.Create(p);
                     bitmap.Save(stream);
@@ -1220,7 +1220,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     return;
                 }
 
-                string? path = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this) as Window);
+                string? path = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this));
                 if (string.IsNullOrEmpty(path)) return;
 
                 // Decode the source image through the shared SkiaSharp

--- a/FEBuilderGBA.Avalonia/Views/MapTileAnimation1View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MapTileAnimation1View.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -257,7 +257,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     return;
                 }
                 // #1639: write via the SAF bridge so Android content:// targets work.
-                string? written = await FileDialogHelper.SaveImageFileVia(TopLevel.GetTopLevel(this) as Window, $"maptileanim1_{_vm.CurrentAddr:X08}.png", p =>
+                string? written = await FileDialogHelper.SaveImageFileVia(TopLevel.GetTopLevel(this), $"maptileanim1_{_vm.CurrentAddr:X08}.png", p =>
                 {
                     using var stream = File.Create(p); bmp.Save(stream);
                 });
@@ -280,7 +280,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     CoreState.Services?.ShowError("No entry selected.");
                     return;
                 }
-                string? path = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this) as Window);
+                string? path = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this));
                 if (string.IsNullOrEmpty(path)) return;
 
                 var img = CoreState.ImageService?.LoadImage(path);

--- a/FEBuilderGBA.Avalonia/Views/OPPrologueViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OPPrologueViewerView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.IO;
 using global::Avalonia.Controls;
@@ -139,7 +139,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (!U.isSafetyOffset(palAddr)) { CoreState.Services.ShowError("No palette pointer"); return; }
                 byte[] pal = ImageUtilCore.GetPalette(palAddr, 256);
                 if (pal == null || pal.Length < 32) { CoreState.Services.ShowError("Failed to read palette"); return; }
-                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this) as Window, "op_prologue_palette.pal", p =>
+                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this), "op_prologue_palette.pal", p =>
                 {
                     // #1639: write via the SAF bridge so Android content:// targets work.
                     PaletteFormat fmt = PaletteFormatConverter.FormatFromExtension(System.IO.Path.GetExtension(p));
@@ -155,7 +155,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 ROM rom = CoreState.ROM;
                 if (rom == null) return;
-                string path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this) as Window);
+                string path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this));
                 if (string.IsNullOrEmpty(path)) return;
                 byte[] fileData = File.ReadAllBytes(path);
                 PaletteFormat fmt = PaletteFormatConverter.DetectFormat(fileData, System.IO.Path.GetExtension(path));

--- a/FEBuilderGBA.Avalonia/Views/PointerToolView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/PointerToolView.axaml
@@ -1,9 +1,6 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        x:Class="FEBuilderGBA.Avalonia.Views.PointerToolView"
-        Title="Pointer Tool" Width="1050" Height="780"
-        WindowStartupLocation="CenterOwner"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="FEBuilderGBA.Avalonia.Views.PointerToolView">
   <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
   <DockPanel Margin="12">
     <!-- Bottom buttons -->
@@ -200,4 +197,4 @@
     </Grid>
   </DockPanel>
   </ScrollViewer>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/PointerToolView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/PointerToolView.axaml.cs
@@ -5,6 +5,7 @@
 // button, LDR Address + Reference textboxes, 4 per-result warning
 // indicators), and ensures every ROM-mutating handler runs inside a
 // _undoService.Begin / Commit / Rollback scope.
+using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Input;
@@ -16,12 +17,15 @@ using FEBuilderGBA.Avalonia.Dialogs;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class PointerToolView : TranslatedWindow, IEditorView
+    public partial class PointerToolView : TranslatedUserControl, IEmbeddableEditor
     {
         readonly PointerToolViewModel _vm = new();
         readonly UndoService _undoService = new();
         public string ViewTitle => "Pointer Tool";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("Pointer Tool", 1050, 780, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         public PointerToolView()
         {
@@ -134,7 +138,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                var storage = StorageProvider;
+                var storage = TopLevel.GetTopLevel(this)?.StorageProvider;
                 if (storage == null) return;
                 var gbaFiles = new FilePickerFileType("GBA ROMs") { Patterns = new[] { "*.gba" } };
                 var binFiles = new FilePickerFileType("Binary files") { Patterns = new[] { "*.bin" } };
@@ -206,7 +210,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
         }
 
-        void Close_Click(object? sender, RoutedEventArgs e) => Close();
+        void Close_Click(object? sender, RoutedEventArgs e) => RequestClose();
 
         public void NavigateTo(uint address)
         {

--- a/FEBuilderGBA.Avalonia/Views/PortraitViewerView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/PortraitViewerView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.PortraitViewerView"
-        Title="Portrait Editor" Width="789" Height="700"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.PortraitViewerView">
   <Grid ColumnDefinitions="250,*">
     <controls:AddressListControl AutomationProperties.AutomationId="PortraitViewer_Portrait_List" Grid.Column="0" Name="PortraitList" Margin="4" />
 
@@ -82,4 +80,4 @@
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/PortraitViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/PortraitViewerView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.IO;
 using global::Avalonia.Controls;
@@ -160,7 +160,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
         async void ImportPng_Click(object? sender, RoutedEventArgs e)
         {
-            string? filePath = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this) as Window);
+            string? filePath = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this));
             if (string.IsNullOrEmpty(filePath)) return;
             ImportImageFromFile(filePath);
         }
@@ -231,7 +231,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // Portrait palette is raw (not compressed), 16 colors = 32 bytes
                 byte[] pal = ImageUtilCore.GetPalette(palAddr, 16);
                 if (pal == null || pal.Length < 32) { CoreState.Services.ShowError("Failed to read palette"); return; }
-                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this) as Window, "portrait_palette.pal", p =>
+                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this), "portrait_palette.pal", p =>
                 {
                     // #1639: write via the SAF bridge so Android content:// targets work.
                     PaletteFormat fmt = PaletteFormatConverter.FormatFromExtension(System.IO.Path.GetExtension(p));
@@ -247,7 +247,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 ROM rom = CoreState.ROM;
                 if (rom == null) return;
-                string? path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this) as Window);
+                string? path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this));
                 if (string.IsNullOrEmpty(path)) return;
                 byte[] fileData = File.ReadAllBytes(path);
                 PaletteFormat fmt = PaletteFormatConverter.DetectFormat(fileData, System.IO.Path.GetExtension(path));

--- a/FEBuilderGBA.Avalonia/Views/PortraitViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/PortraitViewerView.axaml.cs
@@ -1,3 +1,4 @@
+using global::Avalonia;
 using System;
 using System.IO;
 using global::Avalonia.Controls;
@@ -8,14 +9,18 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class PortraitViewerView : TranslatedWindow, IPickableEditor, IDataVerifiableView
+    public partial class PortraitViewerView : TranslatedUserControl, IEmbeddableEditor, IPickableEditor, IDataVerifiableView
     {
         readonly PortraitViewerViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
 
         public string ViewTitle => "Portrait Editor";
-        public bool IsLoaded => _vm.CanWrite;
+        public new bool IsLoaded => _vm.CanWrite;
+        public EditorDescriptor Descriptor => new("Portrait Editor", 789, 700, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         public event Action<PickResult>? SelectionConfirmed;
 
@@ -24,7 +29,16 @@ namespace FEBuilderGBA.Avalonia.Views
             InitializeComponent();
             PortraitList.SelectedAddressChanged += OnPortraitSelected;
             PortraitList.SelectionConfirmed += result => SelectionConfirmed?.Invoke(result);
-            Opened += (_, _) => LoadList();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         void LoadList()
@@ -146,7 +160,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
         async void ImportPng_Click(object? sender, RoutedEventArgs e)
         {
-            string? filePath = await FileDialogHelper.OpenImageFile(this);
+            string? filePath = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this) as Window);
             if (string.IsNullOrEmpty(filePath)) return;
             ImportImageFromFile(filePath);
         }
@@ -157,7 +171,7 @@ namespace FEBuilderGBA.Avalonia.Views
         // size to enforce), so the lenient quantize matches the file-picker.
         async void FERepo_Click(object? sender, RoutedEventArgs e)
         {
-            string? path = await FERepoPickHelper.PickForEditor(this,
+            string? path = await FERepoPickHelper.PickForEditor(TopLevel.GetTopLevel(this) as Window,
                 FERepoResourceBrowser.FERepoEditorKind.Portrait);
             if (string.IsNullOrEmpty(path)) return;
             ImportImageFromFile(path);
@@ -202,7 +216,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
         async void ExportPng_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
         {
-            await MainPortraitImage.ExportPng(this, "portrait.png");
+            await MainPortraitImage.ExportPng(TopLevel.GetTopLevel(this) as Window, "portrait.png");
         }
 
         async void ExportPal_Click(object? sender, RoutedEventArgs e)
@@ -217,7 +231,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // Portrait palette is raw (not compressed), 16 colors = 32 bytes
                 byte[] pal = ImageUtilCore.GetPalette(palAddr, 16);
                 if (pal == null || pal.Length < 32) { CoreState.Services.ShowError("Failed to read palette"); return; }
-                await FileDialogHelper.SavePaletteFileVia(this, "portrait_palette.pal", p =>
+                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this) as Window, "portrait_palette.pal", p =>
                 {
                     // #1639: write via the SAF bridge so Android content:// targets work.
                     PaletteFormat fmt = PaletteFormatConverter.FormatFromExtension(System.IO.Path.GetExtension(p));
@@ -233,7 +247,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 ROM rom = CoreState.ROM;
                 if (rom == null) return;
-                string? path = await FileDialogHelper.OpenPaletteFile(this);
+                string? path = await FileDialogHelper.OpenPaletteFile(TopLevel.GetTopLevel(this) as Window);
                 if (string.IsNullOrEmpty(path)) return;
                 byte[] fileData = File.ReadAllBytes(path);
                 PaletteFormat fmt = PaletteFormatConverter.DetectFormat(fileData, System.IO.Path.GetExtension(path));

--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassCSkillSysView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassCSkillSysView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.SkillAssignmentClassCSkillSysView"
-        Title="Skill Assignment - Class (CSkillSys)" Width="1200" Height="900"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.SkillAssignmentClassCSkillSysView">
   <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
     <StackPanel Margin="12" Spacing="8">
 
@@ -256,4 +254,4 @@
 
     </StackPanel>
   </ScrollViewer>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassCSkillSysView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassCSkillSysView.axaml.cs
@@ -6,6 +6,7 @@
 // ...ViewViewModel.cs stub was removed). The XView -> XViewModel name
 // pairing is what enables UndoCoverageScanner's View-to-VM upgrade pass to
 // mark the in-VM write callsites as Covered.
+using global::Avalonia;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -17,10 +18,11 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class SkillAssignmentClassCSkillSysView : TranslatedWindow, IEditorView, IDataVerifiableView
+    public partial class SkillAssignmentClassCSkillSysView : TranslatedUserControl, IEmbeddableEditor, IDataVerifiableView
     {
         readonly SkillAssignmentClassCSkillSysViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
 
         // Track currently selected N1 row address. Reset on class change
         // (Copilot-flagged stale-selection guard from PR #544).
@@ -34,8 +36,11 @@ namespace FEBuilderGBA.Avalonia.Views
         List<AddrResult> _n1Items = new();
 
         public string ViewTitle => "Skill Assignment - Class (CSkillSys)";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("Skill Assignment - Class (CSkillSys)", 1200, 900, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         public SkillAssignmentClassCSkillSysView()
         {
@@ -52,20 +57,31 @@ namespace FEBuilderGBA.Avalonia.Views
                 int idx = N1ListBox.SelectedIndex;
                 if (idx >= 0 && idx < _n1Items.Count) OnN1Selected(_n1Items[idx]);
             };
-            Opened += (_, _) => Initialize();
-            Closed += (_, _) =>
-            {
-                if (_classSkillIconBitmap != null) try { _classSkillIconBitmap.Dispose(); } catch { /* swallow */ }
-                if (_n1SkillIconBitmap != null) try { _n1SkillIconBitmap.Dispose(); } catch { /* swallow */ }
-                _classSkillIconBitmap = null;
-                _n1SkillIconBitmap = null;
-            };
             N1B0Box.ValueChanged += (s, e) => OnLevelChanged();
             XLvValueBox.ValueChanged += (s, e) => OnXLevelValueChanged();
             XLvPlayerOnlyCheckBox.IsCheckedChanged += (s, e) => OnLevelModeCheckboxChanged(32);
             XLvEnemyOnlyCheckBox.IsCheckedChanged += (s, e) => OnLevelModeCheckboxChanged(64);
             XLvNormalHardCheckBox.IsCheckedChanged += (s, e) => OnLevelModeCheckboxChanged(96);
             XLvHardOnlyCheckBox.IsCheckedChanged += (s, e) => OnLevelModeCheckboxChanged(128);
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromVisualTree(e);
+            if (_classSkillIconBitmap != null) try { _classSkillIconBitmap.Dispose(); } catch { /* swallow */ }
+            if (_n1SkillIconBitmap != null) try { _n1SkillIconBitmap.Dispose(); } catch { /* swallow */ }
+            _classSkillIconBitmap = null;
+            _n1SkillIconBitmap = null;
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                Initialize();
+            }
         }
 
         void Initialize()

--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassSkillSystemView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassSkillSystemView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.SkillAssignmentClassSkillSystemView"
-        Title="Skill Assignment (Class)" Width="1200" Height="900"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.SkillAssignmentClassSkillSystemView">
   <Grid ColumnDefinitions="260,*" RowDefinitions="Auto,Auto,*">
 
     <!-- Row 0: top read-config bar — unified via EditorTopBarWithInputs (#743). -->
@@ -286,4 +284,4 @@ If promoted...` parses with
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassSkillSystemView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentClassSkillSystemView.axaml.cs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -17,10 +18,11 @@ namespace FEBuilderGBA.Avalonia.Views
     /// scopes. List expand for the N1 sub-list handles both first-allocation
     /// (pointer == 0) and growth (pointer > 0).
     /// </summary>
-    public partial class SkillAssignmentClassSkillSystemView : TranslatedWindow, IEditorView, IDataVerifiableView
+    public partial class SkillAssignmentClassSkillSystemView : TranslatedUserControl, IEmbeddableEditor, IDataVerifiableView
     {
         readonly SkillAssignmentClassSkillSystemViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
         Bitmap _classIconBitmap;
         Bitmap _n1IconBitmap;
         bool _suppressN1B0Change;
@@ -28,7 +30,10 @@ namespace FEBuilderGBA.Avalonia.Views
         bool _suppressLevelChange;
 
         public string ViewTitle => "Skill Assignment (Class)";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("Skill Assignment (Class)", 1200, 900, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
         public ViewModelBase DataViewModel => _vm;
 
         public SkillAssignmentClassSkillSystemView()
@@ -38,12 +43,23 @@ namespace FEBuilderGBA.Avalonia.Views
             // (Copilot bot review on PR #555).
             DataContext = _vm;
             EntryList.SelectedAddressChanged += OnSelected;
-            Opened += (_, _) => LoadList();
-            Closed += (_, _) =>
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromVisualTree(e);
+            DisposeBitmap(ref _classIconBitmap);
+            DisposeBitmap(ref _n1IconBitmap);
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
             {
-                DisposeBitmap(ref _classIconBitmap);
-                DisposeBitmap(ref _n1IconBitmap);
-            };
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         static void DisposeBitmap(ref Bitmap bmp)
@@ -458,7 +474,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                var sp = StorageProvider;
+                var sp = TopLevel.GetTopLevel(this)?.StorageProvider;
                 if (sp == null) return;
                 var file = await sp.SaveFilePickerAsync(new FilePickerSaveOptions
                 {
@@ -492,7 +508,7 @@ namespace FEBuilderGBA.Avalonia.Views
             // PR #555).
             try
             {
-                var sp = StorageProvider;
+                var sp = TopLevel.GetTopLevel(this)?.StorageProvider;
                 if (sp == null) return;
                 var files = await sp.OpenFilePickerAsync(new FilePickerOpenOptions
                 {

--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentUnitCSkillSysView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentUnitCSkillSysView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.SkillAssignmentUnitCSkillSysView"
-        Title="Skill Assignment - Unit (CSkillSys)" Width="1200" Height="900"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.SkillAssignmentUnitCSkillSysView">
   <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
     <StackPanel Margin="12" Spacing="8">
 
@@ -224,4 +222,4 @@
 
     </StackPanel>
   </ScrollViewer>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentUnitCSkillSysView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentUnitCSkillSysView.axaml.cs
@@ -11,6 +11,7 @@
 // Unit WinForms form has no X_LV level-breakdown panel (Class-only), but it
 // DOES expose a per-unit level-up pointer (X_LevelUpAddr) which the master
 // Write commits alongside W0 — see OnWrite.
+using global::Avalonia;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -22,10 +23,11 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class SkillAssignmentUnitCSkillSysView : TranslatedWindow, IEditorView, IDataVerifiableView
+    public partial class SkillAssignmentUnitCSkillSysView : TranslatedUserControl, IEmbeddableEditor, IDataVerifiableView
     {
         readonly SkillAssignmentUnitCSkillSysViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
 
         // Track currently selected N1 row address. Reset on unit change.
         uint _n1SelectedAddr;
@@ -38,8 +40,11 @@ namespace FEBuilderGBA.Avalonia.Views
         List<AddrResult> _n1Items = new();
 
         public string ViewTitle => "Skill Assignment - Unit (CSkillSys)";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("Skill Assignment - Unit (CSkillSys)", 1200, 900, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         public SkillAssignmentUnitCSkillSysView()
         {
@@ -58,14 +63,25 @@ namespace FEBuilderGBA.Avalonia.Views
                 int idx = N1ListBox.SelectedIndex;
                 if (idx >= 0 && idx < _n1Items.Count) OnN1Selected(_n1Items[idx]);
             };
-            Opened += (_, _) => Initialize();
-            Closed += (_, _) =>
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromVisualTree(e);
+            if (_unitSkillIconBitmap != null) try { _unitSkillIconBitmap.Dispose(); } catch { /* swallow */ }
+            if (_n1SkillIconBitmap != null) try { _n1SkillIconBitmap.Dispose(); } catch { /* swallow */ }
+            _unitSkillIconBitmap = null;
+            _n1SkillIconBitmap = null;
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
             {
-                if (_unitSkillIconBitmap != null) try { _unitSkillIconBitmap.Dispose(); } catch { /* swallow */ }
-                if (_n1SkillIconBitmap != null) try { _n1SkillIconBitmap.Dispose(); } catch { /* swallow */ }
-                _unitSkillIconBitmap = null;
-                _n1SkillIconBitmap = null;
-            };
+                _hasLoadedList = true;
+                Initialize();
+            }
         }
 
         void Initialize()

--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentUnitSkillSystemView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentUnitSkillSystemView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.SkillAssignmentUnitSkillSystemView"
-        Title="Skill Assignment (Unit)" Width="1200" Height="900"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.SkillAssignmentUnitSkillSystemView">
   <Grid ColumnDefinitions="260,*" RowDefinitions="Auto,Auto,*">
 
     <!-- Row 0: top read-config bar -->
@@ -241,4 +239,4 @@
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/SkillAssignmentUnitSkillSystemView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillAssignmentUnitSkillSystemView.axaml.cs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -26,15 +27,19 @@ namespace FEBuilderGBA.Avalonia.Views
     /// <c>FindAssignUnitLevelUpSkillPointer() == U.NOT_FOUND</c>), so no dead
     /// level-up UI is shown.
     /// </summary>
-    public partial class SkillAssignmentUnitSkillSystemView : TranslatedWindow, IEditorView, IDataVerifiableView
+    public partial class SkillAssignmentUnitSkillSystemView : TranslatedUserControl, IEmbeddableEditor, IDataVerifiableView
     {
         readonly SkillAssignmentUnitSkillSystemViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
         Bitmap _unitIconBitmap;
         Bitmap _n1IconBitmap;
 
         public string ViewTitle => "Skill Assignment (Unit)";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("Skill Assignment (Unit)", 1200, 900, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
         public ViewModelBase DataViewModel => _vm;
 
         public SkillAssignmentUnitSkillSystemView()
@@ -43,12 +48,23 @@ namespace FEBuilderGBA.Avalonia.Views
             // Bind DataContext so AXAML {Binding LevelUpEntries} resolves.
             DataContext = _vm;
             EntryList.SelectedAddressChanged += OnSelected;
-            Opened += (_, _) => LoadList();
-            Closed += (_, _) =>
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromVisualTree(e);
+            DisposeBitmap(ref _unitIconBitmap);
+            DisposeBitmap(ref _n1IconBitmap);
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
             {
-                DisposeBitmap(ref _unitIconBitmap);
-                DisposeBitmap(ref _n1IconBitmap);
-            };
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         static void DisposeBitmap(ref Bitmap bmp)
@@ -378,7 +394,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                var sp = StorageProvider;
+                var sp = TopLevel.GetTopLevel(this)?.StorageProvider;
                 if (sp == null) return;
                 var file = await sp.SaveFilePickerAsync(new FilePickerSaveOptions
                 {
@@ -411,7 +427,7 @@ namespace FEBuilderGBA.Avalonia.Views
             // the picker is showing.
             try
             {
-                var sp = StorageProvider;
+                var sp = TopLevel.GetTopLevel(this)?.StorageProvider;
                 if (sp == null) return;
                 var files = await sp.OpenFilePickerAsync(new FilePickerOpenOptions
                 {

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NSkillView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NSkillView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.SkillConfigFE8NSkillView"
-        Title="Skill Configuration (FE8N)" Width="1189" Height="898"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.SkillConfigFE8NSkillView">
   <Grid ColumnDefinitions="260,*" RowDefinitions="Auto,Auto,*">
 
     <!-- Row 0: top read-config bar — unified via EditorTopBarWithInputs (#743 round 2).
@@ -594,4 +592,4 @@
 
     </TabControl>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NSkillView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NSkillView.axaml.cs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -25,24 +26,42 @@ namespace FEBuilderGBA.Avalonia.Views
     /// one editable tab is faithful + complete. The Class/Item/Other tabs remain
     /// informational placeholders (same 16 bytes; KnownGap #374).
     /// </summary>
-    public partial class SkillConfigFE8NSkillView : TranslatedWindow, IEditorView, IDataVerifiableView
+    public partial class SkillConfigFE8NSkillView : TranslatedUserControl, IEmbeddableEditor, IDataVerifiableView
     {
         readonly SkillConfigFE8NSkillViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
         bool _suppressPointerChange;
         bool _suppressChangeTypeChange;
         Bitmap? _currentIconBitmap;
 
         public string ViewTitle => "Skill Configuration (FE8N)";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("Skill Configuration (FE8N)", 1189, 898, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         public SkillConfigFE8NSkillView()
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
-            Opened += (_, _) => LoadList();
-            Closed += (_, _) => DisposeBitmap(ref _currentIconBitmap);
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromVisualTree(e);
+            DisposeBitmap(ref _currentIconBitmap);
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         static void DisposeBitmap(ref Bitmap? bmp)

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer2SkillView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer2SkillView.axaml
@@ -1,10 +1,8 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        xmlns:views="clr-namespace:FEBuilderGBA.Avalonia.Views"
-        x:Class="FEBuilderGBA.Avalonia.Views.SkillConfigFE8NVer2SkillView"
-        Title="Skill Configuration (FE8N v2)" Width="980" Height="780"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             xmlns:views="clr-namespace:FEBuilderGBA.Avalonia.Views"
+             x:Class="FEBuilderGBA.Avalonia.Views.SkillConfigFE8NVer2SkillView">
   <Grid ColumnDefinitions="260,*" RowDefinitions="Auto,Auto,*">
 
     <!-- Row 0: top read-config bar — unified via EditorTopBarWithInputs (#743). -->
@@ -315,4 +313,4 @@
 
     </TabControl>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer2SkillView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer2SkillView.axaml.cs
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+﻿// SPDX-License-Identifier: GPL-3.0-or-later
+using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -24,10 +25,11 @@ namespace FEBuilderGBA.Avalonia.Views
     /// surface the resolved sub-list pointer + entry count from the parent
     /// skill row but do not yet support editing or list expansion.
     /// </summary>
-    public partial class SkillConfigFE8NVer2SkillView : TranslatedWindow, IEditorView, IDataVerifiableView
+    public partial class SkillConfigFE8NVer2SkillView : TranslatedUserControl, IEmbeddableEditor, IDataVerifiableView
     {
         readonly SkillConfigFE8NVer2SkillViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
         readonly SkillConfigAnimePreview _animePreview = new();
         bool _suppressZoomChange;
         bool _suppressFrameChange;
@@ -35,8 +37,11 @@ namespace FEBuilderGBA.Avalonia.Views
         Bitmap? _currentPreviewBitmap;
 
         public string ViewTitle => "Skill Configuration (FE8N v2)";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("Skill Configuration (FE8N v2)", 980, 780, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         public SkillConfigFE8NVer2SkillView()
         {
@@ -64,13 +69,24 @@ namespace FEBuilderGBA.Avalonia.Views
             ItemSubEditor.Changed += OnSubListChanged;
             Item2SubEditor.Changed += OnSubListChanged;
 
-            Opened += (_, _) => LoadList();
-            Closed += (_, _) =>
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromVisualTree(e);
+            DisposeBitmap(ref _currentIconBitmap);
+            DisposeBitmap(ref _currentPreviewBitmap);
+            _animePreview.Clear();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
             {
-                DisposeBitmap(ref _currentIconBitmap);
-                DisposeBitmap(ref _currentPreviewBitmap);
-                _animePreview.Clear();
-            };
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         /// <summary>
@@ -358,7 +374,7 @@ namespace FEBuilderGBA.Avalonia.Views
             if (!TryResolveIconAddrs(rom, out uint iconByteAddr, out uint paletteAddr)) return;
 
             string? err = await SkillConfigIconIoHelper.ImportIconAsync(
-                this, rom, iconByteAddr, paletteAddr, _undoService);
+                TopLevel.GetTopLevel(this) as Window, rom, iconByteAddr, paletteAddr, _undoService);
             if (err == null) return; // user cancelled — do not refresh.
             if (err != "")
             {
@@ -381,7 +397,7 @@ namespace FEBuilderGBA.Avalonia.Views
             if (rom == null || !_vm.IsLoaded || _vm.SkillBaseAddress == 0) return;
             if (!TryResolveIconAddrs(rom, out uint iconByteAddr, out uint paletteAddr)) return;
 
-            string? path = await FERepoPickHelper.PickForEditor(this,
+            string? path = await FERepoPickHelper.PickForEditor(TopLevel.GetTopLevel(this) as Window,
                 FERepoResourceBrowser.FERepoEditorKind.SkillIcon);
             if (string.IsNullOrEmpty(path)) return;
 
@@ -405,7 +421,7 @@ namespace FEBuilderGBA.Avalonia.Views
             if (rom == null || !_vm.IsLoaded || _vm.SkillBaseAddress == 0) return;
             if (!TryResolveIconAddrs(rom, out uint iconByteAddr, out uint paletteAddr)) return;
 
-            await SkillConfigIconIoHelper.ExportIconAsync(this, rom, iconByteAddr, paletteAddr);
+            await SkillConfigIconIoHelper.ExportIconAsync(TopLevel.GetTopLevel(this) as Window, rom, iconByteAddr, paletteAddr);
         }
 
         // #913 SLICE 1 — real skill-anime import via SkillSystemsAnimeImportCore
@@ -414,7 +430,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             if (!_vm.IsLoaded) return;
             bool ok = await SkillConfigAnimeImportHelper.ImportAsync(
-                this, _vm.AnimationPointer, _undoService);
+                TopLevel.GetTopLevel(this) as Window, _vm.AnimationPointer, _undoService);
             if (!ok) return;
 
             // #1010 — the animation bytes changed; drop the cached decode.
@@ -428,7 +444,7 @@ namespace FEBuilderGBA.Avalonia.Views
         async void AnimationExport_Click(object? sender, RoutedEventArgs e)
         {
             if (!_vm.IsLoaded) return;
-            await SkillConfigAnimeExportHelper.ExportAsync(this, _vm.AnimationPointer, _vm.SelectedId);
+            await SkillConfigAnimeExportHelper.ExportAsync(TopLevel.GetTopLevel(this) as Window, _vm.AnimationPointer, _vm.SelectedId);
         }
 
         void JumpToEditor_Click(object? sender, RoutedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer3SkillView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer3SkillView.axaml
@@ -1,10 +1,8 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        xmlns:views="clr-namespace:FEBuilderGBA.Avalonia.Views"
-        x:Class="FEBuilderGBA.Avalonia.Views.SkillConfigFE8NVer3SkillView"
-        Title="Skill Configuration (FE8N v3)" Width="1100" Height="820"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             xmlns:views="clr-namespace:FEBuilderGBA.Avalonia.Views"
+             x:Class="FEBuilderGBA.Avalonia.Views.SkillConfigFE8NVer3SkillView">
   <Grid ColumnDefinitions="260,*" RowDefinitions="Auto,Auto,*">
 
     <!-- Row 0: top read-config bar — unified via EditorTopBarWithInputs (#743). -->
@@ -348,4 +346,4 @@
 
     </TabControl>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer3SkillView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8NVer3SkillView.axaml.cs
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+﻿// SPDX-License-Identifier: GPL-3.0-or-later
+using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -24,10 +25,11 @@ namespace FEBuilderGBA.Avalonia.Views
     /// they surface the resolved sub-list pointer + entry count from the
     /// parent skill row but do not yet support editing or list expansion.
     /// </summary>
-    public partial class SkillConfigFE8NVer3SkillView : TranslatedWindow, IEditorView, IDataVerifiableView
+    public partial class SkillConfigFE8NVer3SkillView : TranslatedUserControl, IEmbeddableEditor, IDataVerifiableView
     {
         readonly SkillConfigFE8NVer3SkillViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
         readonly SkillConfigAnimePreview _animePreview = new();
         bool _suppressZoomChange;
         bool _suppressFrameChange;
@@ -35,8 +37,11 @@ namespace FEBuilderGBA.Avalonia.Views
         Bitmap? _currentPreviewBitmap;
 
         public string ViewTitle => "Skill Configuration (FE8N v3)";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("Skill Configuration (FE8N v3)", 1100, 820, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         public SkillConfigFE8NVer3SkillView()
         {
@@ -68,13 +73,24 @@ namespace FEBuilderGBA.Avalonia.Views
             Item2SubEditor.Changed += OnSubListChanged;
             CompositeSubEditor.Changed += OnSubListChanged;
 
-            Opened += (_, _) => LoadList();
-            Closed += (_, _) =>
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromVisualTree(e);
+            DisposeBitmap(ref _currentIconBitmap);
+            DisposeBitmap(ref _currentPreviewBitmap);
+            _animePreview.Clear();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
             {
-                DisposeBitmap(ref _currentIconBitmap);
-                DisposeBitmap(ref _currentPreviewBitmap);
-                _animePreview.Clear();
-            };
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         /// <summary>
@@ -358,7 +374,7 @@ namespace FEBuilderGBA.Avalonia.Views
             if (!TryResolveIconAddrs(rom, out uint iconByteAddr, out uint paletteAddr)) return;
 
             string? err = await SkillConfigIconIoHelper.ImportIconAsync(
-                this, rom, iconByteAddr, paletteAddr, _undoService);
+                TopLevel.GetTopLevel(this) as Window, rom, iconByteAddr, paletteAddr, _undoService);
             if (err == null) return; // user cancelled — do not refresh.
             if (err != "")
             {
@@ -381,7 +397,7 @@ namespace FEBuilderGBA.Avalonia.Views
             if (rom == null || !_vm.IsLoaded || _vm.SkillBaseAddress == 0) return;
             if (!TryResolveIconAddrs(rom, out uint iconByteAddr, out uint paletteAddr)) return;
 
-            string? path = await FERepoPickHelper.PickForEditor(this,
+            string? path = await FERepoPickHelper.PickForEditor(TopLevel.GetTopLevel(this) as Window,
                 FERepoResourceBrowser.FERepoEditorKind.SkillIcon);
             if (string.IsNullOrEmpty(path)) return;
 
@@ -405,7 +421,7 @@ namespace FEBuilderGBA.Avalonia.Views
             if (rom == null || !_vm.IsLoaded || _vm.SkillBaseAddress == 0) return;
             if (!TryResolveIconAddrs(rom, out uint iconByteAddr, out uint paletteAddr)) return;
 
-            await SkillConfigIconIoHelper.ExportIconAsync(this, rom, iconByteAddr, paletteAddr);
+            await SkillConfigIconIoHelper.ExportIconAsync(TopLevel.GetTopLevel(this) as Window, rom, iconByteAddr, paletteAddr);
         }
 
         // #913 SLICE 1 — real skill-anime import via SkillSystemsAnimeImportCore
@@ -414,7 +430,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             if (!_vm.IsLoaded) return;
             bool ok = await SkillConfigAnimeImportHelper.ImportAsync(
-                this, _vm.AnimationPointer, _undoService);
+                TopLevel.GetTopLevel(this) as Window, _vm.AnimationPointer, _undoService);
             if (!ok) return;
 
             // #1010 — the animation bytes changed; drop the cached decode.
@@ -428,7 +444,7 @@ namespace FEBuilderGBA.Avalonia.Views
         async void AnimationExport_Click(object? sender, RoutedEventArgs e)
         {
             if (!_vm.IsLoaded) return;
-            await SkillConfigAnimeExportHelper.ExportAsync(this, _vm.AnimationPointer, _vm.SelectedId);
+            await SkillConfigAnimeExportHelper.ExportAsync(TopLevel.GetTopLevel(this) as Window, _vm.AnimationPointer, _vm.SelectedId);
         }
 
         void JumpToEditor_Click(object? sender, RoutedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8UCSkillSys09xView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8UCSkillSys09xView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.SkillConfigFE8UCSkillSys09xView"
-        Title="Skill Configuration (CSkillSys 0.9.x)" Width="900" Height="640"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.SkillConfigFE8UCSkillSys09xView">
   <Grid ColumnDefinitions="260,*" RowDefinitions="Auto,Auto,*">
 
     <!-- Row 0: top read-config bar — unified via EditorTopBarWithInputs (#743). -->
@@ -193,4 +191,4 @@
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigFE8UCSkillSys09xView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigFE8UCSkillSys09xView.axaml.cs
@@ -1,3 +1,4 @@
+﻿using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -17,10 +18,11 @@ namespace FEBuilderGBA.Avalonia.Views
     /// but their click handlers are intentional no-ops with a tooltip until
     /// the Core seam lands (mirrors the pattern used by #433).
     /// </summary>
-    public partial class SkillConfigFE8UCSkillSys09xView : TranslatedWindow, IEditorView, IDataVerifiableView
+    public partial class SkillConfigFE8UCSkillSys09xView : TranslatedUserControl, IEmbeddableEditor, IDataVerifiableView
     {
         readonly SkillConfigFE8UCSkillSys09xViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
         readonly SkillConfigAnimePreview _animePreview = new();
         bool _suppressZoomChange;
         bool _suppressFrameChange;
@@ -28,20 +30,34 @@ namespace FEBuilderGBA.Avalonia.Views
         Bitmap? _currentPreviewBitmap;
 
         public string ViewTitle => "Skill Configuration (CSkillSys 0.9.x)";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("Skill Configuration (CSkillSys 0.9.x)", 900, 640, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         public SkillConfigFE8UCSkillSys09xView()
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
-            Opened += (_, _) => LoadList();
-            Closed += (_, _) =>
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromVisualTree(e);
+            DisposeBitmap(ref _currentIconBitmap);
+            DisposeBitmap(ref _currentPreviewBitmap);
+            _animePreview.Clear();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
             {
-                DisposeBitmap(ref _currentIconBitmap);
-                DisposeBitmap(ref _currentPreviewBitmap);
-                _animePreview.Clear();
-            };
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         static void DisposeBitmap(ref Bitmap? bmp)
@@ -237,7 +253,7 @@ namespace FEBuilderGBA.Avalonia.Views
             uint paletteAddr = rom.p32(SKILL_PALETTE_POINTER);
 
             string? err = await SkillConfigIconIoHelper.ImportIconAsync(
-                this, rom, iconByteAddr, paletteAddr, _undoService);
+                TopLevel.GetTopLevel(this) as Window, rom, iconByteAddr, paletteAddr, _undoService);
             if (err == null) return; // user cancelled — do not refresh.
             if (err != "")
             {
@@ -266,7 +282,7 @@ namespace FEBuilderGBA.Avalonia.Views
             uint iconByteAddr = U.toOffset(iconGbaPointer);
             uint paletteAddr = rom.p32(SKILL_PALETTE_POINTER);
 
-            string? path = await FERepoPickHelper.PickForEditor(this,
+            string? path = await FERepoPickHelper.PickForEditor(TopLevel.GetTopLevel(this) as Window,
                 FERepoResourceBrowser.FERepoEditorKind.SkillIcon);
             if (string.IsNullOrEmpty(path)) return;
 
@@ -296,7 +312,7 @@ namespace FEBuilderGBA.Avalonia.Views
             uint iconByteAddr = U.toOffset(iconGbaPointer);
             uint paletteAddr = rom.p32(SKILL_PALETTE_POINTER);
 
-            await SkillConfigIconIoHelper.ExportIconAsync(this, rom, iconByteAddr, paletteAddr);
+            await SkillConfigIconIoHelper.ExportIconAsync(TopLevel.GetTopLevel(this) as Window, rom, iconByteAddr, paletteAddr);
         }
 
         // #913 SLICE 1 — real skill-anime import via SkillSystemsAnimeImportCore
@@ -305,7 +321,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             if (!_vm.IsLoaded) return;
             bool ok = await SkillConfigAnimeImportHelper.ImportAsync(
-                this, _vm.AnimationPointer, _undoService);
+                TopLevel.GetTopLevel(this) as Window, _vm.AnimationPointer, _undoService);
             if (!ok) return;
 
             // #1010 — the animation bytes changed; drop the cached decode.
@@ -319,7 +335,7 @@ namespace FEBuilderGBA.Avalonia.Views
         async void AnimationExport_Click(object? sender, RoutedEventArgs e)
         {
             if (!_vm.IsLoaded) return;
-            await SkillConfigAnimeExportHelper.ExportAsync(this, _vm.AnimationPointer, _vm.SelectedId);
+            await SkillConfigAnimeExportHelper.ExportAsync(TopLevel.GetTopLevel(this) as Window, _vm.AnimationPointer, _vm.SelectedId);
         }
 
         void JumpToEditor_Click(object? sender, RoutedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigSkillSystemView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigSkillSystemView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.SkillConfigSkillSystemView"
-        Title="Skill Config (SkillSystem)" Width="980" Height="700"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.SkillConfigSkillSystemView">
   <Grid ColumnDefinitions="260,*" RowDefinitions="Auto,Auto,*">
 
     <!-- Row 0: top read-config bar — unified via EditorTopBarWithInputs (#743).
@@ -205,4 +203,4 @@
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigSkillSystemView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigSkillSystemView.axaml.cs
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+﻿// SPDX-License-Identifier: GPL-3.0-or-later
+using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -20,10 +21,11 @@ namespace FEBuilderGBA.Avalonia.Views
     /// no-ops with a tooltip until the Core seam lands (mirrors the pattern
     /// established by PR #516 for SkillConfigFE8UCSkillSys09xView).
     /// </summary>
-    public partial class SkillConfigSkillSystemView : TranslatedWindow, IEditorView, IDataVerifiableView
+    public partial class SkillConfigSkillSystemView : TranslatedUserControl, IEmbeddableEditor, IDataVerifiableView
     {
         readonly SkillConfigSkillSystemViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
         readonly SkillConfigAnimePreview _animePreview = new();
         bool _suppressZoomChange;
         bool _suppressFrameChange;
@@ -31,20 +33,34 @@ namespace FEBuilderGBA.Avalonia.Views
         Bitmap? _currentPreviewBitmap;
 
         public string ViewTitle => "Skill Config (SkillSystem)";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("Skill Config (SkillSystem)", 980, 700, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         public SkillConfigSkillSystemView()
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
-            Opened += (_, _) => LoadList();
-            Closed += (_, _) =>
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromVisualTree(e);
+            DisposeBitmap(ref _currentIconBitmap);
+            DisposeBitmap(ref _currentPreviewBitmap);
+            _animePreview.Clear();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
             {
-                DisposeBitmap(ref _currentIconBitmap);
-                DisposeBitmap(ref _currentPreviewBitmap);
-                _animePreview.Clear();
-            };
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         static void DisposeBitmap(ref Bitmap? bmp)
@@ -254,7 +270,7 @@ namespace FEBuilderGBA.Avalonia.Views
             uint paletteAddr = rom.p32(SKILL_PALETTE_POINTER);
 
             string? err = await SkillConfigIconIoHelper.ImportIconAsync(
-                this, rom, iconByteAddr, paletteAddr, _undoService);
+                TopLevel.GetTopLevel(this) as Window, rom, iconByteAddr, paletteAddr, _undoService);
             if (err == null) return; // user cancelled — do not refresh.
             if (err != "")
             {
@@ -280,7 +296,7 @@ namespace FEBuilderGBA.Avalonia.Views
             if (_vm.IconBaseAddress == 0) return;
             if (!U.isSafetyOffset(SKILL_PALETTE_POINTER + 3, rom)) return;
 
-            string? path = await FERepoPickHelper.PickForEditor(this,
+            string? path = await FERepoPickHelper.PickForEditor(TopLevel.GetTopLevel(this) as Window,
                 FERepoResourceBrowser.FERepoEditorKind.SkillIcon);
             if (string.IsNullOrEmpty(path)) return;
 
@@ -311,7 +327,7 @@ namespace FEBuilderGBA.Avalonia.Views
             uint iconByteAddr = _vm.IconBaseAddress + SkillConfigIconIoHelper.IconByteSize * _vm.SelectedId;
             uint paletteAddr = rom.p32(SKILL_PALETTE_POINTER);
 
-            await SkillConfigIconIoHelper.ExportIconAsync(this, rom, iconByteAddr, paletteAddr);
+            await SkillConfigIconIoHelper.ExportIconAsync(TopLevel.GetTopLevel(this) as Window, rom, iconByteAddr, paletteAddr);
         }
 
         // #913 SLICE 1 — real skill-anime import via the cross-platform
@@ -321,7 +337,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             if (!_vm.IsLoaded) return;
             bool ok = await SkillConfigAnimeImportHelper.ImportAsync(
-                this, _vm.AnimationPointer, _undoService);
+                TopLevel.GetTopLevel(this) as Window, _vm.AnimationPointer, _undoService);
             if (!ok) return;
 
             // Success: the animation bytes changed — drop the cached decode,
@@ -338,7 +354,7 @@ namespace FEBuilderGBA.Avalonia.Views
         async void AnimationExport_Click(object? sender, RoutedEventArgs e)
         {
             if (!_vm.IsLoaded) return;
-            await SkillConfigAnimeExportHelper.ExportAsync(this, _vm.AnimationPointer, _vm.SelectedId);
+            await SkillConfigAnimeExportHelper.ExportAsync(TopLevel.GetTopLevel(this) as Window, _vm.AnimationPointer, _vm.SelectedId);
         }
 
         void JumpToEditor_Click(object? sender, RoutedEventArgs e)
@@ -366,7 +382,7 @@ namespace FEBuilderGBA.Avalonia.Views
             // chosen TSV's OWN directory, so require a real local path; a SAF pick
             // (no local path) cannot resolve those sibling dirs → message on
             // Android, never silent.
-            string? path = await FileDialogHelper.OpenFile(this,
+            string? path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this) as Window,
                 R._("Bulk Import Skill Config"), "*.SkillConfig.tsv", requireLocalPath: true);
             if (string.IsNullOrEmpty(path))
             {
@@ -463,7 +479,7 @@ namespace FEBuilderGBA.Avalonia.Views
             // #1639: bulk export writes per-skill anime* directories next to the
             // TSV, so require a real local path; a SAF pick (no local path) cannot
             // place those siblings → message on Android, never silent.
-            string? path = await FileDialogHelper.SaveFile(this,
+            string? path = await FileDialogHelper.SaveFile(TopLevel.GetTopLevel(this) as Window,
                 R._("Bulk Export Skill Config"),
                 new[] { (R._("Skill Config TSV"), "*.SkillConfig.tsv") },
                 suggested);

--- a/FEBuilderGBA.Avalonia/Views/SkillConfigSkillSystemView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SkillConfigSkillSystemView.axaml.cs
@@ -382,7 +382,7 @@ namespace FEBuilderGBA.Avalonia.Views
             // chosen TSV's OWN directory, so require a real local path; a SAF pick
             // (no local path) cannot resolve those sibling dirs → message on
             // Android, never silent.
-            string? path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this) as Window,
+            string? path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this),
                 R._("Bulk Import Skill Config"), "*.SkillConfig.tsv", requireLocalPath: true);
             if (string.IsNullOrEmpty(path))
             {
@@ -479,7 +479,7 @@ namespace FEBuilderGBA.Avalonia.Views
             // #1639: bulk export writes per-skill anime* directories next to the
             // TSV, so require a real local path; a SAF pick (no local path) cannot
             // place those siblings → message on Android, never silent.
-            string? path = await FileDialogHelper.SaveFile(TopLevel.GetTopLevel(this) as Window,
+            string? path = await FileDialogHelper.SaveFile(TopLevel.GetTopLevel(this),
                 R._("Bulk Export Skill Config"),
                 new[] { (R._("Skill Config TSV"), "*.SkillConfig.tsv") },
                 suggested);

--- a/FEBuilderGBA.Avalonia/Views/SongInstrumentView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SongInstrumentView.axaml.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+﻿// SPDX-License-Identifier: GPL-3.0-or-later
 // SongInstrumentView — Avalonia parity rebuild for #387. Mirrors
 // `SongInstrumentForm` layout (panel1 read-config + AddressPanel master-write
 // + panel2 common-header + 14 instrument tabs + panel4 fingerprint footer).
@@ -616,7 +616,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
             try
             {
-                string? path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this) as Window, R._("Import Wave"), "*.wav");
+                string? path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this), R._("Import Wave"), "*.wav");
                 if (string.IsNullOrEmpty(path)) return;
 
                 byte[] bytes = File.ReadAllBytes(path);

--- a/FEBuilderGBA.Avalonia/Views/SongTableView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SongTableView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.SongTableView"
-        Title="Song Table Editor" Width="1505" Height="809"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.SongTableView">
   <Grid ColumnDefinitions="250,*">
     <controls:AddressListControl AutomationProperties.AutomationId="SongTable_Song_List" Grid.Column="0" Name="SongList" Margin="4" />
 
@@ -37,4 +35,4 @@
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/SongTableView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SongTableView.axaml.cs
@@ -1,3 +1,4 @@
+using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -6,13 +7,16 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class SongTableView : TranslatedWindow, IPickableEditor, IDataVerifiableView
+    public partial class SongTableView : TranslatedUserControl, IEmbeddableEditor, IPickableEditor, IDataVerifiableView
     {
         readonly SongTableViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
 
         public string ViewTitle => "Song Table";
-        public bool IsLoaded => _vm.CanWrite;
+        public new bool IsLoaded => _vm.CanWrite;
+        public EditorDescriptor Descriptor => new("Song Table Editor", 1505, 809, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
 
         public event Action<PickResult>? SelectionConfirmed;
 
@@ -21,7 +25,16 @@ namespace FEBuilderGBA.Avalonia.Views
             InitializeComponent();
             SongList.SelectedAddressChanged += OnSongSelected;
             SongList.SelectionConfirmed += result => SelectionConfirmed?.Invoke(result);
-            Opened += (_, _) => LoadList();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         void LoadList()
@@ -128,6 +141,7 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         static uint ParseHexText(string? text)
         {

--- a/FEBuilderGBA.Avalonia/Views/SongTrackImportMidiView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SongTrackImportMidiView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.SongTrackImportMidiView"
-        Title="MIDI Import" Width="761" Height="794"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.SongTrackImportMidiView">
   <Grid ColumnDefinitions="250,*">
     <controls:AddressListControl AutomationProperties.AutomationId="SongTrackImportMidi_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
 
@@ -55,4 +53,4 @@
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/SongTrackImportMidiView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SongTrackImportMidiView.axaml.cs
@@ -1,3 +1,4 @@
+using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -9,19 +10,32 @@ using FEBuilderGBA.Core;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class SongTrackImportMidiView : TranslatedWindow, IEditorView
+    public partial class SongTrackImportMidiView : TranslatedUserControl, IEmbeddableEditor
     {
         readonly SongTrackImportMidiViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
 
         public string ViewTitle => "MIDI Import";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("MIDI Import", 761, 794, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         public SongTrackImportMidiView()
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
-            Opened += (_, _) => LoadList();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         void LoadList()
@@ -90,7 +104,9 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 var midiType = new FilePickerFileType(R._("MIDI Files")) { Patterns = new[] { "*.mid", "*.midi" } };
                 var allType = new FilePickerFileType(R._("All Files")) { Patterns = new[] { "*" } };
-                var files = await this.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+                var storageProvider = TopLevel.GetTopLevel(this)?.StorageProvider;
+                if (storageProvider == null) return;
+                var files = await storageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
                 {
                     Title = R._("Select MIDI File"),
                     AllowMultiple = false,
@@ -200,7 +216,7 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 pick = await WindowManager.Instance.PickFromEditor<SongTrackImportSelectInstrumentView>(
-                    seed, this);
+                    seed, TopLevel.GetTopLevel(this) as Window);
             }
             catch (Exception ex)
             {

--- a/FEBuilderGBA.Avalonia/Views/SongTrackImportSelectInstrumentView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SongTrackImportSelectInstrumentView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.SongTrackImportSelectInstrumentView"
-        Title="Instrument Selection" Width="767" Height="400"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.SongTrackImportSelectInstrumentView">
   <Grid ColumnDefinitions="250,*">
     <controls:AddressListControl AutomationProperties.AutomationId="SongTrackImportSelectInstrument_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
 
@@ -36,4 +34,4 @@
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/SongTrackImportSelectInstrumentView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SongTrackImportSelectInstrumentView.axaml.cs
@@ -1,3 +1,4 @@
+using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -6,12 +7,16 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class SongTrackImportSelectInstrumentView : TranslatedWindow, IPickableEditor
+    public partial class SongTrackImportSelectInstrumentView : TranslatedUserControl, IEmbeddableEditor, IPickableEditor
     {
         readonly SongTrackImportSelectInstrumentViewModel _vm = new();
+        bool _hasLoadedList;
 
         public string ViewTitle => "Instrument Selection";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("Instrument Selection", 767, 400, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         // #1001 PR2 / #1002: the browser is now a pick-and-return editor — the
         // SongTrack .s import opens it via WindowManager.PickFromEditor and the
@@ -24,7 +29,16 @@ namespace FEBuilderGBA.Avalonia.Views
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
             EntryList.SelectionConfirmed += result => SelectionConfirmed?.Invoke(result);
-            Opened += (_, _) => LoadList();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         void LoadList()

--- a/FEBuilderGBA.Avalonia/Views/SongTrackView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SongTrackView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.SongTrackView"
-        Title="Song Track Editor" Width="1200" Height="720"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.SongTrackView">
   <Grid RowDefinitions="Auto,*">
 
     <!-- Top read-config bar — unified via EditorTopBarWithInputs (#649).
@@ -277,4 +275,4 @@
       </Grid>
     </Grid>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/SongTrackView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SongTrackView.axaml.cs
@@ -7,6 +7,7 @@
 // SelectInstrument) stay deferred and explicitly absent from both the
 // manifest and the click-handler wiring — see
 // `SongTrackViewModel.NavigationTargets.cs`.
+using global::Avalonia;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -21,13 +22,16 @@ using FEBuilderGBA.Core;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class SongTrackView : TranslatedWindow, IEditorView, IDataVerifiableView
+    public partial class SongTrackView : TranslatedUserControl, IEmbeddableEditor, IDataVerifiableView
     {
         readonly SongTrackViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
 
         public string ViewTitle => "Song Track Editor";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("Song Track Editor", 1200, 720, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
 
         // The 16 track ListBox controls — populated in OnSelected from
         // `_vm.Tracks`. Indexed by 0..15 for direct mapping to track index.
@@ -45,7 +49,16 @@ namespace FEBuilderGBA.Avalonia.Views
             // the two source-file buttons use the binding.
             DataContext = _vm;
             EntryList.SelectedAddressChanged += OnSelected;
-            Opened += (_, _) => LoadList();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         void ResolveTrackControls()
@@ -373,7 +386,9 @@ namespace FEBuilderGBA.Avalonia.Views
                 // Instrument editor — no new Core work.
                 var instType = new FilePickerFileType(R._("Instrument Set Files")) { Patterns = new[] { "*.instrument" } };
                 var allType = new FilePickerFileType(R._("All Files")) { Patterns = new[] { "*" } };
-                var file = await this.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+                var storageProvider = TopLevel.GetTopLevel(this)?.StorageProvider;
+                if (storageProvider == null) return;
+                var file = await storageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
                 {
                     Title = R._("Export Music File"),
                     SuggestedFileName = $"song_0x{_vm.CurrentAddr:X06}.mid",
@@ -446,7 +461,9 @@ namespace FEBuilderGBA.Avalonia.Views
                 var instType = new FilePickerFileType(R._("Instrument Set Files")) { Patterns = new[] { "*.instrument" } };
                 var sType = new FilePickerFileType(R._("SondFont Source Files")) { Patterns = new[] { "*.s" } };
                 var allType = new FilePickerFileType(R._("All Files")) { Patterns = new[] { "*" } };
-                var files = await this.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+                var storageProvider = TopLevel.GetTopLevel(this)?.StorageProvider;
+                if (storageProvider == null) return;
+                var files = await storageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
                 {
                     Title = R._("Import Music File"),
                     AllowMultiple = false,
@@ -500,7 +517,7 @@ namespace FEBuilderGBA.Avalonia.Views
             if (!_vm.IsLoaded) return;
             try
             {
-                string? path = await FERepoPickHelper.PickMusic(this);
+                string? path = await FERepoPickHelper.PickMusic(TopLevel.GetTopLevel(this) as Window);
                 if (string.IsNullOrEmpty(path)) return;
                 await ImportMusicPath(path);
             }
@@ -581,7 +598,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 try
                 {
                     pick = await WindowManager.Instance.PickFromEditor<SongTrackImportSelectInstrumentView>(
-                        currentVoicegroup, this);
+                        currentVoicegroup, TopLevel.GetTopLevel(this) as Window);
                 }
                 catch (Exception exPick)
                 {
@@ -892,7 +909,7 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 pick = await WindowManager.Instance.PickFromEditor<SongTrackImportSelectInstrumentView>(
-                    currentVoicegroup, this);
+                    currentVoicegroup, TopLevel.GetTopLevel(this) as Window);
             }
             catch (Exception ex)
             {
@@ -1061,6 +1078,7 @@ namespace FEBuilderGBA.Avalonia.Views
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);
         public void SelectFirstItem() => EntryList.SelectFirst();
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         /// <summary>
         /// #1383: import a music file into the song at <paramref name="songHeaderAddr"/>

--- a/FEBuilderGBA.Avalonia/Views/SystemIconViewerView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SystemIconViewerView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.SystemIconViewerView"
-        Title="System Icon Viewer" Width="966" Height="656"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.SystemIconViewerView">
   <Grid ColumnDefinitions="250,*">
     <controls:AddressListControl AutomationProperties.AutomationId="SystemIconViewer_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
     <ScrollViewer Grid.Column="1" Margin="4">
@@ -30,4 +28,4 @@
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/SystemIconViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SystemIconViewerView.axaml.cs
@@ -1,3 +1,4 @@
+using global::Avalonia;
 using System;
 using System.IO;
 using global::Avalonia.Controls;
@@ -8,20 +9,33 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class SystemIconViewerView : TranslatedWindow, IEditorView, IDataVerifiableView
+    public partial class SystemIconViewerView : TranslatedUserControl, IEmbeddableEditor, IDataVerifiableView
     {
         readonly SystemIconViewerViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
 
         public string ViewTitle => "System Icon Viewer";
-        public bool IsLoaded => _vm.CanWrite;
+        public new bool IsLoaded => _vm.CanWrite;
+        public EditorDescriptor Descriptor => new("System Icon Viewer", 966, 656, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         public SystemIconViewerView()
         {
             InitializeComponent();
             EntryList.SelectedAddressChanged += OnSelected;
-            Opened += (_, _) => LoadList();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         void LoadList()
@@ -66,7 +80,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
         async void ExportPng_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
         {
-            await ImageDisplay.ExportPng(this, "system_icon.png");
+            await ImageDisplay.ExportPng(TopLevel.GetTopLevel(this) as Window, "system_icon.png");
         }
 
         async void ExportPal_Click(object? sender, RoutedEventArgs e)
@@ -75,7 +89,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 byte[] pal = _vm.CachedPalette;
                 if (pal == null || pal.Length < 32) { CoreState.Services.ShowError("No palette loaded"); return; }
-                await FileDialogHelper.SavePaletteFileVia(this, "system_icon_palette.pal", p =>
+                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this) as Window, "system_icon_palette.pal", p =>
                 {
                     // #1639: write via the SAF bridge so Android content:// targets work.
                     PaletteFormat fmt = PaletteFormatConverter.FormatFromExtension(System.IO.Path.GetExtension(p));
@@ -97,7 +111,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
                 // Remap to existing shared palette instead of quantizing a new one
                 var loadResult = await ImageImportService.LoadAndRemapToExistingPalette(
-                    this, 16, 16, _vm.CachedPalette, 16, strictSize: true);
+                    TopLevel.GetTopLevel(this) as Window, 16, 16, _vm.CachedPalette, 16, strictSize: true);
                 if (loadResult == null) return;
                 if (!loadResult.Success) { CoreState.Services.ShowError(loadResult.Error); return; }
 

--- a/FEBuilderGBA.Avalonia/Views/SystemIconViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SystemIconViewerView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.IO;
 using global::Avalonia.Controls;
@@ -89,7 +89,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 byte[] pal = _vm.CachedPalette;
                 if (pal == null || pal.Length < 32) { CoreState.Services.ShowError("No palette loaded"); return; }
-                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this) as Window, "system_icon_palette.pal", p =>
+                await FileDialogHelper.SavePaletteFileVia(TopLevel.GetTopLevel(this), "system_icon_palette.pal", p =>
                 {
                     // #1639: write via the SAF bridge so Android content:// targets work.
                     PaletteFormat fmt = PaletteFormatConverter.FormatFromExtension(System.IO.Path.GetExtension(p));

--- a/FEBuilderGBA.Avalonia/Views/TextViewerView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/TextViewerView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.TextViewerView"
-        Title="Text Editor" Width="1166" Height="930"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.TextViewerView">
   <Grid ColumnDefinitions="300,*">
     <controls:AddressListControl AutomationProperties.AutomationId="TextViewer_Text_List" Grid.Column="0" Name="TextList" Margin="4" />
 
@@ -255,4 +253,4 @@
       </TabItem>
     </TabControl>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/TextViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/TextViewerView.axaml.cs
@@ -547,7 +547,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                string? path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this) as Window, "TSV Files", "*.tsv");
+                string? path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this), "TSV Files", "*.tsv");
                 if (path == null) return;
 
                 int count = _vm.ImportAllTexts(path);

--- a/FEBuilderGBA.Avalonia/Views/TextViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/TextViewerView.axaml.cs
@@ -1,3 +1,4 @@
+﻿using global::Avalonia;
 using System;
 using System.Threading.Tasks;
 using global::Avalonia.Controls;
@@ -11,14 +12,17 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class TextViewerView : TranslatedWindow, IEditorView, IDataVerifiableView
+    public partial class TextViewerView : TranslatedUserControl, IEmbeddableEditor, IDataVerifiableView
     {
         readonly TextViewerViewModel _vm = new();
         readonly ConversationViewerTabViewModel _convVm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
 
         public string ViewTitle => "Text Editor";
-        public bool IsLoaded => _vm.CanWrite;
+        public new bool IsLoaded => _vm.CanWrite;
+        public EditorDescriptor Descriptor => new("Text Editor", 1166, 930, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
 
         static readonly IBrush YellowBrush = new SolidColorBrush(Colors.Orange);
         static readonly IBrush RedBrush = new SolidColorBrush(Colors.Red);
@@ -52,8 +56,14 @@ namespace FEBuilderGBA.Avalonia.Views
             // (finding 4): wire SelectionChanged + seed the initial label.
             ExportFilterCombo.SelectionChanged += OnExportFilterChanged;
             UpdateExportLimitLabel();
-            Opened += (_, _) =>
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
             {
+                _hasLoadedList = true;
                 LoadList();
                 PopulateAddressBar();
                 // Export Limit descriptor — describes the export filter that
@@ -61,7 +71,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // of read-only stub label. Re-sync in case the combo changed
                 // before the window opened.
                 UpdateExportLimitLabel();
-            };
+            }
         }
 
         /// <summary>
@@ -322,7 +332,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
                 var dlg = new TextRefAddDialogView();
                 dlg.Init(textid, existing);
-                var result = await dlg.ShowDialog<TextRefAddDialogViewModel?>(this);
+                var result = await dlg.ShowDialog<TextRefAddDialogViewModel?>(TopLevel.GetTopLevel(this) as Window);
                 if (result == null) return; // Cancelled.
 
                 // Persist via the cache seam. GetComment() applies the WF blank-entry
@@ -366,7 +376,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 var dlg = new TextScriptCategorySelectView();
                 dlg.Init(isDetail: true);
-                string? code = await dlg.ShowDialog<string?>(this);
+                string? code = await dlg.ShowDialog<string?>(TopLevel.GetTopLevel(this) as Window);
                 if (string.IsNullOrEmpty(code)) return;
 
                 // Convert the raw @XXXX code to the editor's FEditor-display form
@@ -500,7 +510,9 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 var tsvType = new FilePickerFileType(R._("TSV Files")) { Patterns = new[] { "*.tsv" } };
                 var allType = new FilePickerFileType(R._("All Files")) { Patterns = new[] { "*" } };
-                var file = await StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+                var storageProvider = TopLevel.GetTopLevel(this)?.StorageProvider;
+                if (storageProvider == null) return;
+                var file = await storageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
                 {
                     Title = R._("Export Texts"),
                     SuggestedFileName = "texts.tsv",
@@ -522,12 +534,12 @@ namespace FEBuilderGBA.Avalonia.Views
                 string? written = await FileDialogHelper.WriteViaAsync(file,
                     path => { count = _vm.ExportAllTexts(path, includeAIHints, filterIndex); });
                 if (written == null) return;
-                await MessageBoxWindow.Show(this, $"Exported {count} text entries to TSV.", R._("Export Complete"), MessageBoxMode.Ok);
+                await MessageBoxWindow.Show(TopLevel.GetTopLevel(this) as Window, $"Exported {count} text entries to TSV.", R._("Export Complete"), MessageBoxMode.Ok);
             }
             catch (Exception ex)
             {
                 Log.ErrorF("Export failed: {0}", ex.Message);
-                await MessageBoxWindow.Show(this, $"Export failed: {ex.Message}", "Error", MessageBoxMode.Ok);
+                await MessageBoxWindow.Show(TopLevel.GetTopLevel(this) as Window, $"Export failed: {ex.Message}", "Error", MessageBoxMode.Ok);
             }
         }
 
@@ -535,24 +547,24 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                string? path = await FileDialogHelper.OpenFile(this, "TSV Files", "*.tsv");
+                string? path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this) as Window, "TSV Files", "*.tsv");
                 if (path == null) return;
 
                 int count = _vm.ImportAllTexts(path);
                 if (count > 0)
                 {
                     LoadList(); // Refresh the list to show updated texts
-                    await MessageBoxWindow.Show(this, $"Imported {count} text entries.", R._("Import Complete"), MessageBoxMode.Ok);
+                    await MessageBoxWindow.Show(TopLevel.GetTopLevel(this) as Window, $"Imported {count} text entries.", R._("Import Complete"), MessageBoxMode.Ok);
                 }
                 else
                 {
-                    await MessageBoxWindow.Show(this, R._("No texts were imported. Check the file format."), "Import", MessageBoxMode.Ok);
+                    await MessageBoxWindow.Show(TopLevel.GetTopLevel(this) as Window, R._("No texts were imported. Check the file format."), "Import", MessageBoxMode.Ok);
                 }
             }
             catch (Exception ex)
             {
                 Log.ErrorF("Import failed: {0}", ex.Message);
-                await MessageBoxWindow.Show(this, $"Import failed: {ex.Message}", "Error", MessageBoxMode.Ok);
+                await MessageBoxWindow.Show(TopLevel.GetTopLevel(this) as Window, $"Import failed: {ex.Message}", "Error", MessageBoxMode.Ok);
             }
         }
 
@@ -576,7 +588,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             string dialogText = R.Error("文字:{0}はシステムに登録されていません。", error);
             var popup = new TextBadCharPopupView(dialogText);
-            return popup.ShowDialog<string?>(this);
+            return popup.ShowDialog<string?>(TopLevel.GetTopLevel(this) as Window);
         }
 
         Task OpenPatchManagerModalDefaultAsync()
@@ -584,7 +596,7 @@ namespace FEBuilderGBA.Avalonia.Views
             // Open the Patch Manager as a MODAL dialog and AWAIT it — WriteText's
             // subsequent re-check only sees a freshly-installed patch if we block
             // here until the user closes the Patch Manager (Copilot finding 1).
-            return WindowManager.Instance.OpenModal<PatchManagerView>(this);
+            return WindowManager.Instance.OpenModal<PatchManagerView>(TopLevel.GetTopLevel(this) as Window);
         }
 
         async void OnWriteTextClick(object? sender, RoutedEventArgs e)
@@ -938,5 +950,6 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/ToolAllWorkSupportView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ToolAllWorkSupportView.axaml
@@ -1,10 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:views="clr-namespace:FEBuilderGBA.Avalonia.Views"
-        x:Class="FEBuilderGBA.Avalonia.Views.ToolAllWorkSupportView"
-        Title="All Work Support" Width="1024" Height="700"
-        WindowStartupLocation="CenterScreen"
-        SizeToContent="Manual">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:views="clr-namespace:FEBuilderGBA.Avalonia.Views"
+             x:Class="FEBuilderGBA.Avalonia.Views.ToolAllWorkSupportView">
   <DockPanel Margin="12">
     <TextBlock AutomationProperties.AutomationId="ToolAllWorkSupport_Header_Label"
                DockPanel.Dock="Top" Name="HeaderLabel" Text="All Work Support"
@@ -67,4 +64,4 @@
       </ItemsControl>
     </ScrollViewer>
   </DockPanel>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/ToolAllWorkSupportView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolAllWorkSupportView.axaml.cs
@@ -1,4 +1,5 @@
 #nullable enable annotations
+using global::Avalonia;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -18,13 +19,17 @@ namespace FEBuilderGBA.Avalonia.Views
     /// opens that project's ROM in the main window. Mirrors WinForms
     /// <c>ToolAllWorkSupportForm</c>.
     /// </summary>
-    public partial class ToolAllWorkSupportView : TranslatedWindow, IEditorView
+    public partial class ToolAllWorkSupportView : TranslatedUserControl, IEmbeddableEditor
     {
         readonly ToolAllWorkSupportViewModel _vm = new();
+        bool _hasLoadedList;
         readonly List<WorkProjectTileItem> _tiles = new();
 
         public string ViewTitle => "All Work Support";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("All Work Support", 1024, 700, StartupLocation: WindowStartupLocation.CenterScreen);
+        public event EventHandler? CloseRequested;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         public ToolAllWorkSupportView()
         {
@@ -34,8 +39,22 @@ namespace FEBuilderGBA.Avalonia.Views
             HintLabel.Text = R._("Click a project to open its ROM.");
             UpdateCheckButton.Content = R._("Check Updates");
 
-            Opened += (_, _) => LoadList();
-            Closed += (_, _) => DisposeTiles();
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromVisualTree(e);
+            DisposeTiles();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         void LoadList()
@@ -129,7 +148,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 string path = tile.RomFilename;
                 if (string.IsNullOrEmpty(path) || !File.Exists(path))
                 {
-                    _ = MessageBoxWindow.Show(this,
+                    _ = MessageBoxWindow.Show(TopLevel.GetTopLevel(this) as Window,
                         R._("File not found:") + $" {path}", R._("Error"), MessageBoxMode.Ok);
                     return;
                 }
@@ -139,11 +158,11 @@ namespace FEBuilderGBA.Avalonia.Views
                     bool ok = mw.LoadRomFile(path);
                     if (ok)
                     {
-                        Close();
+                        RequestClose();
                     }
                     else
                     {
-                        _ = MessageBoxWindow.Show(this,
+                        _ = MessageBoxWindow.Show(TopLevel.GetTopLevel(this) as Window,
                             R._("Failed to load ROM:") + $" {path}", R._("Error"), MessageBoxMode.Ok);
                     }
                 }

--- a/FEBuilderGBA.Avalonia/Views/ToolAutomaticRecoveryROMHeaderView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolAutomaticRecoveryROMHeaderView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -32,7 +32,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this) as Window);
+                var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this));
                 if (!string.IsNullOrEmpty(path))
                     _vm.OriginalFilename = path;
             }

--- a/FEBuilderGBA.Avalonia/Views/ToolDiffDebugSelectView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolDiffDebugSelectView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -31,7 +31,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this) as Window);
+                var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this));
                 if (!string.IsNullOrEmpty(path))
                 {
                     _vm.OriginalFilename = path;

--- a/FEBuilderGBA.Avalonia/Views/ToolDiffView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ToolDiffView.axaml
@@ -1,8 +1,6 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        x:Class="FEBuilderGBA.Avalonia.Views.ToolDiffView"
-        Title="ROM Diff Tool" Width="820" Height="500"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="FEBuilderGBA.Avalonia.Views.ToolDiffView">
   <DockPanel Margin="12">
     <TextBlock DockPanel.Dock="Top" Text="ROM Diff Tool" FontSize="18" FontWeight="Bold" Margin="0,0,0,8" />
 
@@ -66,4 +64,4 @@
 
     </TabControl>
   </DockPanel>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/ToolDiffView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolDiffView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -30,7 +30,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
         async void OtherBrowse_Click(object? sender, RoutedEventArgs e)
         {
-            var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this) as Window);
+            var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this));
             if (!string.IsNullOrEmpty(path))
                 _vm.OtherPath = path;
         }
@@ -62,14 +62,14 @@ namespace FEBuilderGBA.Avalonia.Views
 
         async void ABrowse_Click(object? sender, RoutedEventArgs e)
         {
-            var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this) as Window);
+            var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this));
             if (!string.IsNullOrEmpty(path))
                 _vm.AFilePath = path;
         }
 
         async void BBrowse_Click(object? sender, RoutedEventArgs e)
         {
-            var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this) as Window);
+            var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this));
             if (!string.IsNullOrEmpty(path))
                 _vm.BFilePath = path;
         }

--- a/FEBuilderGBA.Avalonia/Views/ToolDiffView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolDiffView.axaml.cs
@@ -1,3 +1,4 @@
+using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -8,12 +9,15 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ToolDiffView : TranslatedWindow, IEditorView
+    public partial class ToolDiffView : TranslatedUserControl, IEmbeddableEditor
     {
         readonly ToolDiffViewModel _vm = new();
 
         public string ViewTitle => "ROM Diff Tool";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("ROM Diff Tool", 820, 500, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         public ToolDiffView()
         {
@@ -26,14 +30,16 @@ namespace FEBuilderGBA.Avalonia.Views
 
         async void OtherBrowse_Click(object? sender, RoutedEventArgs e)
         {
-            var path = await FileDialogHelper.OpenRomFile(this);
+            var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this) as Window);
             if (!string.IsNullOrEmpty(path))
                 _vm.OtherPath = path;
         }
 
         async void MakeBinPatch_Click(object? sender, RoutedEventArgs e)
         {
-            var file = await StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            var storageProvider = TopLevel.GetTopLevel(this)?.StorageProvider;
+            if (storageProvider == null) return;
+            var file = await storageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
             {
                 Title = R._("Save Binary Patch File"),
                 SuggestedFileName = "PATCH_diff.txt",
@@ -56,21 +62,23 @@ namespace FEBuilderGBA.Avalonia.Views
 
         async void ABrowse_Click(object? sender, RoutedEventArgs e)
         {
-            var path = await FileDialogHelper.OpenRomFile(this);
+            var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this) as Window);
             if (!string.IsNullOrEmpty(path))
                 _vm.AFilePath = path;
         }
 
         async void BBrowse_Click(object? sender, RoutedEventArgs e)
         {
-            var path = await FileDialogHelper.OpenRomFile(this);
+            var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this) as Window);
             if (!string.IsNullOrEmpty(path))
                 _vm.BFilePath = path;
         }
 
         async void MakeBinPatch3_Click(object? sender, RoutedEventArgs e)
         {
-            var file = await StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            var storageProvider = TopLevel.GetTopLevel(this)?.StorageProvider;
+            if (storageProvider == null) return;
+            var file = await storageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
             {
                 Title = R._("Save 3-Way Binary Patch File"),
                 SuggestedFileName = "PATCH_diff3.txt",

--- a/FEBuilderGBA.Avalonia/Views/ToolExportEAEventView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ToolExportEAEventView.axaml
@@ -1,9 +1,6 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        x:Class="FEBuilderGBA.Avalonia.Views.ToolExportEAEventView"
-        Title="Export EA Event" Width="1096" Height="784"
-        WindowStartupLocation="CenterOwner"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="FEBuilderGBA.Avalonia.Views.ToolExportEAEventView">
   <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
   <Grid ColumnDefinitions="284,*" Margin="11">
     <!-- Left panel: Map list (WinForms panel14 with MAP_LISTBOX) -->
@@ -73,4 +70,4 @@
     </Border>
   </Grid>
   </ScrollViewer>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/ToolExportEAEventView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolExportEAEventView.axaml.cs
@@ -1,3 +1,4 @@
+using global::Avalonia;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -11,11 +12,14 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ToolExportEAEventView : TranslatedWindow, IEditorView
+    public partial class ToolExportEAEventView : TranslatedUserControl, IEmbeddableEditor
     {
         readonly ToolExportEAEventViewViewModel _vm = new();
         public string ViewTitle => "Export EA Event";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("Export EA Event", 1096, 784, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         static FilePickerFileType EaFileType => new(R._("EA Event Files")) { Patterns = new[] { "*.event" } };
         static FilePickerFileType AllFileType => new(R._("All Files")) { Patterns = new[] { "*" } };
@@ -48,7 +52,9 @@ namespace FEBuilderGBA.Avalonia.Views
 
         async System.Threading.Tasks.Task<global::Avalonia.Platform.Storage.IStorageFile?> PickSaveFile(string suggestedName)
         {
-            return await this.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            var storageProvider = TopLevel.GetTopLevel(this)?.StorageProvider;
+            if (storageProvider == null) return null;
+            return await storageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
             {
                 Title = R._("Export EA Event"),
                 SuggestedFileName = suggestedName,

--- a/FEBuilderGBA.Avalonia/Views/ToolLZ77View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ToolLZ77View.axaml
@@ -1,8 +1,6 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        x:Class="FEBuilderGBA.Avalonia.Views.ToolLZ77View"
-        Title="LZ77 Compression Tool" Width="780" Height="500"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="FEBuilderGBA.Avalonia.Views.ToolLZ77View">
   <DockPanel Margin="12">
     <TextBlock DockPanel.Dock="Top" Text="LZ77 Compression Tool" FontSize="18" FontWeight="Bold" Margin="0,0,0,8" />
 
@@ -143,4 +141,4 @@
 
     </TabControl>
   </DockPanel>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/ToolLZ77View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolLZ77View.axaml.cs
@@ -1,3 +1,4 @@
+using global::Avalonia;
 using System;
 using System.Threading.Tasks;
 using global::Avalonia.Controls;
@@ -9,7 +10,7 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class ToolLZ77View : TranslatedWindow, IEditorView
+    public partial class ToolLZ77View : TranslatedUserControl, IEmbeddableEditor
     {
         readonly ToolLZ77ViewModel _vm = new();
 
@@ -20,7 +21,10 @@ namespace FEBuilderGBA.Avalonia.Views
         IStorageFile? _compressDestFile;
 
         public string ViewTitle => "LZ77 Compression Tool";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("LZ77 Compression Tool", 780, 500, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         public ToolLZ77View()
         {
@@ -31,14 +35,16 @@ namespace FEBuilderGBA.Avalonia.Views
 
         async void DecompressSrcBrowse_Click(object? sender, RoutedEventArgs e)
         {
-            var path = await FileDialogHelper.OpenFile(this, "Open source file", "*");
+            var path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this) as Window, "Open source file", "*");
             if (!string.IsNullOrEmpty(path))
                 _vm.DecompressSrcPath = path;
         }
 
         async void DecompressDestBrowse_Click(object? sender, RoutedEventArgs e)
         {
-            var file = await StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            var storageProvider = TopLevel.GetTopLevel(this)?.StorageProvider;
+            if (storageProvider == null) return;
+            var file = await storageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
             {
                 Title = R._("Save Decompressed File"),
                 SuggestedFileName = "decompressed.bin",
@@ -81,14 +87,16 @@ namespace FEBuilderGBA.Avalonia.Views
 
         async void CompressSrcBrowse_Click(object? sender, RoutedEventArgs e)
         {
-            var path = await FileDialogHelper.OpenFile(this, "Open source file", "*");
+            var path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this) as Window, "Open source file", "*");
             if (!string.IsNullOrEmpty(path))
                 _vm.CompressSrcPath = path;
         }
 
         async void CompressDestBrowse_Click(object? sender, RoutedEventArgs e)
         {
-            var file = await StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            var storageProvider = TopLevel.GetTopLevel(this)?.StorageProvider;
+            if (storageProvider == null) return;
+            var file = await storageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
             {
                 Title = R._("Save Compressed File"),
                 SuggestedFileName = "compressed.bin",
@@ -135,7 +143,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
             if (_vm.ZeroClearNeedsConfirmation(from, to))
             {
-                var result = await MessageBoxWindow.Show(this,
+                var result = await MessageBoxWindow.Show(TopLevel.GetTopLevel(this) as Window,
                     R._("Zeroing 0x{0:X8}..0x{1:X8} hits a dangerous low-address region (ROM header, fixed tables). Continue?", from, to),
                     R._("Confirm Zero Clear"),
                     MessageBoxMode.YesNo);
@@ -151,7 +159,9 @@ namespace FEBuilderGBA.Avalonia.Views
 
         async void Base64TextToFile_Click(object? sender, RoutedEventArgs e)
         {
-            var file = await StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            var storageProvider = TopLevel.GetTopLevel(this)?.StorageProvider;
+            if (storageProvider == null) return;
+            var file = await storageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
             {
                 Title = R._("Save Decoded File"),
                 SuggestedFileName = "decoded.bin",
@@ -163,7 +173,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
         async void FileToBase64Text_Click(object? sender, RoutedEventArgs e)
         {
-            var path = await FileDialogHelper.OpenFile(this, R._("Open file to encode as base64"), "*");
+            var path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this) as Window, R._("Open file to encode as base64"), "*");
             if (!string.IsNullOrEmpty(path))
                 _vm.RunFileToBase64Text(path);
         }
@@ -183,7 +193,7 @@ namespace FEBuilderGBA.Avalonia.Views
             // Optional raw-fallback warning.
             if (preflight == ToolLZ77ViewModel.MovePreflightResult.NeedRawFallbackConfirm)
             {
-                var dr = await MessageBoxWindow.Show(this,
+                var dr = await MessageBoxWindow.Show(TopLevel.GetTopLevel(this) as Window,
                     R._("LDR pointer search returned no hits. Falling back to a raw 4-byte binary pointer scan (may match unrelated bytes). Continue?"),
                     R._("Confirm Raw Pointer Fallback"),
                     MessageBoxMode.YesNo);
@@ -200,7 +210,7 @@ namespace FEBuilderGBA.Avalonia.Views
             // Optional pointer-count warning.
             if (preflight == ToolLZ77ViewModel.MovePreflightResult.NeedPointerCountConfirm)
             {
-                var dr = await MessageBoxWindow.Show(this,
+                var dr = await MessageBoxWindow.Show(TopLevel.GetTopLevel(this) as Window,
                     R._("{0} pointer reference(s) will be rewritten. Continue?", sp.Pointers.Count),
                     R._("Confirm Multi-Pointer Move"),
                     MessageBoxMode.YesNo);
@@ -216,7 +226,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
 
             // Final main-confirm prompt.
-            var confirm = await MessageBoxWindow.Show(this,
+            var confirm = await MessageBoxWindow.Show(TopLevel.GetTopLevel(this) as Window,
                 R._("Move 0x{0:X} bytes from 0x{1:X8} to 0x{2:X8}{3}?",
                     length, srcOffset, dstOffset,
                     dstOffset == 0 ? " (auto-allocate)" : ""),
@@ -246,7 +256,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
             if (preflight == ToolLZ77ViewModel.RecompressPreflightResult.NeedRomModifiedAck)
             {
-                var dr = await MessageBoxWindow.Show(this,
+                var dr = await MessageBoxWindow.Show(TopLevel.GetTopLevel(this) as Window,
                     R._("ROM has unsaved modifications. Save first before recompressing? (Pressing No will proceed anyway, which is risky.)"),
                     R._("Confirm Recompress"),
                     MessageBoxMode.YesNo);
@@ -261,7 +271,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
             if (preflight == ToolLZ77ViewModel.RecompressPreflightResult.NeedConfirm)
             {
-                var dr = await MessageBoxWindow.Show(this,
+                var dr = await MessageBoxWindow.Show(TopLevel.GetTopLevel(this) as Window,
                     R._("Run LZ77 recompress? This walks the entire ROM (slow) and rewrites any entries that compress smaller. Heuristic scan — may miss entries WinForms catches."),
                     R._("Confirm Recompress"),
                     MessageBoxMode.YesNo);

--- a/FEBuilderGBA.Avalonia/Views/ToolLZ77View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolLZ77View.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.Threading.Tasks;
 using global::Avalonia.Controls;
@@ -35,7 +35,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
         async void DecompressSrcBrowse_Click(object? sender, RoutedEventArgs e)
         {
-            var path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this) as Window, "Open source file", "*");
+            var path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this), "Open source file", "*");
             if (!string.IsNullOrEmpty(path))
                 _vm.DecompressSrcPath = path;
         }
@@ -87,7 +87,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
         async void CompressSrcBrowse_Click(object? sender, RoutedEventArgs e)
         {
-            var path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this) as Window, "Open source file", "*");
+            var path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this), "Open source file", "*");
             if (!string.IsNullOrEmpty(path))
                 _vm.CompressSrcPath = path;
         }
@@ -173,7 +173,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
         async void FileToBase64Text_Click(object? sender, RoutedEventArgs e)
         {
-            var path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this) as Window, R._("Open file to encode as base64"), "*");
+            var path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this), R._("Open file to encode as base64"), "*");
             if (!string.IsNullOrEmpty(path))
                 _vm.RunFileToBase64Text(path);
         }

--- a/FEBuilderGBA.Avalonia/Views/ToolROMRebuildView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolROMRebuildView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -75,7 +75,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                string? path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this) as Window);
+                string? path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this));
                 if (!string.IsNullOrEmpty(path))
                     OriginalRomTextBox.Text = path;
             }
@@ -147,7 +147,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // flow — it needs a real local path. Pick the handle so we can tell
                 // a genuine CANCEL (null handle → silent return) apart from a SAF
                 // pick with no local path (→ explicit Android message).
-                var outFile = await FileDialogHelper.SaveRomFilePick(TopLevel.GetTopLevel(this) as Window, suggested);
+                var outFile = await FileDialogHelper.SaveRomFilePick(TopLevel.GetTopLevel(this), suggested);
                 if (outFile == null) return;   // user cancelled
                 string? output = outFile.TryGetLocalPath();
                 if (string.IsNullOrEmpty(output))
@@ -222,7 +222,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // (path-based, revealed in the explorer). Pick the handle so a
                 // genuine CANCEL (null handle) is distinguished from a SAF pick
                 // with no local path (→ explicit Android message).
-                var outFile = await FileDialogHelper.SaveFilePick(TopLevel.GetTopLevel(this) as Window,
+                var outFile = await FileDialogHelper.SaveFilePick(TopLevel.GetTopLevel(this),
                     R._("Save ROMRebuild report"), R._("ROMRebuild report"), "*.rebuild", suggested);
                 if (outFile == null) return;   // user cancelled
                 string? output = outFile.TryGetLocalPath();

--- a/FEBuilderGBA.Avalonia/Views/ToolThreeMargeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolThreeMargeView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -27,21 +27,21 @@ namespace FEBuilderGBA.Avalonia.Views
 
         async void BrowseOriginal_Click(object? sender, RoutedEventArgs e)
         {
-            var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this) as Window);
+            var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this));
             if (path != null)
                 _vm.OriginalPath = path;
         }
 
         async void BrowseMine_Click(object? sender, RoutedEventArgs e)
         {
-            var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this) as Window);
+            var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this));
             if (path != null)
                 _vm.MyPath = path;
         }
 
         async void BrowseTheirs_Click(object? sender, RoutedEventArgs e)
         {
-            var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this) as Window);
+            var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this));
             if (path != null)
                 _vm.TheirsPath = path;
         }
@@ -59,7 +59,7 @@ namespace FEBuilderGBA.Avalonia.Views
             // write through the SAF bridge so Android content:// targets work.
             // SaveMerged returns false (no write) on no merge result — the bridge's
             // missing-output guard then returns null, so nothing is streamed back.
-            var file = await FileDialogHelper.SaveRomFilePick(TopLevel.GetTopLevel(this) as Window, "merged.gba");
+            var file = await FileDialogHelper.SaveRomFilePick(TopLevel.GetTopLevel(this), "merged.gba");
             if (file == null) return;
             string? written = await FileDialogHelper.WriteViaAsync(file, p => _vm.SaveMerged(p));
             // On a SAF target the VM's status shows the temp path; rewrite it with

--- a/FEBuilderGBA.Avalonia/Views/ToolTranslateROMView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolTranslateROMView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.IO;
 using System.Linq;
@@ -51,7 +51,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this) as Window);
+                var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this));
                 if (!string.IsNullOrEmpty(path)) _vm.FromRomPath = path;
             }
             catch (Exception ex) { Log.ErrorF("ToolTranslateROMView.SimpleFromRomBrowse: {0}", ex.Message); }
@@ -61,7 +61,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this) as Window);
+                var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this));
                 if (!string.IsNullOrEmpty(path)) _vm.ToRomPath = path;
             }
             catch (Exception ex) { Log.ErrorF("ToolTranslateROMView.SimpleToRomBrowse: {0}", ex.Message); }
@@ -71,7 +71,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this) as Window);
+                var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this));
                 if (!string.IsNullOrEmpty(path)) _vm.ExtraFontRomPath = path;
             }
             catch (Exception ex) { Log.ErrorF("ToolTranslateROMView.ExtraFontRomBrowse: {0}", ex.Message); }
@@ -81,7 +81,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                var path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this) as Window,
+                var path = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this),
                     R._("Translation Data"), "*.txt");
                 if (!string.IsNullOrEmpty(path)) _vm.TranslateDataPath = path;
             }
@@ -94,7 +94,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this) as Window);
+                var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this));
                 if (!string.IsNullOrEmpty(path)) _vm.FromRomPath = path;
             }
             catch (Exception ex) { Log.ErrorF("ToolTranslateROMView.DetailFromRomBrowse: {0}", ex.Message); }
@@ -104,7 +104,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this) as Window);
+                var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this));
                 if (!string.IsNullOrEmpty(path)) _vm.ToRomPath = path;
             }
             catch (Exception ex) { Log.ErrorF("ToolTranslateROMView.DetailToRomBrowse: {0}", ex.Message); }
@@ -114,7 +114,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this) as Window);
+                var path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this));
                 if (!string.IsNullOrEmpty(path)) _vm.FontRomPath = path;
             }
             catch (Exception ex) { Log.ErrorF("ToolTranslateROMView.FontRomBrowse: {0}", ex.Message); }
@@ -239,7 +239,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
             // #1639: pick the handle now; the actual single-file write is routed
             // through the SAF bridge below so Android content:// targets work.
-            var outFile = await FileDialogHelper.SaveFilePick(TopLevel.GetTopLevel(this) as Window,
+            var outFile = await FileDialogHelper.SaveFilePick(TopLevel.GetTopLevel(this),
                 R._("Save translation file"), "Text", "*.txt", "translation.txt");
             if (outFile == null) return;
 
@@ -292,7 +292,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 return;
             }
 
-            string? inPath = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this) as Window,
+            string? inPath = await FileDialogHelper.OpenFile(TopLevel.GetTopLevel(this),
                 R._("Open translation file"), "*.txt");
             if (string.IsNullOrEmpty(inPath)) return;
 

--- a/FEBuilderGBA.Avalonia/Views/ToolUPSOpenSimpleView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolUPSOpenSimpleView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.IO;
 using global::Avalonia.Controls;
@@ -47,7 +47,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                string? path = await FileDialogHelper.OpenPatchFile(TopLevel.GetTopLevel(this) as Window);
+                string? path = await FileDialogHelper.OpenPatchFile(TopLevel.GetTopLevel(this));
                 if (string.IsNullOrEmpty(path))
                     return;
                 UpsTextBox.Text = path;
@@ -70,7 +70,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                string? path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this) as Window);
+                string? path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this));
                 if (!string.IsNullOrEmpty(path))
                     OriginalRomTextBox.Text = path;
             }
@@ -150,7 +150,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (SaveAsGbaCheck.IsChecked == true)
                 {
                     string suggested = Path.GetFileNameWithoutExtension(ups) + ".gba";
-                    saveFile = await FileDialogHelper.SaveRomFilePick(TopLevel.GetTopLevel(this) as Window, suggested);
+                    saveFile = await FileDialogHelper.SaveRomFilePick(TopLevel.GetTopLevel(this), suggested);
                     if (saveFile == null)
                         return;   // user cancelled
                     string? local = saveFile.TryGetLocalPath();

--- a/FEBuilderGBA.Avalonia/Views/ToolUPSPatchSimpleView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolUPSPatchSimpleView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -44,7 +44,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                string? path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this) as Window);
+                string? path = await FileDialogHelper.OpenRomFile(TopLevel.GetTopLevel(this));
                 if (!string.IsNullOrEmpty(path))
                     OriginalRomTextBox.Text = path;
             }
@@ -68,7 +68,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 string suggested = ToolUPSPatchSimpleViewModel.SuggestedName(DateTime.Now.ToString("yyyyMMddHHmmss"));
                 // #1639: the .ups patch is a single-file output → pick the handle
                 // and write through the SAF bridge so Android content:// targets work.
-                var file = await FileDialogHelper.SaveUpsFilePick(TopLevel.GetTopLevel(this) as Window, suggested);
+                var file = await FileDialogHelper.SaveUpsFilePick(TopLevel.GetTopLevel(this), suggested);
                 if (file == null)
                     return;   // user cancelled
 

--- a/FEBuilderGBA.Avalonia/Views/UnitEditorView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/UnitEditorView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.UnitEditorView"
-        Title="Unit Editor" Width="934" Height="661"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.UnitEditorView">
   <Grid ColumnDefinitions="250,*" RowDefinitions="Auto,*">
     <!-- Address-bar infrastructure (top of left column) - matches WF UnitForm
          "Read Start Address / Read Count / Reload" trio (#413).
@@ -357,4 +355,4 @@
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/UnitEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/UnitEditorView.axaml.cs
@@ -1,3 +1,4 @@
+﻿using global::Avalonia;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,16 +12,19 @@ using FEBuilderGBA.Core;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class UnitEditorView : TranslatedWindow, IPickableEditor, IDataVerifiableView
+    public partial class UnitEditorView : TranslatedUserControl, IEmbeddableEditor, IPickableEditor, IDataVerifiableView
     {
         readonly UnitEditorViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
 
         List<(uint id, string name)> _classList = new();
         List<(uint id, string name)> _affinityList = new();
 
         public string ViewTitle => R._("Unit Editor");
-        public bool IsLoaded => _vm.CanWrite;
+        public new bool IsLoaded => _vm.CanWrite;
+        public EditorDescriptor Descriptor => new("Unit Editor", 934, 661, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
 
         public event Action<PickResult>? SelectionConfirmed;
 
@@ -29,7 +33,6 @@ namespace FEBuilderGBA.Avalonia.Views
             InitializeComponent();
             UnitList.SelectedAddressChanged += OnUnitSelected;
             UnitList.SelectionConfirmed += result => SelectionConfirmed?.Invoke(result);
-            Opened += (_, _) => { LoadList(); UpdateAddressBarInfra(); };
 
             // Ability flag names are set in LoadList() based on ROM version
 
@@ -47,6 +50,16 @@ namespace FEBuilderGBA.Avalonia.Views
 
             // #358: jump to Support Unit Editor for this unit's support row.
             JumpToSupportUnitButton.Click += JumpToSupportUnit_Click;
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadList(); UpdateAddressBarInfra();
+            }
         }
 
         /// <summary>
@@ -641,9 +654,9 @@ namespace FEBuilderGBA.Avalonia.Views
 
                 PickResult? result;
                 if (CoreState.ROM?.RomInfo?.version == 6)
-                    result = await WindowManager.Instance.PickFromEditor<ClassFE6View>(navAddr, this);
+                    result = await WindowManager.Instance.PickFromEditor<ClassFE6View>(navAddr, TopLevel.GetTopLevel(this) as Window);
                 else
-                    result = await WindowManager.Instance.PickFromEditor<ClassEditorView>(navAddr, this);
+                    result = await WindowManager.Instance.PickFromEditor<ClassEditorView>(navAddr, TopLevel.GetTopLevel(this) as Window);
                 if (result != null)
                 {
                     // result.Index is the class list index — set the combo
@@ -671,7 +684,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (dataSize == 0) dataSize = 28;
                 uint navAddr = U.isSafetyOffset(baseAddr) ? baseAddr + portraitId * dataSize : 0;
 
-                var result = await WindowManager.Instance.PickFromEditor<PortraitViewerView>(navAddr, this);
+                var result = await WindowManager.Instance.PickFromEditor<PortraitViewerView>(navAddr, TopLevel.GetTopLevel(this) as Window);
                 if (result != null)
                 {
                     PortraitIdBox.Value = result.Index;
@@ -707,6 +720,7 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         void EditSkills_Click(object? sender, RoutedEventArgs e)
         {
@@ -851,7 +865,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (rom == null) return;
                 var addrs = GetAllUnitAddresses();
                 if (addrs.Length == 0) return;
-                await MakeCsvManager().ExportAllAsync(this, rom, addrs);
+                await MakeCsvManager().ExportAllAsync(TopLevel.GetTopLevel(this) as Window, rom, addrs);
             }
             catch (Exception ex) { Log.ErrorF("ExportAll_Click failed: {0}", ex.Message); }
         }
@@ -869,7 +883,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // record. Falls back to 0 when no selection is resolvable.
                 int idx = UnitList.SelectedOriginalIndex;
                 uint uid = idx >= 0 ? (uint)idx : 0u;
-                await MakeCsvManager().ExportSelectedAsync(this, rom, _vm.CurrentAddr, uid);
+                await MakeCsvManager().ExportSelectedAsync(TopLevel.GetTopLevel(this) as Window, rom, _vm.CurrentAddr, uid);
             }
             catch (Exception ex) { Log.ErrorF("ExportSelected_Click failed: {0}", ex.Message); }
         }
@@ -887,7 +901,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // scope only wraps the actual ROM writes. Opening Begin/Commit
                 // across an `await` would risk capturing unrelated writes
                 // that happen while the picker dialog is open.
-                string? csv = await mgr.ReadCsvForUiAsync(this);
+                string? csv = await mgr.ReadCsvForUiAsync(TopLevel.GetTopLevel(this) as Window);
                 if (csv == null) return;
                 _undoService.Begin(R._("Import Units CSV"));
                 int written;
@@ -915,7 +929,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (_vm.CurrentAddr == 0) return;
                 var mgr = MakeCsvManager();
                 // Read CSV first (no undo scope across the picker await).
-                string? csv = await mgr.ReadCsvForUiAsync(this);
+                string? csv = await mgr.ReadCsvForUiAsync(TopLevel.GetTopLevel(this) as Window);
                 if (csv == null) return;
                 // #1016: thread the SELECTED unit id (0-based AddressList index)
                 // so the FE8U MagicSplit MAG column is read into the correct

--- a/FEBuilderGBA.Avalonia/Views/UnitIncreaseHeightView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/UnitIncreaseHeightView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.UnitIncreaseHeightView"
-        Title="Unit Height Adjustment" Width="1185" Height="658"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.UnitIncreaseHeightView">
   <Grid ColumnDefinitions="250,*">
     <controls:AddressListControl AutomationProperties.AutomationId="UnitIncreaseHeight_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
 
@@ -28,4 +26,4 @@
       </StackPanel>
     </ScrollViewer>
   </Grid>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/UnitIncreaseHeightView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/UnitIncreaseHeightView.axaml.cs
@@ -1,4 +1,4 @@
-using global::Avalonia;
+﻿using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -41,7 +41,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
             // TranslatedWindow auto-translates Text/Content, but NOT ComboBox items — rebuild the
             // combo labels ourselves on a runtime language change (preserving the selection).
-            CoreState.LanguageChanged += RebuildHeightCombo;
 
         }
 
@@ -54,6 +53,8 @@ namespace FEBuilderGBA.Avalonia.Views
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {
             base.OnAttachedToVisualTree(e);
+            CoreState.LanguageChanged -= RebuildHeightCombo;
+            CoreState.LanguageChanged += RebuildHeightCombo;
             if (!_hasLoadedList)
             {
                 _hasLoadedList = true;

--- a/FEBuilderGBA.Avalonia/Views/UnitIncreaseHeightView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/UnitIncreaseHeightView.axaml.cs
@@ -1,3 +1,4 @@
+using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -6,10 +7,11 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class UnitIncreaseHeightView : TranslatedWindow, IEditorView, IDataVerifiableView
+    public partial class UnitIncreaseHeightView : TranslatedUserControl, IEmbeddableEditor, IDataVerifiableView
     {
         readonly UnitIncreaseHeightViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
 
         // True once Opened -> LoadList() has populated EntryList. A NavigateTo
         // request that arrives BEFORE the list loads (WindowManager.Open then an
@@ -22,7 +24,9 @@ namespace FEBuilderGBA.Avalonia.Views
         bool _syncing;
 
         public string ViewTitle => "Unit Height Adjustment";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("Unit Height Adjustment", 1185, 658, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
 
         public UnitIncreaseHeightView()
         {
@@ -38,9 +42,23 @@ namespace FEBuilderGBA.Avalonia.Views
             // TranslatedWindow auto-translates Text/Content, but NOT ComboBox items — rebuild the
             // combo labels ourselves on a runtime language change (preserving the selection).
             CoreState.LanguageChanged += RebuildHeightCombo;
-            Closed += (_, _) => CoreState.LanguageChanged -= RebuildHeightCombo;
 
-            Opened += (_, _) => LoadList();
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromVisualTree(e);
+            CoreState.LanguageChanged -= RebuildHeightCombo;
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadList();
+            }
         }
 
         void RebuildHeightCombo()
@@ -198,5 +216,6 @@ namespace FEBuilderGBA.Avalonia.Views
 
         public void SelectFirstItem() => EntryList.SelectFirst();
         public ViewModelBase? DataViewModel => _vm;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/FEBuilderGBA.Avalonia/Views/WorldMapImageFE6View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapImageFE6View.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.WorldMapImageFE6View"
-        Title="World Map Image (FE6)" Width="900" Height="720"
-        SizeToContent="Width">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.WorldMapImageFE6View">
   <!-- World Map Image (FE6) editor (#1183) — port of WF WorldMapImageFE6Form.
        The FE6 world map is a FLAT 256-color LINEAR raster (NOT the FE7/FE8
        header-TSA), with FIVE zoom views (full + 4 quadrants NW/NE/SW/SE), each
@@ -203,4 +201,4 @@
       </StackPanel>
     </ScrollViewer>
   </DockPanel>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/WorldMapImageFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapImageFE6View.axaml.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+﻿// SPDX-License-Identifier: GPL-3.0-or-later
 // World Map Image (FE6) editor view (#1183) — port of WF WorldMapImageFE6Form.
 // Five GbaImageControl previews (full + 4 quadrants NW/NE/SW/SE), each with a
 // per-zoom PNG Import (file dialog -> validate 240x160 -> Core 256-linear import
@@ -118,7 +118,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                string? path = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this) as Window);
+                string? path = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this));
                 if (path == null) return;
                 await DoImport(slotByteOffset, path, target, render, label);
             }

--- a/FEBuilderGBA.Avalonia/Views/WorldMapImageFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapImageFE6View.axaml.cs
@@ -8,6 +8,7 @@
 // "AllWriteButton"). Mirrors the FE7 view's preview/import/export/undo idioms.
 // All Log.Error calls pass a single interpolated string (Core Log.Error is
 // params string[] — no {0}/{1} composite substitution).
+using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -18,19 +19,32 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class WorldMapImageFE6View : TranslatedWindow, IEditorView
+    public partial class WorldMapImageFE6View : TranslatedUserControl, IEmbeddableEditor
     {
         readonly WorldMapImageFE6ViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
 
         public string ViewTitle => "World Map Image (FE6)";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("World Map Image (FE6)", 900, 720, SizeToContent: global::Avalonia.Controls.SizeToContent.Width);
+        public event EventHandler? CloseRequested;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         public WorldMapImageFE6View()
         {
             InitializeComponent();
             DataContext = _vm;
-            Opened += (_, _) => Load();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                Load();
+            }
         }
 
         void Load()
@@ -104,7 +118,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                string? path = await FileDialogHelper.OpenImageFile(this);
+                string? path = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this) as Window);
                 if (path == null) return;
                 await DoImport(slotByteOffset, path, target, render, label);
             }
@@ -189,7 +203,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                await source.ExportPng(this, suggestedName);
+                await source.ExportPng(TopLevel.GetTopLevel(this) as Window, suggestedName);
             }
             catch (Exception ex)
             {

--- a/FEBuilderGBA.Avalonia/Views/WorldMapImageFE7View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapImageFE7View.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.WorldMapImageFE7View"
-        Title="World Map Image (FE7)" Width="1100" Height="720"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.WorldMapImageFE7View">
   <!-- World Map Image (FE7) editor (#1184) — port of WF WorldMapImageFE7Form.
        The FE7 big field map is a 12-split (4x3) grid of 256x256 header-TSA
        pieces composited into 1024x688 (bottom row clipped to 176). The event
@@ -92,4 +90,4 @@
       </StackPanel>
     </ScrollViewer>
   </DockPanel>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/WorldMapImageFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapImageFE7View.axaml.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+﻿// SPDX-License-Identifier: GPL-3.0-or-later
 // World Map Image (FE7) editor view (#1184) — port of WF WorldMapImageFE7Form.
 // Two GbaImageControl previews (12-split big field map + event image), each with
 // PNG import (file dialog -> remap -> Core import under one UndoService scope) and
@@ -105,7 +105,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                string? path = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this) as Window);
+                string? path = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this));
                 if (path == null) return;
                 await DoBigImport(path);
             }
@@ -193,7 +193,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                string? path = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this) as Window);
+                string? path = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this));
                 if (path == null) return;
                 await DoEventImport(path);
             }
@@ -287,7 +287,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     try
                     {
                         // #1639: write via the SAF bridge so Android content:// targets work.
-                        await FileDialogHelper.SaveImageFileVia(TopLevel.GetTopLevel(this) as Window, "worldmap_fe7_event", p => cropped.Save(p));
+                        await FileDialogHelper.SaveImageFileVia(TopLevel.GetTopLevel(this), "worldmap_fe7_event", p => cropped.Save(p));
                     }
                     finally { cropped.Dispose(); }
                 }

--- a/FEBuilderGBA.Avalonia/Views/WorldMapImageFE7View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapImageFE7View.axaml.cs
@@ -6,6 +6,7 @@
 // read-only pointer labels. Mirrors the base WorldMapImageView's preview/import/
 // export/undo idioms. All Log.Error calls pass a single interpolated string (Core
 // Log.Error is params string[] — no {0}/{1} composite substitution).
+using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
@@ -16,18 +17,31 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class WorldMapImageFE7View : TranslatedWindow, IEditorView
+    public partial class WorldMapImageFE7View : TranslatedUserControl, IEmbeddableEditor
     {
         readonly WorldMapImageFE7ViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
 
         public string ViewTitle => "World Map Image (FE7)";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("World Map Image (FE7)", 1100, 720, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         public WorldMapImageFE7View()
         {
             InitializeComponent();
-            Opened += (_, _) => Load();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                Load();
+            }
         }
 
         void Load()
@@ -91,7 +105,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                string? path = await FileDialogHelper.OpenImageFile(this);
+                string? path = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this) as Window);
                 if (path == null) return;
                 await DoBigImport(path);
             }
@@ -163,7 +177,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                await BigPreviewImage.ExportPng(this, "worldmap_fe7_bigfieldmap");
+                await BigPreviewImage.ExportPng(TopLevel.GetTopLevel(this) as Window, "worldmap_fe7_bigfieldmap");
             }
             catch (Exception ex)
             {
@@ -179,7 +193,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                string? path = await FileDialogHelper.OpenImageFile(this);
+                string? path = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this) as Window);
                 if (path == null) return;
                 await DoEventImport(path);
             }
@@ -273,7 +287,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     try
                     {
                         // #1639: write via the SAF bridge so Android content:// targets work.
-                        await FileDialogHelper.SaveImageFileVia(this, "worldmap_fe7_event", p => cropped.Save(p));
+                        await FileDialogHelper.SaveImageFileVia(TopLevel.GetTopLevel(this) as Window, "worldmap_fe7_event", p => cropped.Save(p));
                     }
                     finally { cropped.Dispose(); }
                 }

--- a/FEBuilderGBA.Avalonia/Views/WorldMapImageView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapImageView.axaml
@@ -1,9 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
-        x:Class="FEBuilderGBA.Avalonia.Views.WorldMapImageView"
-        Title="World Map Image" Width="1080" Height="640"
-        SizeToContent="WidthAndHeight">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
+             x:Class="FEBuilderGBA.Avalonia.Views.WorldMapImageView">
   <!-- Six-tab parity raise (#395) - mirrors WF WorldMapImageForm.WMTabControl.
        tabPage1 / Main:      4 main-map pointers (image / palette / dark / palettemap)
        tabPage2 / Event:     3 pointers (image / palette / TSA)
@@ -638,4 +636,4 @@
 
     </TabControl>
   </DockPanel>
-</Window>
+</UserControl>

--- a/FEBuilderGBA.Avalonia/Views/WorldMapImageView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapImageView.axaml.cs
@@ -12,6 +12,7 @@
 //
 // A single top-level Undo button is present (Copilot CLI plan review C3 —
 // WinForms has no per-tab Undo; we don't introduce them either).
+using global::Avalonia;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -24,13 +25,17 @@ using FEBuilderGBA.Avalonia.ViewModels;
 
 namespace FEBuilderGBA.Avalonia.Views
 {
-    public partial class WorldMapImageView : TranslatedWindow, IEditorView
+    public partial class WorldMapImageView : TranslatedUserControl, IEmbeddableEditor
     {
         readonly WorldMapImageViewModel _vm = new();
         readonly UndoService _undoService = new();
+        bool _hasLoadedList;
 
         public string ViewTitle => "World Map Image";
-        public bool IsLoaded => _vm.IsLoaded;
+        public new bool IsLoaded => _vm.IsLoaded;
+        public EditorDescriptor Descriptor => new("World Map Image", 1080, 640, SizeToContent: global::Avalonia.Controls.SizeToContent.WidthAndHeight);
+        public event EventHandler? CloseRequested;
+        public void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
         public WorldMapImageView()
         {
@@ -43,7 +48,16 @@ namespace FEBuilderGBA.Avalonia.Views
             DataContext = _vm;
             Border_EntryList.SelectedAddressChanged += OnBorderSelected;
             IconData_EntryList.SelectedAddressChanged += OnIconSelected;
-            Opened += (_, _) => LoadAll();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (!_hasLoadedList)
+            {
+                _hasLoadedList = true;
+                LoadAll();
+            }
         }
 
         // ===================================================================
@@ -262,7 +276,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                string? path = await FileDialogHelper.OpenImageFile(this);
+                string? path = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this) as Window);
                 if (path == null) return;
                 await DoBorderImport(path);
             }
@@ -420,7 +434,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 uint defaultCount = current + 1;
                 if (defaultCount > 255) defaultCount = 255;
                 uint? chosen = await NumberInputDialog.Show(
-                    this,
+                    TopLevel.GetTopLevel(this) as Window,
                     R._("Enter the new entry count for the world map border list (current: {0}, max: 255).", current),
                     R._("List Expansion"),
                     defaultCount,
@@ -610,7 +624,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 uint defaultCount = current + 1;
                 if (defaultCount > 255) defaultCount = 255;
                 uint? chosen = await NumberInputDialog.Show(
-                    this,
+                    TopLevel.GetTopLevel(this) as Window,
                     R._("Enter the new entry count for the world map icon-data list (current: {0}, max: 255).", current),
                     R._("List Expansion"),
                     defaultCount,
@@ -750,7 +764,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                string? path = await FileDialogHelper.OpenImageFile(this);
+                string? path = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this) as Window);
                 if (path == null) return;
                 await DoMainImport(path);
             }
@@ -870,7 +884,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                string? path = await FileDialogHelper.OpenImageFile(this);
+                string? path = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this) as Window);
                 if (path == null) return;
                 await DoDarkImport(path);
             }
@@ -1082,7 +1096,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     return;
                 }
                 var result = await ImageImportService.LoadAndRemapToExistingPalette(
-                    this, widthPx, heightPx, palette, 16, strictSize: true);
+                    TopLevel.GetTopLevel(this) as Window, widthPx, heightPx, palette, 16, strictSize: true);
                 if (result == null) return;
                 if (!result.Success) { CoreState.Services?.ShowError(result.Error); return; }
 
@@ -1121,7 +1135,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                string? path = await FileDialogHelper.OpenImageFile(this);
+                string? path = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this) as Window);
                 if (path == null) return;
                 await DoEventImport(path);
             }
@@ -1213,7 +1227,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     return;
                 }
                 // #1639: write via the SAF bridge so Android content:// targets work.
-                await FileDialogHelper.SaveImageFileVia(this, "worldmap_darkfieldmap", p =>
+                await FileDialogHelper.SaveImageFileVia(TopLevel.GetTopLevel(this) as Window, "worldmap_darkfieldmap", p =>
                 {
                     using var stream = System.IO.File.Create(p);
                     bmp.Save(stream);
@@ -1247,7 +1261,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                await target.ExportPng(this, suggestedName);
+                await target.ExportPng(TopLevel.GetTopLevel(this) as Window, suggestedName);
             }
             catch (Exception ex)
             {

--- a/FEBuilderGBA.Avalonia/Views/WorldMapImageView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/WorldMapImageView.axaml.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+﻿// SPDX-License-Identifier: GPL-3.0-or-later
 // WorldMapImageView code-behind — gap-sweep #395 parity raise.
 //
 // Wires the six Avalonia tabs (Main / Event / Mini / PointIcon / Border /
@@ -276,7 +276,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                string? path = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this) as Window);
+                string? path = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this));
                 if (path == null) return;
                 await DoBorderImport(path);
             }
@@ -764,7 +764,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                string? path = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this) as Window);
+                string? path = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this));
                 if (path == null) return;
                 await DoMainImport(path);
             }
@@ -884,7 +884,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                string? path = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this) as Window);
+                string? path = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this));
                 if (path == null) return;
                 await DoDarkImport(path);
             }
@@ -1135,7 +1135,7 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             try
             {
-                string? path = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this) as Window);
+                string? path = await FileDialogHelper.OpenImageFile(TopLevel.GetTopLevel(this));
                 if (path == null) return;
                 await DoEventImport(path);
             }
@@ -1227,7 +1227,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     return;
                 }
                 // #1639: write via the SAF bridge so Android content:// targets work.
-                await FileDialogHelper.SaveImageFileVia(TopLevel.GetTopLevel(this) as Window, "worldmap_darkfieldmap", p =>
+                await FileDialogHelper.SaveImageFileVia(TopLevel.GetTopLevel(this), "worldmap_darkfieldmap", p =>
                 {
                     using var stream = System.IO.File.Create(p);
                     bmp.Save(stream);

--- a/FEBuilderGBA.Tests/Unit/AvaloniaDialogViewTests.cs
+++ b/FEBuilderGBA.Tests/Unit/AvaloniaDialogViewTests.cs
@@ -903,19 +903,7 @@ namespace FEBuilderGBA.Tests.Unit
         // ===========================================================================
 
         [Theory]
-        [InlineData("SystemIconViewerView.axaml", 966, 656)]
-        // #440 — Width bumped to 1253 to accommodate the dense filter/read-config
-        // bar + selection-row added by the gap-sweep parity raise.
-        [InlineData("TextViewerView.axaml", 1166, 930)]
-        [InlineData("PortraitViewerView.axaml", 789, 700)]
-        [InlineData("SongTableView.axaml", 1505, 809)]
-        [InlineData("UnitEditorView.axaml", 934, 661)]
-        [InlineData("ItemEditorView.axaml", 1408, 856)]
-        [InlineData("ClassEditorView.axaml", 1200, 900)]
-        [InlineData("ClassFE6View.axaml", 1200, 900)]
-        [InlineData("ItemFE6View.axaml", 1408, 856)]
         [InlineData("EventCondView.axaml", 1834, 999)]
-        [InlineData("UnitIncreaseHeightView.axaml", 1185, 658)]
         [InlineData("DisASMDumpAllView.axaml", 695, 721)]
         [InlineData("DisASMDumpAllArgGrepView.axaml", 891, 757)]
         public void ImageViewerForm_HasCorrectWindowSize(string axamlFile, int width, int height)

--- a/scripts/tools/convert-editor-to-embeddable.py
+++ b/scripts/tools/convert-editor-to-embeddable.py
@@ -17,8 +17,6 @@ from dataclasses import dataclass
 from pathlib import Path
 
 EXCLUDED_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
-    ("IPickableEditor", re.compile(r"\bIPickableEditor\b")),
-    ("Closed event", re.compile(r"\bClosed\s*\+=")),
     ("OnClosed override", re.compile(r"\boverride\s+void\s+OnClosed\s*\(")),
     ("Close with result", re.compile(r"(?<![\.\w])Close\s*\(\s*[^)\s]|\bthis\s*\.\s*Close\s*\(\s*[^)\s]")),
 )
@@ -29,12 +27,32 @@ OPENED_RE = re.compile(
     r"^(?P<indent>[ \t]*)Opened[ \t]*\+=[ \t]*\([^;\n]*\)[ \t]*=>[ \t]*(?P<stmt>[^;\n]+;)[ \t]*\n",
     re.MULTILINE,
 )
+OPENED_METHOD_RE = re.compile(
+    r"^(?P<indent>[ \t]*)Opened[ \t]*\+=[ \t]*(?P<handler>[A-Za-z_][A-Za-z0-9_]*)[ \t]*;[ \t]*\n",
+    re.MULTILINE,
+)
 OPENED_COMPOUND_RE = re.compile(
     r"^(?P<indent>[ \t]*)Opened[ \t]*\+=[ \t]*\([^;\n]*\)[ \t]*=>[ \t]*(?:\r?\n[ \t]*)?\{(?P<body>.*?)^(?P=indent)\}[ \t]*;[ \t]*\n",
     re.DOTALL | re.MULTILINE,
 )
 OPENED_INLINE_COMPOUND_RE = re.compile(
     r"^(?P<indent>[ \t]*)Opened[ \t]*\+=[ \t]*\([^;\n]*\)[ \t]*=>[ \t]*\{[ \t]*(?P<body>.*?)[ \t]*\}[ \t]*;[ \t]*\n",
+    re.MULTILINE,
+)
+CLOSED_RE = re.compile(
+    r"^(?P<indent>[ \t]*)(?:this[ \t]*\.[ \t]*)?Closed[ \t]*\+=[ \t]*\([^;\n]*\)[ \t]*=>[ \t]*(?P<stmt>[^;\n]+;)[ \t]*\n",
+    re.MULTILINE,
+)
+CLOSED_METHOD_RE = re.compile(
+    r"^(?P<indent>[ \t]*)(?:this[ \t]*\.[ \t]*)?Closed[ \t]*\+=[ \t]*(?P<handler>[A-Za-z_][A-Za-z0-9_]*)[ \t]*;[ \t]*\n",
+    re.MULTILINE,
+)
+CLOSED_COMPOUND_RE = re.compile(
+    r"^(?P<indent>[ \t]*)(?:this[ \t]*\.[ \t]*)?Closed[ \t]*\+=[ \t]*\([^;\n]*\)[ \t]*=>[ \t]*(?:\r?\n[ \t]*)?\{(?P<body>.*?)^(?P=indent)\}[ \t]*;[ \t]*\n",
+    re.DOTALL | re.MULTILINE,
+)
+CLOSED_INLINE_COMPOUND_RE = re.compile(
+    r"^(?P<indent>[ \t]*)(?:this[ \t]*\.[ \t]*)?Closed[ \t]*\+=[ \t]*\([^;\n]*\)[ \t]*=>[ \t]*\{[ \t]*(?P<body>.*?)[ \t]*\}[ \t]*;[ \t]*\n",
     re.MULTILINE,
 )
 
@@ -172,9 +190,13 @@ def convert_base_list(cs: str, view_name: str) -> str:
     bases = match.group("bases")
     if "TranslatedWindow" not in bases:
         raise ValueError("class does not derive from TranslatedWindow")
-    if "IEditorView" not in bases:
-        raise ValueError("class does not implement IEditorView")
-    new_bases = bases.replace("TranslatedWindow", "TranslatedUserControl").replace("IEditorView", "IEmbeddableEditor")
+    if "IEditorView" not in bases and "IPickableEditor" not in bases:
+        raise ValueError("class does not implement IEditorView/IPickableEditor")
+    new_bases = bases.replace("TranslatedWindow", "TranslatedUserControl")
+    if "IEditorView" in new_bases:
+        new_bases = new_bases.replace("IEditorView", "IEmbeddableEditor")
+    elif "IEmbeddableEditor" not in new_bases:
+        new_bases = new_bases.replace("IPickableEditor", "IEmbeddableEditor, IPickableEditor", 1)
     return cs[: match.start("bases")] + new_bases + cs[match.end("bases") :]
 
 
@@ -388,13 +410,18 @@ def convert_opened_handler(cs: str) -> str:
     match = OPENED_RE.search(cs)
     body_lines: list[str]
     if not match:
-        compound = OPENED_COMPOUND_RE.search(cs)
+        compound = OPENED_INLINE_COMPOUND_RE.search(cs)
         if not compound:
-            compound = OPENED_INLINE_COMPOUND_RE.search(cs)
+            compound = OPENED_COMPOUND_RE.search(cs)
         if not compound:
-            return cs
-        body_lines = normalize_lambda_body(compound.group("body"))
-        match = compound
+            method = OPENED_METHOD_RE.search(cs)
+            if not method:
+                return cs
+            body_lines = [f"{method.group('handler')}(this, EventArgs.Empty);"]
+            match = method
+        else:
+            body_lines = normalize_lambda_body(compound.group("body"))
+            match = compound
     else:
         body_lines = [match.group("stmt").strip()]
     cs = cs[: match.start()] + cs[match.end() :]
@@ -438,6 +465,62 @@ def convert_opened_handler(cs: str) -> str:
     return cs[:ctor_end] + override + cs[ctor_end:]
 
 
+def insert_lifecycle_override(cs: str, method_name: str, body_lines: list[str]) -> str:
+    if f"{method_name}(VisualTreeAttachmentEventArgs e)" in cs:
+        raise ValueError(f"{method_name} already exists; merge manually")
+
+    ctor_match = re.search(r"^(?P<indent>[ \t]*)public\s+[A-Za-z_][A-Za-z0-9_]*\s*\(\)\s*\{", cs, re.MULTILINE)
+    if not ctor_match:
+        raise ValueError("constructor not found")
+    pos = ctor_match.end()
+    depth = 1
+    while pos < len(cs) and depth:
+        if cs[pos] == "{":
+            depth += 1
+        elif cs[pos] == "}":
+            depth -= 1
+        pos += 1
+    if depth != 0:
+        raise ValueError("constructor body did not parse")
+    method_indent = ctor_match.group("indent")
+    override = (
+        "\n\n"
+        f"{method_indent}protected override void {method_name}(VisualTreeAttachmentEventArgs e)\n"
+        f"{method_indent}{{\n"
+        f"{method_indent}    base.{method_name}(e);\n"
+        + "\n".join(f"{method_indent}    {line}" for line in body_lines)
+        + "\n"
+        f"{method_indent}}}"
+    )
+    return cs[:pos] + override + cs[pos:]
+
+
+def convert_closed_handler(cs: str) -> str:
+    """Move own Window.Closed cleanup into UserControl visual-detach cleanup."""
+    if "OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)" in cs:
+        return cs
+    match = CLOSED_RE.search(cs)
+    body_lines: list[str]
+    if not match:
+        compound = CLOSED_INLINE_COMPOUND_RE.search(cs)
+        if not compound:
+            compound = CLOSED_COMPOUND_RE.search(cs)
+        if not compound:
+            method = CLOSED_METHOD_RE.search(cs)
+            if not method:
+                return cs
+            body_lines = [f"{method.group('handler')}(this, EventArgs.Empty);"]
+            match = method
+        else:
+            body_lines = normalize_lambda_body(compound.group("body"))
+            match = compound
+    else:
+        body_lines = [match.group("stmt").strip()]
+
+    cs = cs[: match.start()] + cs[match.end() :]
+    return insert_lifecycle_override(cs, "OnDetachedFromVisualTree", body_lines)
+
+
 def convert_cs(cs: str, view_name: str, descriptor: Descriptor) -> str:
     for label, pattern in EXCLUDED_PATTERNS:
         if pattern.search(cs):
@@ -454,6 +537,7 @@ def convert_cs(cs: str, view_name: str, descriptor: Descriptor) -> str:
     cs = ensure_avalonia_controls_using(cs)
     cs = ensure_system_using(cs)
     cs = convert_opened_handler(cs)
+    cs = convert_closed_handler(cs)
     return cs
 
 

--- a/scripts/tools/convert-editor-to-embeddable.py
+++ b/scripts/tools/convert-editor-to-embeddable.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+﻿#!/usr/bin/env python3
 """Convert Avalonia Window editors to embeddable UserControl editors.
 
 Usage:
@@ -234,7 +234,7 @@ def convert_owner_bound_dialog_calls(cs: str) -> str:
         ),
         (
             re.compile(r"(?P<prefix>\bFERepoPickHelper\s*\.\s*[A-Za-z_][A-Za-z0-9_]*\s*\(\s*)this(?P<suffix>\s*[,)])"),
-            rf"\g<prefix>{owner}\g<suffix>",
+            rf"\g<prefix>{file_owner}\g<suffix>",
         ),
         (
             re.compile(r"(?P<prefix>\bTableExportImportHelper\s*\.\s*[A-Za-z_][A-Za-z0-9_]*\s*\(\s*)this(?P<suffix>\s*,)"),
@@ -495,6 +495,34 @@ def insert_lifecycle_override(cs: str, method_name: str, body_lines: list[str]) 
     return cs[:pos] + override + cs[pos:]
 
 
+def make_language_changed_lifecycle_symmetric(cs: str) -> str:
+    """Move matching CoreState.LanguageChanged += handlers into visual attach.
+
+    Window-era editors often subscribed once in the constructor and unsubscribed
+    in Closed. After Closed cleanup moves to OnDetachedFromVisualTree, the
+    unsubscribe can run on every detach/reparent; subscribe must therefore be
+    attach-scoped too.
+    """
+    handlers = re.findall(r"CoreState\.LanguageChanged\s*-\=\s*([A-Za-z_][A-Za-z0-9_]*)\s*;", cs)
+    if not handlers:
+        return cs
+    for handler in dict.fromkeys(handlers):
+        plus = re.compile(r"^[ \t]*CoreState\.LanguageChanged\s*\+=\s*" + re.escape(handler) + r"\s*;[ \t]*\n", re.MULTILINE)
+        if not plus.search(cs):
+            continue
+        cs = plus.sub("", cs, count=1)
+        attach = re.search(
+            r"(?P<head>protected\s+override\s+void\s+OnAttachedToVisualTree\s*\(VisualTreeAttachmentEventArgs\s+e\)\s*\{\s*\n(?P<indent>[ \t]*)base\.OnAttachedToVisualTree\(e\);\s*\n)",
+            cs,
+        )
+        if not attach:
+            raise ValueError(f"LanguageChanged handler {handler} needs OnAttachedToVisualTree")
+        indent = attach.group("indent")
+        lines = f"{indent}CoreState.LanguageChanged -= {handler};\n{indent}CoreState.LanguageChanged += {handler};\n"
+        cs = cs[: attach.end()] + lines + cs[attach.end() :]
+    return cs
+
+
 def convert_closed_handler(cs: str) -> str:
     """Move own Window.Closed cleanup into UserControl visual-detach cleanup."""
     if "OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)" in cs:
@@ -538,6 +566,7 @@ def convert_cs(cs: str, view_name: str, descriptor: Descriptor) -> str:
     cs = ensure_system_using(cs)
     cs = convert_opened_handler(cs)
     cs = convert_closed_handler(cs)
+    cs = make_language_changed_lifecycle_symmetric(cs)
     return cs
 
 


### PR DESCRIPTION
## Summary

**Slice 10** of the single-view editor-hosting rollout (#1873) — converts **34 editors** across the more-mechanical complex categories, including all **8 pick targets** (the major launcher editors: Unit/Class/Item/Portrait/Song).

- **Pick targets** (`IPickableEditor`): converted to `TranslatedUserControl, IEmbeddableEditor, IPickableEditor` — the host `PickFromEditor` path (Slice 1) already drives `EnablePickMode()` + `SelectionConfirmed` on the content, so pick mode works unchanged. Verified each keeps its pick members.
- **`Closed`-event editors**: an editor's own `this.Closed += <cleanup>` is moved into `OnDetachedFromVisualTree` (paired with its `+=` subscription — no handler leak). Conservative: other objects' `.Closed` left alone.
- Plus remaining FileDialogHelper/owner-bound stragglers. 68 editors remain (close-result modal-dialogs 38 — reserved for a final specialized slice needing a result-return mechanism; + storage/showdialog/clipboard/other).

## Scope
- **Ref #1873** (partial - rollout Slice 10). Does not close it.

## Test plan
- [x] `dotnet build FEBuilderGBA.Avalonia` - **0 errors**.
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests` - **9408/0**.
- [x] `dotnet test FEBuilderGBA.Tests` - **2152/0** (descriptor guard auto-covers the new editors; 12 window-size InlineData removed).
- [x] **Visual/behavior proof:** CI all-editor data-verify + screenshot + smoke + list-parity harnesses render/validate every converted editor. Slice 1 hosting proof: https://raw.githubusercontent.com/laqieer/FEBuilderGBA/master/pr-screenshots/1873/movecost-hosted-fe8u.png

## GUI Test Report

| Scenario | Platform | Result |
| --- | --- | --- |
| Unit/Class/Item/Portrait/Song editors open + pick mode works | Desktop | Pass (host PickFromEditor drives EnablePickMode/SelectionConfirmed) |
| 34 editors open as pages (no Window constructed) | Single-view | Pass (IEmbeddableEditor page path) |
| Closed-event cleanup runs on detach (no handler leak) | Both | Pass |
| Desktop multi-window parity unchanged | Desktop | Pass (smoke/screenshot/data-verify/list-parity) |

---
Copilot CLI: 1.0.69-2
Model: Claude Opus 4.8 (claude-opus-4.8)
