### PR TITLE
docs: replace Claude reviewer with Grok 4.5

### DIFF
--- a/DEVELOPMENT-WORKFLOW.md
+++ b/DEVELOPMENT-WORKFLOW.md
@@ -95,22 +95,20 @@ unless the PR satisfies every screenshot-only helper exemption predicate above.
    | xAI | `grok-4.5` (Grok 4.5) | — (no xAI alternate exposed; use the fallback below) |
    | Google | `gemini-3.6-flash` (Gemini 3.6 Flash) | `gemini-3.1-pro-preview` (Gemini 3.1 Pro Preview) |
 
-   **Independence (apply in order):**
-   1. Start with each seat's primary model.
-   2. If that primary is unavailable or equals your active developer model, use its named same-provider alternate
-      when one is exposed, available, distinct, and not the developer model.
-   3. If the seat has no usable same-provider alternate (including the `grok-4.5` seat), substitute an available
-      model from a different provider than that seat. The substitute must be neither the developer model nor
-      already on the board. Prefer the other providers' unused named alternates in this order:
-      `gemini-3.1-pro-preview`, then `gpt-5.5`; otherwise choose the lexicographically smallest model id among
-      the remaining available different-provider candidates (ordinal order on canonical lowercase ids).
-   4. The final board must contain exactly three distinct reviewers, none equal to the developer model, from at
-      least two providers (OpenAI / xAI / Google). Note every substitution in the consolidated review.
-   Resolve seats top-to-bottom in table order and recompute candidates after every substitution. If no legal
-   candidate set satisfies step 4, fail closed and report that the cross-model board cannot be convened.
+   **Independence (deterministic complete-board search):**
+   1. For each provider seat, build an ordered candidate list containing: its eligible primary; its eligible named
+      same-provider alternate; the other providers' eligible named alternates in this order
+      (`gemini-3.1-pro-preview`, then `gpt-5.5`); then all remaining eligible different-provider models in ordinal
+      order by canonical lowercase model id. Eligible means available and not the active developer model.
+   2. Enumerate complete three-seat tuples depth-first in table-seat order and each seat's candidate order. Reject
+      any tuple with duplicate models or fewer than two providers. The default seats are OpenAI / xAI / Google.
+   3. Select the first legal tuple. Note every seat that did not use its primary in the consolidated review.
+      If no legal tuple exists, fail closed and report that the cross-model board cannot be convened.
 
    Examples: active `gpt-5.6-sol` ⇒ `gpt-5.5`, `grok-4.5`, `gemini-3.6-flash`;
    active `grok-4.5` ⇒ `gpt-5.6-sol`, `gemini-3.1-pro-preview`, `gemini-3.6-flash`.
+   The complete search may backtrack: if Grok and the Google primary are unavailable, it must not consume
+   `gemini-3.1-pro-preview` for the xAI seat when a later Google seat needs it and another legal xAI fallback exists.
 2. **Pass identifiers, not embedded content — every reviewer fetches its own full source-of-truth context inside
    its own isolated invocation.** Give each reviewer prompt only:
    - **Plan gate (Phase 2):** the issue number and the plan-comment URL/ID.

--- a/DEVELOPMENT-WORKFLOW.md
+++ b/DEVELOPMENT-WORKFLOW.md
@@ -92,12 +92,22 @@ unless the PR satisfies every screenshot-only helper exemption predicate above.
    | Provider | Primary | Same-provider alternate |
    |---|---|---|
    | OpenAI | `gpt-5.6-sol` (GPT-5.6 Sol) | `gpt-5.5` (GPT-5.5) |
-   | Anthropic | `claude-opus-5` (Claude Opus 5) | `claude-sonnet-5` (Claude Sonnet 5) |
+   | xAI | `grok-4.5` (Grok 4.5) | — (no xAI alternate exposed; use the fallback below) |
    | Google | `gemini-3.6-flash` (Gemini 3.6 Flash) | `gemini-3.1-pro-preview` (Gemini 3.1 Pro Preview) |
 
-   **Independence:** if your own active model is a primary, swap that member for its named alternate so all
-   three reviewers differ from you; keep ≥2 providers (Anthropic / OpenAI / Google). If a roster/alternate model is
-   unavailable, substitute another available model from a different provider and note the substitution.
+   **Independence (apply in order):**
+   1. Start with each seat's primary model.
+   2. If that primary is unavailable or equals your active developer model, use its named same-provider alternate
+      when one is exposed, available, distinct, and not the developer model.
+   3. If the seat has no usable same-provider alternate (including the `grok-4.5` seat), substitute an available
+      model from a different provider than that seat. The substitute must be neither the developer model nor
+      already on the board. Prefer the other providers' unused named alternates in this order:
+      `gemini-3.1-pro-preview`, then `gpt-5.5`; otherwise use another available different-provider model.
+   4. The final board must contain exactly three distinct reviewers, none equal to the developer model, from at
+      least two providers (OpenAI / xAI / Google). Note every substitution in the consolidated review.
+
+   Examples: active `gpt-5.6-sol` ⇒ `gpt-5.5`, `grok-4.5`, `gemini-3.6-flash`;
+   active `grok-4.5` ⇒ `gpt-5.6-sol`, `gemini-3.1-pro-preview`, `gemini-3.6-flash`.
 2. **Pass identifiers, not embedded content — every reviewer fetches its own full source-of-truth context inside
    its own isolated invocation.** Give each reviewer prompt only:
    - **Plan gate (Phase 2):** the issue number and the plan-comment URL/ID.
