### PR TITLE
docs: use Gemini 3.6 Flash for review board

### DIFF
--- a/DEVELOPMENT-WORKFLOW.md
+++ b/DEVELOPMENT-WORKFLOW.md
@@ -93,7 +93,7 @@ unless the PR satisfies every screenshot-only helper exemption predicate above.
    |---|---|---|
    | OpenAI | `gpt-5.6-sol` (GPT-5.6 Sol) | `gpt-5.5` (GPT-5.5) |
    | Anthropic | `claude-opus-4.8` (Claude Opus 4.8) | `claude-sonnet-5` (Claude Sonnet 5) |
-   | Google | `gemini-3.5-flash` (Gemini 3.5 Flash) | `gemini-3.1-pro-preview` (Gemini 3.1 Pro Preview) |
+   | Google | `gemini-3.6-flash` (Gemini 3.6 Flash) | `gemini-3.1-pro-preview` (Gemini 3.1 Pro Preview) |
 
    **Independence:** if your own active model is a primary, swap that member for its named alternate so all
    three reviewers differ from you; keep ≥2 providers (Anthropic / OpenAI / Google). If a roster/alternate model is
@@ -135,7 +135,7 @@ unless the PR satisfies every screenshot-only helper exemption predicate above.
    End the posted review with a board-roster line **immediately above** the mandatory 2-line footer (so
    `.github/copilot-instructions.md` stays satisfied):
    ```
-   Review Board: gpt-5.6-sol, claude-opus-4.8, gemini-3.5-flash
+   Review Board: gpt-5.6-sol, claude-opus-4.8, gemini-3.6-flash
    Copilot CLI: <version>
    Model: <display-name> (<model-id>)
    ```


### PR DESCRIPTION
## Summary

- replace the current Google primary cross-model reviewer with `gemini-3.6-flash` (Gemini 3.6 Flash)
- update the documented `Review Board:` roster example
- preserve the historical Gemini 3.5 Flash attribution for issue #1998

## Plan

Accepted plan: https://github.com/laqieer/FEBuilderGBA/issues/2005#issuecomment-5047824989  
Plan review gate: https://github.com/laqieer/FEBuilderGBA/issues/2005#issuecomment-5047893443

Closes #2005

## Test plan

- [x] `git diff --check`
- [x] tracked search confirms the only remaining `gemini-3.5-flash` reference is the historical `MapEditorView.axaml.cs` attribution
- [x] tracked search confirms both active workflow references use `gemini-3.6-flash`
- [x] reviewed the final documentation diff for scope and formatting

## Notes

`pre-commit install --hook-type commit-msg --install-hooks` was attempted before commit; it declined because this checkout already configures `core.hooksPath`. Existing repository hooks and CI remain authoritative.

Copilot CLI: 1.0.74-0
Model: GPT-5.6 Sol (gpt-5.6-sol)