### PR TITLE
docs: use Claude Opus 5 for review board

### DIFF
--- a/DEVELOPMENT-WORKFLOW.md
+++ b/DEVELOPMENT-WORKFLOW.md
@@ -92,7 +92,7 @@ unless the PR satisfies every screenshot-only helper exemption predicate above.
    | Provider | Primary | Same-provider alternate |
    |---|---|---|
    | OpenAI | `gpt-5.6-sol` (GPT-5.6 Sol) | `gpt-5.5` (GPT-5.5) |
-   | Anthropic | `claude-opus-4.8` (Claude Opus 4.8) | `claude-sonnet-5` (Claude Sonnet 5) |
+   | Anthropic | `claude-opus-5` (Claude Opus 5) | `claude-sonnet-5` (Claude Sonnet 5) |
    | Google | `gemini-3.6-flash` (Gemini 3.6 Flash) | `gemini-3.1-pro-preview` (Gemini 3.1 Pro Preview) |
 
    **Independence:** if your own active model is a primary, swap that member for its named alternate so all
@@ -135,7 +135,7 @@ unless the PR satisfies every screenshot-only helper exemption predicate above.
    End the posted review with a board-roster line **immediately above** the mandatory 2-line footer (so
    `.github/copilot-instructions.md` stays satisfied):
    ```
-   Review Board: gpt-5.6-sol, claude-opus-4.8, gemini-3.6-flash
+   Review Board: gpt-5.6-sol, claude-opus-5, gemini-3.6-flash
    Copilot CLI: <version>
    Model: <display-name> (<model-id>)
    ```


### PR DESCRIPTION
## Summary

- Replace the active Anthropic cross-model reviewer with Claude Opus 5.
- Update the documented `Review Board:` roster example to use `claude-opus-5`.
- Preserve the Sonnet alternate, other provider models, and historical Opus 4.8 provenance.

## Plan Reference

Implements the accepted plan from https://github.com/laqieer/FEBuilderGBA/issues/2014#issuecomment-5076832477

Plan review: https://github.com/laqieer/FEBuilderGBA/issues/2014#issuecomment-5076851221

## Scope

Closes #2014

## Test plan

- [x] `git diff --check origin/master...HEAD` reports no whitespace errors.
- [x] The commit changes only `DEVELOPMENT-WORKFLOW.md`, with two insertions and two deletions.
- [x] `DEVELOPMENT-WORKFLOW.md` has no remaining active Claude Opus 4.8 model ID or display-name reference.
- [x] `DEVELOPMENT-WORKFLOW.md` contains the two expected Claude Opus 5 references.
- [x] `pr-screenshots/pr1389-mapanime1gfx-fe8u.txt:41` retains its historical Claude Opus 4.8 attribution.

## Known limitations

None. This is a documentation/workflow-only change with no runtime behavior.

Copilot CLI: 1.0.75
Model: GPT-5.6 Sol (gpt-5.6-sol)