@@ -135,7 +145,7 @@ unless the PR satisfies every screenshot-only helper exemption predicate above.
    End the posted review with a board-roster line **immediately above** the mandatory 2-line footer (so
    `.github/copilot-instructions.md` stays satisfied):
    ```
-   Review Board: gpt-5.6-sol, claude-opus-5, gemini-3.6-flash
+   Review Board: gpt-5.6-sol, grok-4.5, gemini-3.6-flash
    Copilot CLI: <version>
    Model: <display-name> (<model-id>)
    ```

--- a/DEVELOPMENT-WORKFLOW.md
+++ b/DEVELOPMENT-WORKFLOW.md
@@ -103,9 +103,11 @@ unless the PR satisfies every screenshot-only helper exemption predicate above.
       model from a different provider than that seat. The substitute must be neither the developer model nor
       already on the board. Prefer the other providers' unused named alternates in this order:
       `gemini-3.1-pro-preview`, then `gpt-5.5`; otherwise choose the lexicographically smallest model id among
-      the remaining available different-provider candidates.
+      the remaining available different-provider candidates (ordinal order on canonical lowercase ids).
    4. The final board must contain exactly three distinct reviewers, none equal to the developer model, from at
       least two providers (OpenAI / xAI / Google). Note every substitution in the consolidated review.
+   Resolve seats top-to-bottom in table order and recompute candidates after every substitution. If no legal
+   candidate set satisfies step 4, fail closed and report that the cross-model board cannot be convened.
 
    Examples: active `gpt-5.6-sol` ⇒ `gpt-5.5`, `grok-4.5`, `gemini-3.6-flash`;
    active `grok-4.5` ⇒ `gpt-5.6-sol`, `gemini-3.1-pro-preview`, `gemini-3.6-flash`.

--- a/DEVELOPMENT-WORKFLOW.md
+++ b/DEVELOPMENT-WORKFLOW.md
@@ -98,6 +98,8 @@ unless the PR satisfies every screenshot-only helper exemption predicate above.
    **Independence (closed deterministic complete-board search):**
    - The candidate pool is exactly the five ids in this table: `gpt-5.6-sol`, `gpt-5.5`, `grok-4.5`,
      `gemini-3.6-flash`, and `gemini-3.1-pro-preview`. Do not use unlisted session models or invent an xAI alternate.
+   - Seat order is fixed as OpenAI → xAI → Google. The two GPT ids are OpenAI, Grok is xAI, and the two Gemini ids
+     are Google.
    - The fixed global id order is: `gemini-3.1-pro-preview`, `gemini-3.6-flash`, `gpt-5.5`, `gpt-5.6-sol`,
      `grok-4.5`.
    1. For each provider seat, append each id at most once in this order: its eligible primary; its eligible named
@@ -105,7 +107,7 @@ unless the PR satisfies every screenshot-only helper exemption predicate above.
       `gpt-5.5`); then remaining eligible different-provider ids in the fixed global order. Eligible means listed,
       available, and not the active developer model. Different-provider tiers compare the selected model's actual
       provider with the seat provider.
-   2. Enumerate complete three-seat tuples depth-first in table-seat order and each seat's candidate order. Reject
+   2. Enumerate complete three-seat tuples in nested seat order and each seat's candidate order. Reject
       tuples with duplicate model ids or fewer than two distinct selected-model providers.
    3. Select the first legal tuple and note every non-primary substitution. If no legal tuple exists, do not spawn
       reviewers or post a partial board; fail closed and report that the cross-model board cannot be convened.

--- a/DEVELOPMENT-WORKFLOW.md
+++ b/DEVELOPMENT-WORKFLOW.md
@@ -112,8 +112,11 @@ unless the PR satisfies every screenshot-only helper exemption predicate above.
 
    Examples: active `gpt-5.6-sol` ⇒ `gpt-5.5`, `grok-4.5`, `gemini-3.6-flash`;
    active `grok-4.5` ⇒ `gpt-5.6-sol`, `gemini-3.1-pro-preview`, `gemini-3.6-flash`.
-   The complete search may backtrack: if Grok and the Google primary are unavailable, it must not consume
-   `gemini-3.1-pro-preview` for the xAI seat when a later Google seat needs it and another legal xAI fallback exists.
+   If Grok is unavailable and the developer is `gpt-5.6-sol`, the first legal tuple is `gpt-5.5`,
+   `gemini-3.1-pro-preview`, `gemini-3.6-flash`. If Grok and `gemini-3.6-flash` are unavailable while the developer
+   is outside the three remaining eligible ids, the first legal tuple is `gpt-5.6-sol`,
+   `gemini-3.1-pro-preview`, `gpt-5.5`. With this five-id pool, fewer than three eligible ids means no board:
+   fail closed rather than weakening the reviewer count.
 2. **Pass identifiers, not embedded content — every reviewer fetches its own full source-of-truth context inside
    its own isolated invocation.** Give each reviewer prompt only:
    - **Plan gate (Phase 2):** the issue number and the plan-comment URL/ID.

