### PR TITLE
test: block-binaries RED proof for #1944 (DO NOT MERGE)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,8 @@
 # Keep shell scripts LF-only so they run on the Linux CI runners regardless of
 # a contributor's core.autocrlf setting (a CRLF shebang breaks /bin/sh). (#1632)
 *.sh text eol=lf
+
+# Keep GitHub Actions workflows LF-only for the same reason: an embedded bash
+# `run:` block with CRLF would inject stray \r on the Linux runner. (#1943)
+/.github/workflows/*.yml text eol=lf
+

--- a/.github/workflows/block-binaries.yml
+++ b/.github/workflows/block-binaries.yml
@@ -1,0 +1,82 @@
+name: Block binary & secret files
+
+# Repo-wide guardrail: refuse binary executables, ROMs, disk/app images, archives,
+# and secret/certificate/key material (issue #1943). Harmless data fixtures
+# (*.bin / *.dmp / *.wav) are intentionally allowed. `push` is restricted to master
+# (matching every other workflow in this repo); all pull requests are always checked,
+# which is the enforced entry point for contributions and forks.
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: block-binaries-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  block:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect disallowed added/modified files
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base='${{ github.event.pull_request.base.sha }}'
+            head='${{ github.event.pull_request.head.sha }}'
+          else
+            base='${{ github.event.before }}'
+            head='${{ github.sha }}'
+          fi
+
+          # New branch / unknown base → diff against the empty tree; otherwise diff from
+          # the merge-base so only files this push/PR introduces are inspected (changes
+          # already present on the base branch are ignored).
+          if [ -z "$base" ] || ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+            base="$(git hash-object -t tree /dev/null)"
+          else
+            base="$(git merge-base "$base" "$head" 2>/dev/null || printf '%s' "$base")"
+          fi
+
+          # Legitimately-tracked binaries (issue #1943) — never flagged.
+          allow='^(FEBuilderGBA/lib/7-zip32\.dll|FEBuilderGBA/test/test\.elf)$'
+          # Committable env templates — always allowed.
+          example='(^|/)\.env\.(example|sample|template)$'
+          # Secret files matched by NAME (no blockable extension).
+          names='(^|/)(\.env(\..*)?|\.netrc|\.pgpass|\.npmrc|\.pypirc|id_rsa|id_dsa|id_ecdsa|id_ed25519)$'
+          # macOS bundle directories are stored as Foo.app/… — match the path segment.
+          bundle='(^|/)[^/]+\.app(/|$)'
+          # Blocked extensions (113) — everything in the .gitignore block EXCEPT bin/dmp/wav.
+          exts='com|exe|elf|dll|so|dylib|o|a|lib|obj|pdb|ko|class|out|scr|cpl|wasm|app|msi|msix|appx|deb|rpm|pkg|dmg|apk|ipa|aab|jar|gba|gb|gbc|nds|nes|sfc|smc|n64|z64|v64|3ds|cia|agb|mb|srl|sav|rom|ups|ips|iso|img|vhd|vhdx|vmdk|vdi|qcow2|cue|zip|rar|7z|tar|tgz|gz|bz2|xz|lz|lzma|zst|z|cab|arj|lha|lzh|ace|sit|pem|crt|cer|der|crl|key|pkey|ppk|p12|pfx|pkcs12|p8|pk8|pkcs8|p7b|p7c|p7r|p7s|spc|csr|jks|jceks|bks|keystore|keychain|pub|asc|gpg|pgp|ovpn|kdbx|mobileprovision|provisionprofile|secret|secrets|credentials|htpasswd|keytab|env'
+
+          bad=0
+          # --no-renames so a rename into a blocked path shows up as an Add (renames are
+          # otherwise reported as R and dropped by --diff-filter=AMT).
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            [[ "$f" =~ $allow ]] && continue
+            low="$(printf '%s' "$f" | tr 'A-Z' 'a-z')"
+            printf '%s\n' "$low" | grep -Eq "$example" && continue
+            if printf '%s\n' "$low" | grep -Eq "\.($exts)\$" \
+               || printf '%s\n' "$low" | grep -Eq "$bundle" \
+               || printf '%s\n' "$low" | grep -Eq "$names"; then
+              echo "::error file=$f::Disallowed binary/secret file '$f' (see .gitignore policy / issue #1943)."
+              bad=1
+            fi
+          done < <(git diff --no-renames --name-only --diff-filter=AMT "$base" "$head")
+
+          if [ "$bad" -ne 0 ]; then
+            echo "Blocked: remove the file(s) above, or add a documented allowlist exception."
+            exit 1
+          fi
+          echo "OK — no disallowed binary/secret files added or modified."

--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,156 @@ FEBuilderGBA/FEBuilderGBA.csproj.user
 # tools/ subprojects (WinCapture, etc.) — build artifacts only
 tools/**/bin/
 tools/**/obj/
