### PR TITLE
ci: add ggshield secret scanning (pre-commit hook + gated CI)

### DIFF
--- a/.github/workflows/ggshield.yml
+++ b/.github/workflows/ggshield.yml
@@ -1,0 +1,60 @@
+# GitGuardian ggshield — shift-left secret scanning in CI (#1903).
+#
+# Scans the commit range of each push / PR (`ggshield secret scan ci`, which is
+# range-scoped — the PR delta or the push's before..after — and NEVER the whole
+# repository history) for committed secrets. A finding fails this check.
+#
+# Gated on the GITGUARDIAN_API_KEY repo secret using the repo's optional-secret
+# pattern (see android.yml): `secrets.*` can't be used in a step-level `if:`, so a
+# classifier step reads the key from `env:` and writes present=true/false, and the
+# scan steps run only when present. When the key is absent (fork PRs, or before the
+# secret is configured) the scan is skipped and the job is GREEN — so this never
+# breaks master or fork PRs. Intentionally NOT part of the required-checks ruleset
+# (advisory): a finding fails the check but does not hard-block merge.
+name: ggshield
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ggshield-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: GitGuardian secret scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for GITGUARDIAN_API_KEY
+        id: check
+        env:
+          GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
+        run: |
+          if [ -z "${GITGUARDIAN_API_KEY:-}" ]; then
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::GITGUARDIAN_API_KEY not set (e.g. a fork PR) — skipping ggshield scan."
+          else
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.check.outputs.present == 'true'
+        uses: actions/checkout@v4
+        with:
+          # Required: ggshield's `ci` mode resolves the commit range from history.
+          fetch-depth: 0
+
+      - name: ggshield secret scan
+        if: steps.check.outputs.present == 'true'
+        # SHA-pinned to v1.52.2 (annotated tag -> commit da20be06...).
+        uses: GitGuardian/ggshield-action@da20be06cafe5e8633dc24744efe1efe8d30f06b # v1.52.2
+        env:
+          GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
+          # Range base for a multi-commit push (else only the last commit is scanned).
+          GITHUB_PUSH_BASE_SHA: ${{ github.event.before }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,4 +11,3 @@ repos:
     hooks:
       - id: ggshield
         language_version: python3
-        stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+# Pre-commit hooks for FEBuilderGBA (opt-in). Enable with:
+#   pip install pre-commit
+#   pre-commit install
+# See docs/SECRET-SCANNING.md for setup, auth, and the escape hatch. (#1903)
+repos:
+  # GitGuardian ggshield — shift-left secret scanning. Blocks a commit that would
+  # introduce a secret. Requires `ggshield auth login` (or a GITGUARDIAN_API_KEY
+  # env var). Needs pre-commit >= 3.2.0.
+  - repo: https://github.com/gitguardian/ggshield
+    rev: v1.52.2
+    hooks:
+      - id: ggshield
+        language_version: python3
+        stages: [pre-commit]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,13 @@ should reject or redirect new-feature PRs that target the WinForms GUI.
 
 See [DEVELOPMENT-WORKFLOW.md](DEVELOPMENT-WORKFLOW.md) for the mandatory development workflow including plan review, implementation, and PR review gates.
 
+## Secret Scanning (ggshield)
+
+This repo uses **[GitGuardian ggshield](https://github.com/gitguardian/ggshield)** to catch committed secrets (API keys, tokens) — "shift left" — both locally and in CI. Full setup: **[docs/SECRET-SCANNING.md](docs/SECRET-SCANNING.md)**.
+
+- **Local (opt-in pre-commit hook):** `pip install pre-commit && pre-commit install`, then authenticate once with `ggshield auth login` (or export `GITGUARDIAN_API_KEY`). ggshield then scans each commit and blocks one that would introduce a secret. Escape hatch for a false positive: `SKIP=ggshield git commit …` (or `git commit --no-verify`). Requires pre-commit ≥ 3.2.0.
+- **CI:** `.github/workflows/ggshield.yml` scans the commit range of each push / PR. It runs only when the `GITGUARDIAN_API_KEY` repo secret is set, so **fork PRs skip it** (secrets aren't shared with forks) and it never breaks the build. It's an advisory (non-required) check — a finding fails the check but doesn't hard-block merge.
+
 ## Commit & PR Title Convention
 
 Commit subjects and pull-request titles follow the

--- a/docs/SECRET-SCANNING.md
+++ b/docs/SECRET-SCANNING.md
@@ -1,0 +1,72 @@
+# Secret Scanning (ggshield / GitGuardian)
+
+FEBuilderGBA uses **[GitGuardian ggshield](https://github.com/gitguardian/ggshield)**
+to detect secrets (API keys, tokens, credentials) *before* they land in the repo —
+"shift left" — in two places: an **opt-in local pre-commit hook** and a **CI check**.
+Tracked in #1903.
+
+## Why
+
+A leaked secret in git history is expensive to remediate (rotate the key, scrub
+history). ggshield catches the common case — a secret in a *new* commit — at the
+earliest point: your machine, then the pull request.
+
+## Local pre-commit hook (opt-in)
+
+The hook is defined in [`.pre-commit-config.yaml`](../.pre-commit-config.yaml)
+(ggshield `v1.52.2`). It is **opt-in** — nothing runs until you install it.
+
+1. Install [pre-commit](https://pre-commit.com/) (≥ 3.2.0) and the hook:
+   ```bash
+   pip install pre-commit
+   pre-commit install
+   ```
+2. Authenticate ggshield once (free personal account):
+   ```bash
+   ggshield auth login
+   # …or, instead of login, export a token:
+   #   export GITGUARDIAN_API_KEY=<your token>
+   ```
+   Without auth the hook errors and blocks the commit.
+
+Now every `git commit` scans the staged changes. A detected secret **blocks the
+commit** with the finding location.
+
+### False positive / escape hatch
+
+If ggshield flags something that is *not* a real secret (e.g. a test fixture):
+
+```bash
+SKIP=ggshield git commit -m "…"   # skip just this hook for one commit
+git commit --no-verify -m "…"      # skip all hooks for one commit
+```
+
+For a recurring false positive, silence it in a `.gitguardian.yaml`
+(`secret.ignored-matches`) rather than disabling the hook — see the
+[ggshield docs](https://docs.gitguardian.com/ggshield-docs/configuration).
+
+## CI check
+
+[`.github/workflows/ggshield.yml`](../.github/workflows/ggshield.yml) runs
+`ggshield secret scan ci` on each push to `master` and each pull request. It scans
+only the **commit range of the event** (the PR delta, or the push's
+`before..after`) — never the whole repository history — so it will not fail on
+pre-existing secrets in untouched history.
+
+- **Gated on the `GITGUARDIAN_API_KEY` repo secret.** When the secret is absent —
+  most importantly on **fork pull requests**, where GitHub never shares secrets —
+  the scan is **skipped and the job is green**. So the check never breaks `master`
+  or fork PRs.
+- It is an **advisory, non-required** check: a finding fails the check (red) but
+  does **not** hard-block merge via branch protection.
+- On a GitGuardian API outage / quota error the check goes red (harmless noise
+  since it's non-required); set `GITGUARDIAN_FAIL_ON_SERVER_ERROR=false` in the
+  workflow's `env:` if you'd rather outages be non-fatal.
+
+### Maintainer setup (one-time)
+
+Add a repository secret **`GITGUARDIAN_API_KEY`** under
+*Settings → Secrets and variables → Actions* (a GitGuardian *personal access
+token* with the `scan` scope, from <https://dashboard.gitguardian.com>). The
+workflow only ever references `${{ secrets.GITGUARDIAN_API_KEY }}` — the token
+value is never committed.


### PR DESCRIPTION
## Summary

Adds **GitGuardian ggshield** shift-left secret scanning (#1903) — an opt-in local **pre-commit hook** and a **gated CI check** — so secrets (API keys, tokens) are caught before they land in the repo.

> The issue body was a GitGuardian onboarding email; its `customerio.gitguardian.com` tracking links were **not** followed (treated as untrusted per the maintenance security guardrail). This is built from ggshield's official pre-commit hook + GitHub Action.

## What's added

- **`.pre-commit-config.yaml`** — opt-in `gitguardian/ggshield` hook (`v1.52.2`). Nothing runs until a contributor does `pre-commit install`.
- **`.github/workflows/ggshield.yml`** — `ggshield secret scan ci` on `push`(master) + `pull_request`. **Range-scoped** (PR delta / push `before..after`, **never** whole history → can't false-fail on pre-existing history), `fetch-depth: 0` for range resolution, **SHA-pinned** action (`v1.52.2` → `da20be06`, annotated tag dereferenced to confirm). **Gated** on `GITGUARDIAN_API_KEY` via the repo's proven `android.yml` optional-secret pattern: absent key (fork PRs / keyless) → **skip → job green**, so it never breaks the build. Advisory (**non-required**) check.
- **Docs** — `CONTRIBUTING.md` section + `docs/SECRET-SCANNING.md` (setup, `ggshield auth login`, the `SKIP=ggshield` / `--no-verify` escape hatch, fork behavior, maintainer secret setup, API-outage note).

The maintainer has **already configured the `GITGUARDIAN_API_KEY` repo secret** (per #1903 comments), so the CI scan is active — including **on this PR** (see the `GitGuardian secret scan` check below, scanning this PR's own changes as a live proof).

## Scope

Closes #1903. CI/config + docs only — no app-code change. No secret is committed (only `${{ secrets.GITGUARDIAN_API_KEY }}`).

## Test plan

- [x] Both YAML files parse valid; the two scan steps are gated `if: steps.check.outputs.present == 'true'`, only the presence classifier always runs.
- [x] Pins verified live: `gitguardian/ggshield` release `v1.52.2` exists; `GitGuardian/ggshield-action` `v1.52.2` annotated tag → commit `da20be06cafe5e8633dc24744efe1efe8d30f06b`.
- [x] Gating mirrors the proven `android.yml` optional-secret pattern (skip ⇒ job success; fork PRs get no secret ⇒ skip ⇒ green).
- [x] The `GitGuardian secret scan` check on **this PR** runs (secret configured) and scans this PR's commit range green (no secrets in the diff) — live end-to-end proof.

Non-GUI (CI/docs) change — CI + YAML validation is the proof per the workflow.

---
Copilot CLI: 1.0.69-2
Model: Claude Opus 4.8 (claude-opus-4.8)