--- a/DEVELOPMENT-WORKFLOW.md
+++ b/DEVELOPMENT-WORKFLOW.md
@@ -95,15 +95,20 @@ unless the PR satisfies every screenshot-only helper exemption predicate above.
    | xAI | `grok-4.5` (Grok 4.5) | — (no xAI alternate exposed; use the fallback below) |
    | Google | `gemini-3.6-flash` (Gemini 3.6 Flash) | `gemini-3.1-pro-preview` (Gemini 3.1 Pro Preview) |
 
-   **Independence (deterministic complete-board search):**
-   1. For each provider seat, build an ordered candidate list containing: its eligible primary; its eligible named
-      same-provider alternate; the other providers' eligible named alternates in this order
-      (`gemini-3.1-pro-preview`, then `gpt-5.5`); then all remaining eligible different-provider models in ordinal
-      order by canonical lowercase model id. Eligible means available and not the active developer model.
+   **Independence (closed deterministic complete-board search):**
+   - The candidate pool is exactly the five ids in this table: `gpt-5.6-sol`, `gpt-5.5`, `grok-4.5`,
+     `gemini-3.6-flash`, and `gemini-3.1-pro-preview`. Do not use unlisted session models or invent an xAI alternate.
+   - The fixed global id order is: `gemini-3.1-pro-preview`, `gemini-3.6-flash`, `gpt-5.5`, `gpt-5.6-sol`,
+     `grok-4.5`.
+   1. For each provider seat, append each id at most once in this order: its eligible primary; its eligible named
+      same-provider alternate; the other providers' eligible named alternates (`gemini-3.1-pro-preview`, then
+      `gpt-5.5`); then remaining eligible different-provider ids in the fixed global order. Eligible means listed,
+      available, and not the active developer model. Different-provider tiers compare the selected model's actual
+      provider with the seat provider.
    2. Enumerate complete three-seat tuples depth-first in table-seat order and each seat's candidate order. Reject
-      any tuple with duplicate models or fewer than two providers. The default seats are OpenAI / xAI / Google.
-   3. Select the first legal tuple. Note every seat that did not use its primary in the consolidated review.
-      If no legal tuple exists, fail closed and report that the cross-model board cannot be convened.
+      tuples with duplicate model ids or fewer than two distinct selected-model providers.
+   3. Select the first legal tuple and note every non-primary substitution. If no legal tuple exists, do not spawn
+      reviewers or post a partial board; fail closed and report that the cross-model board cannot be convened.
 
    Examples: active `gpt-5.6-sol` ⇒ `gpt-5.5`, `grok-4.5`, `gemini-3.6-flash`;
    active `grok-4.5` ⇒ `gpt-5.6-sol`, `gemini-3.1-pro-preview`, `gemini-3.6-flash`.

--- a/DEVELOPMENT-WORKFLOW.md
+++ b/DEVELOPMENT-WORKFLOW.md
@@ -102,7 +102,8 @@ unless the PR satisfies every screenshot-only helper exemption predicate above.
    3. If the seat has no usable same-provider alternate (including the `grok-4.5` seat), substitute an available
       model from a different provider than that seat. The substitute must be neither the developer model nor
       already on the board. Prefer the other providers' unused named alternates in this order:
-      `gemini-3.1-pro-preview`, then `gpt-5.5`; otherwise use another available different-provider model.
+      `gemini-3.1-pro-preview`, then `gpt-5.5`; otherwise choose the lexicographically smallest model id among
+      the remaining available different-provider candidates.
    4. The final board must contain exactly three distinct reviewers, none equal to the developer model, from at
       least two providers (OpenAI / xAI / Google). Note every substitution in the consolidated review.
 


### PR DESCRIPTION
## Summary

- replace disabled Claude-family Branch-B reviewer models with xAI Grok 4.5
- define deterministic fallback behavior when Grok is unavailable or is the active developer model
- preserve Claude Code CLI / Branch A runtime instructions and all board veto/independence rules
- update the canonical Review Board roster example

## Plan Reference

Implements the accepted plan: https://github.com/laqieer/FEBuilderGBA/issues/2058#issuecomment-5190828656

## Scope

Closes #2058

## Test plan

- [x] active workflow contains `grok-4.5` and the updated canonical roster
- [x] active workflow contains no `claude-opus-*` or `claude-sonnet-*` reviewer ids
- [x] Claude Code CLI / Branch A runtime guidance remains present
- [x] developer=`gpt-5.6-sol` and developer=`grok-4.5` examples satisfy three-distinct / non-developer / at-least-two-provider rules
- [x] Markdown table and ordered fallback prose render coherently

Copilot CLI: 1.0.78
Model: GPT-5.6 Sol (gpt-5.6-sol)