### PR TITLE
ci: pin available JUnit test logger

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -222,7 +222,7 @@ jobs:
 
     - name: Install JUnit Test Logger
       if: always()
-      run: dotnet add FEBuilderGBA.Tests/FEBuilderGBA.Tests.csproj package JunitXml.TestLogger --version 3.1.21
+      run: dotnet add FEBuilderGBA.Tests/FEBuilderGBA.Tests.csproj package JunitXml.TestLogger --version 4.0.254
 
     - name: Restore and Build Test Project
       if: always()

--- a/scripts/tests/test_build_warning_contract.py
+++ b/scripts/tests/test_build_warning_contract.py
@@ -381,6 +381,28 @@ class BuildWarningContractTests(unittest.TestCase):
         ]
         self.assertEqual([], offenders)
 
+    def test_msbuild_junit_logger_uses_available_exact_version(self) -> None:
+        workflow = (WORKFLOWS_DIR / "msbuild.yml").read_text(encoding="utf-8")
+        install_steps = [
+            step
+            for step in parse_workflow_runs(workflow, "msbuild.yml")
+            if step.name == "Install JUnit Test Logger"
+        ]
+
+        self.assertEqual(1, len(install_steps))
+        self.assertEqual(
+            [
+                "dotnet",
+                "add",
+                "FEBuilderGBA.Tests/FEBuilderGBA.Tests.csproj",
+                "package",
+                "JunitXml.TestLogger",
+                "--version",
+                "4.0.254",
+            ],
+            split_shell_words(install_steps[0].command),
+        )
+
     def test_colorzcore_compiles_have_explicit_matching_restore(self) -> None:
         failures: list[str] = []
         by_workflow_job: dict[tuple[str, str], list[DotnetInvocation]] = {}

--- a/scripts/tests/test_build_warning_contract.py
+++ b/scripts/tests/test_build_warning_contract.py
@@ -383,9 +383,10 @@ class BuildWarningContractTests(unittest.TestCase):
 
     def test_msbuild_junit_logger_uses_available_exact_version(self) -> None:
         workflow = (WORKFLOWS_DIR / "msbuild.yml").read_text(encoding="utf-8")
+        steps = parse_workflow_runs(workflow, "msbuild.yml")
         install_steps = [
             step
-            for step in parse_workflow_runs(workflow, "msbuild.yml")
+            for step in steps
             if step.name == "Install JUnit Test Logger"
         ]
 
@@ -401,6 +402,39 @@ class BuildWarningContractTests(unittest.TestCase):
                 "4.0.254",
             ],
             split_shell_words(install_steps[0].command),
+        )
+
+        install_index = steps.index(install_steps[0])
+        sequence = steps[install_index : install_index + 3]
+        self.assertEqual(
+            [
+                "Install JUnit Test Logger",
+                "Restore and Build Test Project",
+                "Re-run Tests with JUnit Logger",
+            ],
+            [step.name for step in sequence],
+        )
+
+        build_invocations = dotnet_invocations(sequence[1])
+        self.assertEqual(1, len(build_invocations))
+        self.assertEqual("build", build_invocations[0].verb)
+        self.assertEqual(
+            "FEBuilderGBA.Tests/FEBuilderGBA.Tests.csproj",
+            build_invocations[0].project,
+        )
+        self.assertTrue(has_cli_warn_as_error(build_invocations[0].tokens))
+
+        test_invocations = dotnet_invocations(sequence[2])
+        self.assertEqual(1, len(test_invocations))
+        self.assertEqual("test", test_invocations[0].verb)
+        self.assertEqual(
+            "FEBuilderGBA.Tests/FEBuilderGBA.Tests.csproj",
+            test_invocations[0].project,
+        )
+        self.assertIn("--no-build", test_invocations[0].tokens)
+        self.assertIn(
+            "junit;LogFileName=test-results.xml",
+            [token.strip("\"'") for token in test_invocations[0].tokens],
         )
 
     def test_colorzcore_compiles_have_explicit_matching_restore(self) -> None:


### PR DESCRIPTION
## Summary
- pin the dynamically installed JUnit logger to available version `4.0.254`
- add a fail-closed workflow contract for the exact install command
- preserve warning-as-error build and JUnit rerun semantics

## Plan Reference
Implements the post-merge plan from https://github.com/laqieer/FEBuilderGBA/issues/2067#issuecomment-5232504630

## Scope
Closes #2067

## Test plan
- [x] Workflow warning contracts: 8 passed
- [x] Dynamic `dotnet add` with JunitXml.TestLogger 4.0.254: success
- [x] FEBuilderGBA.Tests Release build with `-warnaserror`: 0 warnings, 0 errors
- [x] JUnit logger test rerun: 2,357 passed, 0 failed
- [x] `git diff --check`: clean

## Known limitations
- Local commit-msg hook provisioning remains blocked by the host npm TLS handshake; CI commit lint remains authoritative.

Copilot CLI: 1.0.78
Model: GPT-5.6 Sol (gpt-5.6-sol)