+
+# ── Security / hygiene: block binary executables, ROMs, disk & app images, archives,
+#    and secret / certificate / key material (issue #1943) ──
+# Opaque/attackable binaries + copyright-risk ROMs + leaked credentials must never be
+# committed. Harmless data fixtures (*.bin / *.dmp / *.wav) are intentionally NOT blocked.
+# (*.gba is already ignored at the top of this file.)
+# Enforced server-side by .github/workflows/block-binaries.yml + secret-scanning push protection.
+
+# Executables & libraries
+*.com
+*.exe
+*.elf
+*.dll
+*.so
+*.dylib
+*.o
+*.a
+*.lib
+*.obj
+*.pdb
+*.ko
+*.class
+*.out
+*.scr
+*.cpl
+*.wasm
+*.app
+
+# Installers & app packages
+*.msi
+*.msix
+*.appx
+*.deb
+*.rpm
+*.pkg
+*.dmg
+*.apk
+*.ipa
+*.aab
+*.jar
+
+# ROMs, game images & patches
+*.gb
+*.gbc
+*.nds
+*.nes
+*.sfc
+*.smc
+*.n64
+*.z64
+*.v64
+*.3ds
+*.cia
+*.agb
+*.mb
+*.srl
+*.sav
+*.rom
+*.ups
+*.ips
+
+# Disk & filesystem images
+*.iso
+*.img
+*.vhd
+*.vhdx
+*.vmdk
+*.vdi
+*.qcow2
+*.cue
+
+# Archives & compressed
+*.zip
+*.rar
+*.7z
+*.tar
+*.tgz
+*.gz
+*.bz2
+*.xz
+*.lz
+*.lzma
+*.zst
+*.z
+*.cab
+*.arj
+*.lha
+*.lzh
+*.ace
+*.sit
+
+# Secrets, certificates, keys & keystores
+*.pem
+*.crt
+*.cer
+*.der
+*.crl
+*.key
+*.pkey
+*.ppk
+*.p12
+*.pfx
+*.pkcs12
+*.p8
+*.pk8
+*.pkcs8
+*.p7b
+*.p7c
+*.p7r
+*.p7s
+*.spc
+*.csr
+*.jks
+*.jceks
+*.bks
+*.keystore
+*.keychain
+*.pub
+*.asc
+*.gpg
+*.pgp
+*.ovpn
+*.kdbx
+*.mobileprovision
+*.provisionprofile
+*.secret
+*.secrets
+*.credentials
+*.htpasswd
+*.keytab
+*.env
+
+# Secret dotfiles / env / credential files (no blockable extension).
+# .env.example / .sample / .template are re-included so they can still be committed.
+.env
+.env.*
+!.env.example
+!.env.sample
+!.env.template
+.netrc
+.pgpass
+.htpasswd
+.npmrc
+.pypirc
+id_rsa
+id_dsa
+id_ecdsa
+id_ed25519
+
+# ── Exceptions: legitimately-tracked binaries (must stay tracked) ──
+# These fall in the blocked set above; negations MUST come after *.dll / *.elf.
+!FEBuilderGBA/lib/7-zip32.dll
+!FEBuilderGBA/test/test.elf

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,15 @@ This repo uses **[GitGuardian ggshield](https://github.com/gitguardian/ggshield)
 - **Local (opt-in pre-commit hook):** `pip install pre-commit && pre-commit install --hook-type pre-commit --hook-type commit-msg` (these `--hook-type` flags register **both** the ggshield secret-scan hook *and* the commitlint commit-msg hook — see [Commit & PR Title Convention](#commit--pr-title-convention)), then authenticate once with `ggshield auth login` (or export `GITGUARDIAN_API_KEY`). ggshield then scans each commit and blocks one that would introduce a secret. Escape hatch for a false positive: `SKIP=ggshield git commit …` (or `git commit --no-verify`). Requires pre-commit ≥ 3.2.0.
 - **CI:** `.github/workflows/ggshield.yml` scans the commit range of each push / PR. It runs only when the `GITGUARDIAN_API_KEY` repo secret is set, so **fork PRs skip it** (secrets aren't shared with forks) and it never breaks the build. It's an advisory (non-required) check — a finding fails the check but doesn't hard-block merge.
 
+## Binary, ROM & Secret Files (do not commit)
+
+Executables, ROMs, disk/app images, archives, and secret/certificate/key material must **never** be committed (copyright risk for ROMs; supply-chain/leak risk for the rest). This is enforced two ways:
+
+- **`.gitignore`** blocks the whole class locally (`*.exe`, `*.dll`, `*.elf`, `*.7z`, `*.zip`, `*.nds`, `*.iso`, `*.pem`, `*.key`, `*.p12`, `*.env`, `id_rsa`, … — see the *Security / hygiene* block). `*.gba` and `/roms/` are also blocked.
+- **`.github/workflows/block-binaries.yml`** is a required-eligible CI check that fails any push/PR that **adds or modifies** a disallowed file (server-side; GitHub push rulesets aren't available on public repos).
+
+**Intentional exceptions:** the harmless test fixtures `*.bin` / `*.dmp` / `*.wav` are allowed, and the two legitimately-tracked binaries `FEBuilderGBA/lib/7-zip32.dll` (native archive helper) and `FEBuilderGBA/test/test.elf` (ARM test fixture) are explicitly allowlisted in both the `.gitignore` and the workflow. If you have a genuine need to commit another binary, add a documented allowlist entry in both places in the same PR. Together with **ggshield** (content-based) and **secret-scanning push protection**, this gives layered protection against accidental binary/secret commits.
+
 ## Commit & PR Title Convention
 
 Commit subjects and pull-request titles follow the

--- a/README.md
+++ b/README.md
@@ -475,6 +475,8 @@ The step lists every zip entry with its uncompressed size before extraction, so 
 - `AppRunner.Run()` calls `WaitForExit()` (no-param) after `WaitForExit(timeout)` to flush async `OutputDataReceived` events before reading captured stdout
 - `RomLocator` treats any explicit `ROMS_DIR` value (even empty string) as an override — only when the variable is **absent** from the environment does the walk-up fallback activate
 
+**Repository-hygiene guardrail:** `.github/workflows/block-binaries.yml` runs on every push (to `master`) and pull request and **fails** if a commit adds or modifies a binary executable, ROM, disk/app image, archive, or secret/certificate/key file. Harmless test fixtures (`*.bin`/`*.dmp`/`*.wav`) and the two tracked binaries (`FEBuilderGBA/lib/7-zip32.dll`, `FEBuilderGBA/test/test.elf`) are allowlisted. This mirrors the `.gitignore` block and complements ggshield + secret-scanning push protection — see [CONTRIBUTING.md](CONTRIBUTING.md#binary-rom--secret-files-do-not-commit).
+
 ## 🔄 Update System
 
 > **Cutting a release?** See the full-suite release runbook in **[docs/RELEASE.md](docs/RELEASE.md)** — it covers tagging (`ver_YYYYMMDD.NN`), the per-platform artifacts (WinForms / CLI / Avalonia / Android), and the GitHub-release step.

--- a/blocktest.exe
+++ b/blocktest.exe
@@ -1,0 +1,1 @@
+MZ fake executable for CI block proof


### PR DESCRIPTION
Temporary PR to prove `.github/workflows/block-binaries.yml` fails when a `.exe` is added. Will be closed immediately after the check goes red. Ref #1943.