### PR TITLE
fix(deps): bump SharpCompress to 0.48.0 and migrate ArchSevenZip to renamed API

### DIFF
--- a/FEBuilderGBA.Avalonia/FEBuilderGBA.Avalonia.csproj
+++ b/FEBuilderGBA.Avalonia/FEBuilderGBA.Avalonia.csproj
@@ -76,7 +76,7 @@
          browser #1864). -->
     <PackageReference Include="Avalonia.Desktop" Version="11.2.3" Condition="'$(IsHeadTfm)' != 'true'" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" Condition="'$(IsHeadTfm)' != 'true'" />
-    <PackageReference Include="Tmds.DBus.Protocol" Version="0.21.3" />
+    <PackageReference Include="Tmds.DBus.Protocol" Version="0.21.3" Condition="'$(IsHeadTfm)' != 'true'" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsHeadTfm)' == 'true'">
     <!-- Desktop-only sources excluded on the head TFMs (android #1121, iOS #1859, browser #1864):

--- a/FEBuilderGBA.Avalonia/FEBuilderGBA.Avalonia.csproj
+++ b/FEBuilderGBA.Avalonia/FEBuilderGBA.Avalonia.csproj
@@ -76,6 +76,7 @@
          browser #1864). -->
     <PackageReference Include="Avalonia.Desktop" Version="11.2.3" Condition="'$(IsHeadTfm)' != 'true'" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" Condition="'$(IsHeadTfm)' != 'true'" />
+    <PackageReference Include="Tmds.DBus.Protocol" Version="0.21.3" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsHeadTfm)' == 'true'">
     <!-- Desktop-only sources excluded on the head TFMs (android #1121, iOS #1859, browser #1864):

--- a/FEBuilderGBA.Core/ArchSevenZip.cs
+++ b/FEBuilderGBA.Core/ArchSevenZip.cs
@@ -140,7 +140,7 @@ namespace FEBuilderGBA
                 }
 
                 // Use ArchiveFactory which supports 7z, zip, rar, tar, etc.
