### PR TITLE
docs(agent-harness): correct FEBUILDER.md CLI command count and layout (#1934)

### DIFF
--- a/agent-harness/FEBUILDER.md
+++ b/agent-harness/FEBUILDER.md
@@ -6,7 +6,7 @@ FEBuilderGBA is a comprehensive ROM hacking suite for the Fire Emblem GBA trilog
 
 ## Backend
 
-The real software is `FEBuilderGBA.CLI` — a cross-platform .NET 9.0 CLI that exposes **~67 commands** (lint, rebuild, text export/import, struct data export/import, disassembly, palette quantization, UPS patching, event compile/disassemble, portrait / battle-animation / MIDI / palette I/O, buildfile & decomp-asset emit, and more). The authoritative, always-current command list is [`docs/cli-reference.md`](../docs/cli-reference.md) (per-argument detail in [`docs/cli-args.md`](../docs/cli-args.md)); the exact count drifts as verbs are added, so treat that reference — not this number — as canonical.
+The real software is `FEBuilderGBA.CLI` — a cross-platform .NET 9.0 CLI that exposes **~67 commands** (lint, rebuild, text export/import, struct data export/import, disassembly, palette quantization, UPS patching, event compile/disassemble, portrait / battle-animation / MIDI / palette I/O, decomp-asset export, and more). The authoritative, always-current command list is [`docs/cli-reference.md`](../docs/cli-reference.md) (per-argument detail in [`docs/cli-args.md`](../docs/cli-args.md)); the exact count drifts as verbs are added, so treat that reference — not this number — as canonical.
 
 The Python CLI harness wraps `FEBuilderGBA.CLI` via subprocess, adding:
 - Stateful session management (track open ROM, undo history)

--- a/agent-harness/FEBUILDER.md
+++ b/agent-harness/FEBUILDER.md
@@ -43,7 +43,7 @@ Coverage note below.
 | `rom` | ROM info, validate, version detection, tables, header, save |
 | `data` | Struct data export/import (40 tables: units, classes, items, etc.), roundtrip, inspect, diff, lookup |
 | `text` | Text export/import, search, roundtrip validation |
-| `patch` | Patch operations — list, create UPS, apply UPS |
+| `patch` | Patch operations — list, create UPS, apply UPS, apply BIN (`apply-bin`) |
 | `image` | Palette quantization (`quantize`), map tile conversion (`convert-map`) |
 | `session` | Session management (open, close, status, history) |
 

--- a/agent-harness/FEBUILDER.md
+++ b/agent-harness/FEBUILDER.md
@@ -6,7 +6,7 @@ FEBuilderGBA is a comprehensive ROM hacking suite for the Fire Emblem GBA trilog
 
 ## Backend
 
-The real software is `FEBuilderGBA.CLI` — a cross-platform .NET 9.0 CLI that already supports 15+ commands (lint, rebuild, text export/import, struct data export/import, disassembly, palette quantization, UPS patching, etc.).
+The real software is `FEBuilderGBA.CLI` — a cross-platform .NET 9.0 CLI that exposes **~67 commands** (lint, rebuild, text export/import, struct data export/import, disassembly, palette quantization, UPS patching, event compile/disassemble, portrait / battle-animation / MIDI / palette I/O, buildfile & decomp-asset emit, and more). The authoritative, always-current command list is [`docs/cli-reference.md`](../docs/cli-reference.md) (per-argument detail in [`docs/cli-args.md`](../docs/cli-args.md)); the exact count drifts as verbs are added, so treat that reference — not this number — as canonical.
 
 The Python CLI harness wraps `FEBuilderGBA.CLI` via subprocess, adding:
 - Stateful session management (track open ROM, undo history)
@@ -29,21 +29,46 @@ Python CLI Harness (cli-anything-febuildergba)
               └── ROM manipulation, Huffman text, event scripts, etc.
 ```
 
-## Command Groups
+## Command Layout
+
+The Python harness (`cli_anything/febuildergba/febuildergba_cli.py`) exposes its surface as six
+**Click command groups** (each with subcommands) plus a set of **standalone top-level commands**.
+These harness commands are a *subset* of the backend's ~67 `FEBuilderGBA.CLI` verbs — see the
+Coverage note below.
+
+### Command groups
 
 | Group | Purpose |
 |-------|---------|
-| `rom` | ROM loading, info, validate, version detection |
-| `data` | Struct data export/import (40 tables: units, classes, items, etc.) |
-| `text` | Text export/import, roundtrip validation |
-| `lint` | ROM integrity validation |
-| `patch` | UPS patch creation/application |
-| `disasm` | Disassemble ROM to text file |
+| `rom` | ROM info, validate, version detection, tables, header, save |
+| `data` | Struct data export/import (40 tables: units, classes, items, etc.), roundtrip, inspect, diff, lookup |
+| `text` | Text export/import, search, roundtrip validation |
+| `patch` | Patch operations — list, create UPS, apply UPS |
 | `image` | Palette quantization (`quantize`), map tile conversion (`convert-map`) |
+| `session` | Session management (open, close, status, history) |
+
+### Standalone commands
+
+| Command | Purpose |
+|---------|---------|
+| `lint` | ROM integrity validation |
+| `disasm` | Disassemble ROM to a text file |
 | `songexchange` | Song exchange between ROMs |
+| `names` | Resolve unit/class/item/song IDs to names |
+| `portrait` | Render a unit portrait to PNG |
+| `export-midi` | Export a ROM song to MIDI |
+| `disasm-event` | Disassemble an event/procs/AI script at an address |
+| `lint-oam` | Validate battle-animation OAM data |
 | `rebuild` | ROM defragmentation/rebuild |
 | `pointercalc` | Search for pointer references in ROM |
-| `session` | Session management (open, close, status, history) |
+| `check` | Verify the `FEBuilderGBA.CLI` backend is available |
+
+> A hidden interactive `repl` command also exists (not part of the normal command surface).
+>
+> **Coverage:** the harness currently wraps roughly a third of the backend's ~67
+> `FEBuilderGBA.CLI` verbs — the harness Click commands above are a subset of the full CLI
+> ([`docs/cli-reference.md`](../docs/cli-reference.md)). Closing that harness↔CLI coverage gap is
+> tracked in [#1933](https://github.com/laqieer/FEBuilderGBA/issues/1933).
 
 ## Data Formats
 


### PR DESCRIPTION
## Summary

Fixes the stale command-count and command-layout documentation in `agent-harness/FEBUILDER.md` (the harness SOP). The Backend section claimed the backend "already supports **15+ commands**"; the real `FEBuilderGBA.CLI` now exposes **~67**. It also had a "Command Groups" table that conflated the 6 real Click groups with standalone commands and omitted 6 newer ones.

Closes #1934.

## Plan & review

- Plan: https://github.com/laqieer/FEBuilderGBA/issues/1934#issuecomment-4928291056
- Plan Review Gate (Cross-Model Board, 3/3 APPROVE, zero blocking): https://github.com/laqieer/FEBuilderGBA/issues/1934#issuecomment-4928397478

## Changes (docs-only, single file)

1. **Backend count** — "15+ commands" → "**~67 commands**", deferring to [`docs/cli-reference.md`](../blob/master/docs/cli-reference.md) as the *authoritative, always-current* list (the exact figure drifts as verbs are added), rather than re-asserting a brittle number in a second doc.
2. **Command layout** — replaced the single mislabeled "Command Groups" table with two accurate tables verified against `febuildergba_cli.py`:
   - **Command groups** (6 real `@cli.group()`): `rom`, `data`, `text`, `patch`, `image`, `session`.
   - **Standalone commands** (all 11 `@cli.command()`): `lint`, `disasm`, `songexchange`, `names`, `portrait`, `export-midi`, `disasm-event`, `lint-oam`, `rebuild`, `pointercalc`, `check`.
   Plus a note on the hidden `repl` and a **Coverage** callout pointing the harness↔CLI gap at #1933.

## Test plan

- [x] Verified `~67` is consistent with the authoritative list (`docs/cli-reference.md` headings + `CLAUDE.md` count note; real figure ~67–68 — tilde covers the drift).
- [x] Verified the 6 groups + 11 standalone commands against `agent-harness/cli_anything/febuildergba/febuildergba_cli.py` (`@cli.group()` / `@cli.command()` decorators, line-cited by the board).
- [x] Verified relative links resolve: `../docs/cli-reference.md` and `../docs/cli-args.md` exist at repo root.
- [x] Docs-only Markdown change — no unit/E2E tests apply; no build/behavior impact.

## Screenshots

N/A — `docs` PR (screenshots optional per the workflow). Proof is the rendered Markdown diff above.

Copilot CLI: 1.0.70-0
Model: Claude Opus 4.8 (claude-opus-4.8)
