### PR TITLE
build(security): update wheel bootstrap dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ FEBuilderGBA.CLI --playtest --rom=mod.gba --scenario=scenario.json \
 ```
 
 mGBA is never bundled or installed automatically. See
-[Headless Playtest](docs/HEADLESS-PLAYTEST.md) for the pinned-source bootstrap,
-scenario schema, deterministic startup contract, safety boundary, and CI proof.
+[Headless Playtest](docs/HEADLESS-PLAYTEST.md) for the hash-locked,
+security-patched build prerequisites, pinned-source bootstrap, scenario schema,
+deterministic startup contract, safety boundary, and CI proof.
 
 > **🧭 GUI strategy — two front-ends, two standards.** The **WinForms GUI**
 > (`FEBuilderGBA`) is the mature, widely-used desktop app; its goal is

--- a/docs/HEADLESS-PLAYTEST.md
+++ b/docs/HEADLESS-PLAYTEST.md
@@ -15,6 +15,9 @@ never downloads or installs dependencies at command runtime.
 - Source is pinned to version `0.10.5`, commit
   `26b7884bc25a5933960f3cdcd98bac1ae14d42e2`, and archive SHA-256
   `9475c26e9fa2f4b30c07ab6636e4b0a5b62e4baee2109ede7b2fecc52edae366`.
+- Python build prerequisites are installed only by the explicit bootstrap,
+  from security-patched pure-Python wheels pinned by exact version and
+  SHA-256. They are never installed by the playtest runtime.
 - mGBA is MPL-2.0. It is built locally into the ignored
   `tools/gba-playtest/.mgba-build/` directory and is not distributed in this
   repository or the FEBuilderGBA CLI archive.

--- a/tools/gba-playtest/README.md
+++ b/tools/gba-playtest/README.md
@@ -28,7 +28,8 @@ canonical `FEBuilderGBA.CLI --playtest` command and the agent-harness
 | `febuildergba_playtest/mgba_backend.py` | Pinned mGBA 0.10.5 adapter (delayed import). |
 | `febuildergba_playtest/__main__.py` | CLI entrypoint: one JSON object on stdout. |
 | `scenario.schema.json` | JSON Schema documenting the accepted scenario shape. |
-| `requirements-mgba-build.txt` | Hash-locked Python build inputs for the bootstrap. |
+| `requirements-mgba-bootstrap.txt` | Hash-locked, security-patched pure-Python bootstrap wheels. |
+| `requirements-mgba-build.txt` | Hash-locked Python source-build inputs for the bootstrap. |
 | `tests/` | Dependency-free unit tests (no mGBA, no proprietary ROM). |
 
 ## Exit codes

--- a/tools/gba-playtest/requirements-mgba-bootstrap.txt
+++ b/tools/gba-playtest/requirements-mgba-bootstrap.txt
@@ -7,7 +7,7 @@
 # stage-2 source builds can run with --no-build-isolation against a known,
 # hash-verified build backend. mGBA's official setup.py declares
 # setup_requires=['cffi', 'pytest-runner']; a fresh Python 3.14 venv may also
-# lack setuptools/wheel, so all three are pinned here.
+# lack setuptools/wheel/packaging, so all four are pinned here.
 #
 # Installed with:
 #   pip install --require-hashes --only-binary :all: \
@@ -20,8 +20,11 @@
 setuptools==83.0.0 \
     --hash=sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3
 
-wheel==0.45.1 \
-    --hash=sha256:708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248
+packaging==26.2 \
+    --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e
+
+wheel==0.46.2 \
+    --hash=sha256:33ae60725d69eaa249bc1982e739943c23b34b58d51f1cb6253453773aca6e65
 
 pytest-runner==6.0.1 \
     --hash=sha256:ea326ed6f6613992746062362efab70212089a4209c08d67177b3df1c52cd9f2

--- a/tools/gba-playtest/tests/test_bootstrap.py
+++ b/tools/gba-playtest/tests/test_bootstrap.py
@@ -53,7 +53,7 @@ REAL_WORKFLOW = os.path.join(REPO_ROOT, ".github", "workflows", "gba-playtest.ym
 BUILD_SCRIPT = SH
 
 # Every package name that must appear, hash-pinned, across the two stages.
-REQUIRED_BOOTSTRAP_PACKAGES = ("setuptools", "wheel", "pytest-runner")
+REQUIRED_BOOTSTRAP_PACKAGES = ("setuptools", "packaging", "wheel", "pytest-runner")
 REQUIRED_BUILD_PACKAGES = ("cffi", "pycparser", "cached-property")
 
 
@@ -1044,7 +1044,7 @@ def test_bootstrap_requirements_are_fully_hashed():
     text = _read(REQUIREMENTS_BOOTSTRAP)
     pins = re.findall(r"^\s*([A-Za-z0-9_.-]+)==", text, re.MULTILINE)
     hashes = re.findall(r"--hash=sha256:([0-9a-f]{64})", text)
-    assert len(pins) >= 3
+    assert len(pins) >= 4
     assert len(hashes) >= len(pins)
     assert "placeholder" not in text.lower()
     assert "0000000000000000000000000000000000000000000000000000000000000000" not in text
@@ -1064,6 +1064,30 @@ def test_pinned_build_stack_supports_current_msys2_python_314():
     build = _read(REQUIREMENTS)
     assert re.search(r"(?mi)^\s*setuptools==83\.0\.0\b", bootstrap)
     assert re.search(r"(?mi)^\s*cffi==2\.1\.0\b", build)
+
+
+def test_wheel_pin_is_the_security_fix_release_with_exact_hash():
+    bootstrap = _read(REQUIREMENTS_BOOTSTRAP)
+    wheel_pins = re.findall(r"(?mi)^\s*wheel==([^\s\\]+)", bootstrap)
+    packaging_pins = re.findall(r"(?mi)^\s*packaging==([^\s\\]+)", bootstrap)
+    assert wheel_pins == ["0.46.2"], "bootstrap must contain exactly one patched wheel pin"
+    assert packaging_pins == ["26.2"], "bootstrap must contain exactly one packaging dependency pin"
+    assert re.search(
+        r"(?mi)^\s*wheel==0\.46\.2\s*\\\s*--hash=sha256:"
+        r"33ae60725d69eaa249bc1982e739943c23b34b58d51f1cb6253453773aca6e65\b",
+        bootstrap,
+    ), "wheel must be pinned to 0.46.2 with its exact official wheel hash"
+    assert re.search(
+        r"(?mi)^\s*packaging==26\.2\s*\\\s*--hash=sha256:"
+        r"5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e\b",
+        bootstrap,
+    ), "wheel's packaging dependency must be pinned with its exact official wheel hash"
+    assert not re.search(r"(?mi)^\s*wheel==0\.45\.1\b", bootstrap), (
+        "the vulnerable wheel 0.45.1 pin must be removed, not just superseded"
+    )
+    assert "708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248" not in bootstrap, (
+        "the vulnerable wheel 0.45.1 hash must not remain in the requirements file"
+    )
 
 
 def test_cffi_pin_is_the_mingw_atomic_fix_release_with_exact_hash():


### PR DESCRIPTION
## Summary

- update the mGBA bootstrap from vulnerable `wheel==0.45.1` to patched `wheel==0.46.2` with the official PyPI wheel hash
- pin and hash `packaging==26.2`, the patched wheel release's new runtime dependency, so `--require-hashes` retains a complete fail-closed dependency graph
- add exact-version/hash regression coverage, update the required bootstrap package contract, and document the explicit security-patched bootstrap boundary

## Plan Reference

Implements the accepted plan from https://github.com/laqieer/FEBuilderGBA/issues/1984#issuecomment-5011191062

Plan Review Gate: https://github.com/laqieer/FEBuilderGBA/issues/1984#issuecomment-5011225282

## Scope

Closes #1984

Resolves Dependabot alert #5 (GHSA-8rrh-rw8j-w5fx / CVE-2026-24049) after the merged default branch is rescanned.

## Screenshots

Not applicable: this is a build-security dependency and documentation update with no GUI behavior.

## Test plan

- [x] all 463 dependency-free `tools/gba-playtest/tests` tests pass
- [x] all 84 focused bootstrap contract tests pass
- [x] no-cache official-PyPI `pip download --require-hashes --only-binary=:all:` resolves and verifies all four stage-1 wheels
- [x] a plain throwaway venv installs the complete hash-locked set and reports `wheel 0.46.2`, `packaging 26.2`, `setuptools 83.0.0`, and `pytest-runner 6.0.1`
- [x] `git diff --check` passes

## Known limitations

The required local `pre-commit install --hook-type commit-msg --install-hooks` attempt was made, but pre-commit correctly refused to overwrite this checkout's configured `core.hooksPath`; the existing repository hook and CI commit-lint job remain authoritative.

Copilot CLI: 1.0.72-0
Model: GPT-5.6 Sol (gpt-5.6-sol)