-                using (var archive = ArchiveFactory.Open(archiveFile))
+                using (var archive = ArchiveFactory.OpenArchive(archiveFile))
                 {
                     var extractOptions = new ExtractionOptions
                     {
@@ -309,7 +309,7 @@ namespace FEBuilderGBA
 
                 // Create zip archive using SharpCompress Writers API
                 using (var stream = File.Create(outputFile))
-                using (var writer = WriterFactory.Open(stream, ArchiveType.Zip, new WriterOptions(CompressionType.Deflate)
+                using (var writer = WriterFactory.OpenWriter(stream, ArchiveType.Zip, new WriterOptions(CompressionType.Deflate)
                 {
                     LeaveStreamOpen = false
                 }))

--- a/FEBuilderGBA.Core/FEBuilderGBA.Core.csproj
+++ b/FEBuilderGBA.Core/FEBuilderGBA.Core.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <!-- InternalsVisibleTo is in Properties/AssemblyInfo.cs (GenerateAssemblyInfo=false) -->
   <ItemGroup>
-    <PackageReference Include="SharpCompress" Version="0.38.0" />
+    <PackageReference Include="SharpCompress" Version="0.48.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/FEBuilderGBA.SkiaSharp/FEBuilderGBA.SkiaSharp.csproj
+++ b/FEBuilderGBA.SkiaSharp/FEBuilderGBA.SkiaSharp.csproj
@@ -10,6 +10,7 @@
          native — managed 3.116 rejects native 2.88 ("88.1") and crashes on
          Linux/macOS where Avalonia ships only the 2.88 native (#796 / #798 CI).
          Avalonia 11.x is not compatible with SkiaSharp 3.x. -->
+    <PackageReference Include="SharpCompress" Version="0.48.0" />
     <PackageReference Include="SkiaSharp" Version="2.88.9" />
   </ItemGroup>
   <ItemGroup>

--- a/FEBuilderGBA.SkiaSharp/FEBuilderGBA.SkiaSharp.csproj
+++ b/FEBuilderGBA.SkiaSharp/FEBuilderGBA.SkiaSharp.csproj
@@ -10,7 +10,6 @@
          native — managed 3.116 rejects native 2.88 ("88.1") and crashes on
          Linux/macOS where Avalonia ships only the 2.88 native (#796 / #798 CI).
          Avalonia 11.x is not compatible with SkiaSharp 3.x. -->
-    <PackageReference Include="SharpCompress" Version="0.48.0" />
     <PackageReference Include="SkiaSharp" Version="2.88.9" />
   </ItemGroup>
   <ItemGroup>

--- a/FEBuilderGBA/ArchSevenZip.cs
+++ b/FEBuilderGBA/ArchSevenZip.cs
@@ -136,7 +136,7 @@ namespace FEBuilderGBA
                 }
 
                 // Use ArchiveFactory which supports 7z, zip, rar, tar, etc.
-                using (var archive = ArchiveFactory.Open(archiveFile))
+                using (var archive = ArchiveFactory.OpenArchive(archiveFile))
                 {
                     var extractOptions = new ExtractionOptions
                     {
@@ -303,7 +303,7 @@ namespace FEBuilderGBA
 
                 // Create zip archive using SharpCompress Writers API
                 using (var stream = File.Create(outputFile))
-                using (var writer = WriterFactory.Open(stream, ArchiveType.Zip, new WriterOptions(CompressionType.Deflate)
+                using (var writer = WriterFactory.OpenWriter(stream, ArchiveType.Zip, new WriterOptions(CompressionType.Deflate)
                 {
                     LeaveStreamOpen = false
                 }))

--- a/FEBuilderGBA/FEBuilderGBA.csproj
+++ b/FEBuilderGBA/FEBuilderGBA.csproj
@@ -172,7 +172,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualBasic" Version="10.3.0" />
-    <PackageReference Include="SharpCompress" Version="0.38.0" />
+    <PackageReference Include="SharpCompress" Version="0.48.0" />
     <PackageReference Include="System.DirectoryServices" Version="9.0.4" />
     <PackageReference Include="System.Speech" Version="9.0.4" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Dependabot opened #1901 to bump the **NuGet security group** (SharpCompress `0.38.0 → 0.48.0`, Tmds.DBus.Protocol `0.20.0 → 0.21.3`), but the SharpCompress major-jump **broke the build** (`CS0117`) because 0.48 renamed its static factory methods. This PR lands the bumps **plus** the required API migration so the build stays green.

> Downstream of #1900 — the new dependency-submission workflow populated the NuGet graph, which is what let Dependabot surface this moderate advisory (`NU1902` / GHSA-6c8g-7p36-r338 / CVE-2026-44788).

## Root cause & fix

SharpCompress 0.48 renamed:

| 0.38 (removed) | 0.48 (new) |
|---|---|
| `ArchiveFactory.Open(path)` | `ArchiveFactory.OpenArchive(path)` |
| `WriterFactory.Open(stream, type, opts)` | `WriterFactory.OpenWriter(stream, type, opts)` |

Migrated both call sites in `ArchSevenZip.cs` (the **Core** canonical copy **and** the compile-excluded WinForms copy, kept in sync). Verified against authoritative SharpCompress `0.48.0` source:
- **Multi-format auto-detection preserved** — `OpenArchive(string)` still auto-detects 7z/zip/rar/tar.
- `OpenWriter(Stream, ArchiveType, IWriterOptions)` matches the existing `new WriterOptions(CompressionType.Deflate){ LeaveStreamOpen = false }` (`WriterOptions : IWriterOptions`).

The compiler reported only these two `CS0117` errors, so no other SharpCompress API used by `ArchSevenZip.cs` changed.

## Dependency changes (final)

Direct `PackageReference` version bumps:
- **`FEBuilderGBA.Core`** — SharpCompress `0.38.0 → 0.48.0` (the one project that uses it).
- **`FEBuilderGBA`** (WinForms) — SharpCompress `0.38.0 → 0.48.0` (pre-existing direct ref, kept).
- **`FEBuilderGBA.Avalonia`** — adds `Tmds.DBus.Protocol 0.21.3`, **gated `Condition="'$(IsHeadTfm)' != 'true'"`** so the desktop-only D-Bus dep isn't pulled into the android/iOS/browser head builds (matches its ItemGroup siblings).

`FEBuilderGBA.SkiaSharp` and `FEBuilderGBA.Avalonia` inherit SharpCompress `0.48.0` **transitively** via their `ProjectReference` to Core — no direct ref needed (a redundant SkiaSharp ref that Dependabot had added was removed per review).

> Diverges intentionally from #1901: dropped Dependabot's redundant SkiaSharp `SharpCompress` pin and gated `Tmds.DBus.Protocol` to desktop.

## Scope

Supersedes #1901. No behavioral change to archive handling — pure dependency bump + API rename.

## Test plan

- [x] `dotnet build FEBuilderGBA.Core -c Release` — **Build succeeded, 0 errors** against SharpCompress 0.48.0.
- [x] `dotnet build FEBuilderGBA.SkiaSharp -c Release` — **Build succeeded** with SharpCompress resolved transitively (no direct ref).
- [x] `dotnet restore FEBuilderGBA.Avalonia` — **restored** with the desktop-gated `Tmds.DBus.Protocol`.
- [x] `dotnet test FEBuilderGBA.Core.Tests --filter ProblemReport` — **5/5 passed** (SharpCompress compress/`OpenWriter` path).
- [x] `dotnet test FEBuilderGBA.Tests --filter ArchSevenZip` — **6/6 passed** (extract via `OpenArchive` + compress round-trip).
- [x] CI: all four required builds green (compile Core/WinForms/SkiaSharp/Avalonia against 0.48.0); lints green.

## Proof (local)

```
Build succeeded.  0 Error(s)                  # FEBuilderGBA.Core (SharpCompress 0.48.0)
Build succeeded.                              # FEBuilderGBA.SkiaSharp (transitive SharpCompress)
Passed! - Failed: 0, Passed: 5, Total: 5      # ProblemReport (compress path)
Passed! - Failed: 0, Passed: 6, Total: 6      # ArchSevenZip (extract + round-trip)
```

Non-GUI change (Core/CLI-shared + csproj) — CLI/test output is the proof per the workflow.

---
Copilot CLI: 1.0.69-2
Model: Claude Opus 4.8 (claude-opus-4.8)
