### PR TITLE
fix(avalonia): restore project mode from recent files

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/RecentFileProjectModeTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/RecentFileProjectModeTests.cs
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.IO;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.Views;
+using global::Avalonia.Controls;
+using global::Avalonia.Headless.XUnit;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+[Collection("SharedState")]
+public sealed class RecentFileProjectModeTests
+{
+    sealed class MainWindowHarness : IDisposable
+    {
+        readonly Window? _previousMainWindow = WindowManager.Instance.MainWindow;
+
+        public MainWindow Window { get; } = new();
+
+        public void Dispose()
+        {
+            try { Window.Close(); } catch { }
+            WindowManager.Instance.MainWindow = _previousMainWindow;
+        }
+    }
+
+    static string NewTestDir()
+    {
+        string dir = Path.Combine(
+            AppContext.BaseDirectory,
+            "recent_project_mode_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    static string CreateDecompRom(string root)
+    {
+        string outputDir = Path.Combine(root, "build", "release");
+        Directory.CreateDirectory(outputDir);
+        File.WriteAllText(
+            Path.Combine(root, DecompProject.ManifestFileName),
+            "{ \"schemaVersion\": 1, \"builtRom\": \"build/release/game.gba\" }");
+        string romPath = Path.Combine(outputDir, "game.gba");
+        File.WriteAllBytes(romPath, new byte[] { 0, 1, 2, 3 });
+        return romPath;
+    }
+
+    [AvaloniaFact]
+    public void RecentLoad_DecompToPlain_ClearsProjectBeforeLoading()
+    {
+        string dir = NewTestDir();
+        DecompProject? previousProject = CoreState.DecompProject;
+        try
+        {
+            string plainRom = Path.Combine(dir, "plain.gba");
+            File.WriteAllBytes(plainRom, new byte[] { 0, 1, 2, 3 });
+            CoreState.DecompProject = new DecompProject
+            {
+                ProjectRoot = dir,
+                BuiltRomPath = Path.Combine(dir, "old.gba"),
+            };
+            using var harness = new MainWindowHarness();
+
+            bool loaded = harness.Window.LoadRecentRomFile(plainRom, path =>
+            {
+                Assert.Equal(plainRom, path);
+                Assert.Null(CoreState.DecompProject);
+                return true;
+            });
+
+            Assert.True(loaded);
+            Assert.Null(CoreState.DecompProject);
+        }
+        finally
+        {
+            CoreState.DecompProject = previousProject;
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [AvaloniaFact]
+    public void RecentLoad_PlainToDecomp_SetsMatchingProjectBeforeLoading()
+    {
+        string dir = NewTestDir();
+        DecompProject? previousProject = CoreState.DecompProject;
+        try
+        {
+            string decompRom = CreateDecompRom(dir);
+            CoreState.DecompProject = null;
+            using var harness = new MainWindowHarness();
+
+            bool loaded = harness.Window.LoadRecentRomFile(decompRom, path =>
+            {
+                Assert.Equal(decompRom, path);
+                Assert.NotNull(CoreState.DecompProject);
+                Assert.Equal(Path.GetFullPath(decompRom), CoreState.DecompProject!.BuiltRomPath);
+                return true;
+            });
+
+            Assert.True(loaded);
+            Assert.NotNull(CoreState.DecompProject);
+            Assert.Equal(Path.GetFullPath(dir), CoreState.DecompProject!.ProjectRoot);
+        }
+        finally
+        {
+            CoreState.DecompProject = previousProject;
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [AvaloniaFact]
+    public void RecentLoad_FailureClearsDetectedProject()
+    {
+        string dir = NewTestDir();
+        DecompProject? previousProject = CoreState.DecompProject;
+        try
+        {
+            string decompRom = CreateDecompRom(dir);
+            CoreState.DecompProject = null;
+            using var harness = new MainWindowHarness();
+            DecompProject? projectDuringLoad = null;
+
+            bool loaded = harness.Window.LoadRecentRomFile(decompRom, _ =>
+            {
+                projectDuringLoad = CoreState.DecompProject;
+                return false;
+            });
+
+            Assert.False(loaded);
+            Assert.NotNull(projectDuringLoad);
+            Assert.Null(CoreState.DecompProject);
+        }
+        finally
+        {
+            CoreState.DecompProject = previousProject;
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [AvaloniaFact]
+    public void RecentLoad_ExceptionClearsDetectedProjectAndPropagates()
+    {
+        string dir = NewTestDir();
+        DecompProject? previousProject = CoreState.DecompProject;
+        try
+        {
+            string decompRom = CreateDecompRom(dir);
+            CoreState.DecompProject = null;
+            using var harness = new MainWindowHarness();
+
+            Assert.Throws<InvalidOperationException>(() =>
+                harness.Window.LoadRecentRomFile(
+                    decompRom,
+                    _ => throw new InvalidOperationException("load failed")));
+
+            Assert.Null(CoreState.DecompProject);
+        }
+        finally
+        {
+            CoreState.DecompProject = previousProject;
+            Directory.Delete(dir, true);
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/RecentFileProjectModeTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/RecentFileProjectModeTests.cs
@@ -34,13 +34,17 @@ public sealed class RecentFileProjectModeTests
         return dir;
     }
 
-    static string CreateDecompRom(string root)
+    static string CreateDecompRom(string root, string? forceVersion = null)
     {
         string outputDir = Path.Combine(root, "build", "release");
         Directory.CreateDirectory(outputDir);
+        string forceVersionJson = forceVersion == null
+            ? ""
+            : $", \"forceVersion\": \"{forceVersion}\"";
         File.WriteAllText(
             Path.Combine(root, DecompProject.ManifestFileName),
-            "{ \"schemaVersion\": 1, \"builtRom\": \"build/release/game.gba\" }");
+            "{ \"schemaVersion\": 1, \"builtRom\": \"build/release/game.gba\""
+            + forceVersionJson + " }");
         string romPath = Path.Combine(outputDir, "game.gba");
         File.WriteAllBytes(romPath, new byte[] { 0, 1, 2, 3 });
         return romPath;
@@ -62,9 +66,10 @@ public sealed class RecentFileProjectModeTests
             };
             using var harness = new MainWindowHarness();
 
-            bool loaded = harness.Window.LoadRecentRomFile(plainRom, path =>
+            bool loaded = harness.Window.LoadRecentRomFile(plainRom, (path, forceVersion) =>
             {
                 Assert.Equal(plainRom, path);
+                Assert.Null(forceVersion);
                 Assert.Null(CoreState.DecompProject);
                 return true;
             });
@@ -90,7 +95,7 @@ public sealed class RecentFileProjectModeTests
             CoreState.DecompProject = null;
             using var harness = new MainWindowHarness();
 
-            bool loaded = harness.Window.LoadRecentRomFile(decompRom, path =>
+            bool loaded = harness.Window.LoadRecentRomFile(decompRom, (path, _) =>
             {
                 Assert.Equal(decompRom, path);
                 Assert.NotNull(CoreState.DecompProject);
@@ -121,7 +126,7 @@ public sealed class RecentFileProjectModeTests
             using var harness = new MainWindowHarness();
             DecompProject? projectDuringLoad = null;
 
-            bool loaded = harness.Window.LoadRecentRomFile(decompRom, _ =>
+            bool loaded = harness.Window.LoadRecentRomFile(decompRom, (_, _) =>
             {
                 projectDuringLoad = CoreState.DecompProject;
                 return false;
@@ -152,9 +157,40 @@ public sealed class RecentFileProjectModeTests
             Assert.Throws<InvalidOperationException>(() =>
                 harness.Window.LoadRecentRomFile(
                     decompRom,
-                    _ => throw new InvalidOperationException("load failed")));
+                    (_, _) => throw new InvalidOperationException("load failed")));
 
             Assert.Null(CoreState.DecompProject);
+        }
+        finally
+        {
+            CoreState.DecompProject = previousProject;
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [AvaloniaFact]
+    public void RecentLoad_PassesRecoveredForceVersionToLoader()
+    {
+        string dir = NewTestDir();
+        DecompProject? previousProject = CoreState.DecompProject;
+        try
+        {
+            string decompRom = CreateDecompRom(dir, forceVersion: "FE8J");
+            CoreState.DecompProject = null;
+            using var harness = new MainWindowHarness();
+            string? seenForceVersion = null;
+
+            bool loaded = harness.Window.LoadRecentRomFile(
+                decompRom,
+                (_, forceVersion) =>
+                {
+                    seenForceVersion = forceVersion;
+                    return true;
+                });
+
+            Assert.True(loaded);
+            Assert.Equal("FE8J", seenForceVersion);
+            Assert.Equal("FE8J", CoreState.DecompProject?.ForceVersion);
         }
         finally
         {

--- a/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
@@ -185,7 +185,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _ = MessageBoxWindow.Show(this, R._("File not found:") + $" {path}", R._("Error"), MessageBoxMode.Ok);
                 return;
             }
-            bool ok = LoadRomFile(path);
+            bool ok = LoadRecentRomFile(path);
             if (!ok)
             {
                 _ = MessageBoxWindow.Show(this, R._("Failed to load ROM:") + $" {path}", R._("Error"), MessageBoxMode.Ok);
@@ -750,6 +750,29 @@ namespace FEBuilderGBA.Avalonia.Views
         /// </summary>
         public bool LoadRomFile(string path)
             => LoadRomFile(path, null);
+
+        /// <summary>
+        /// Shared recent/last-ROM load path. Recovers a matching decomp project before
+        /// loading, falls back to plain-ROM mode, and clears project mode on failure.
+        /// </summary>
+        internal bool LoadRecentRomFile(string path, Func<string, bool>? loadRomOverride = null)
+        {
+            CoreState.DecompProject = DecompProjectDetector.DetectForRom(path);
+
+            bool ok = false;
+            try
+            {
+                Func<string, bool> loadRom = loadRomOverride ?? LoadRomFile;
+                ok = loadRom(path);
+                return ok;
+            }
+            finally
+            {
+                if (!ok)
+                    CoreState.DecompProject = null;
+                UpdateDecompBadge();
+            }
+        }
 
         /// <summary>
         /// Load a ROM file, optionally forcing the version detection (#1134).
@@ -2797,16 +2820,11 @@ namespace FEBuilderGBA.Avalonia.Views
                 return;
             }
 
-            // Opening a plain ROM clears any active decomp project (#1129). Cleared
-            // only after we know a real last ROM exists to load.
-            CoreState.DecompProject = null;
-
-            bool ok = LoadRomFile(lastPath);
+            bool ok = LoadRecentRomFile(lastPath);
             if (!ok)
             {
                 _ = MessageBoxWindow.Show(this, R._("Failed to load ROM:") + $" {lastPath}", R._("Error"), MessageBoxMode.Ok);
             }
-            UpdateDecompBadge();
         }
 
         private void Undo_Click(object? sender, RoutedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/MainWindow.axaml.cs
@@ -755,15 +755,19 @@ namespace FEBuilderGBA.Avalonia.Views
         /// Shared recent/last-ROM load path. Recovers a matching decomp project before
         /// loading, falls back to plain-ROM mode, and clears project mode on failure.
         /// </summary>
-        internal bool LoadRecentRomFile(string path, Func<string, bool>? loadRomOverride = null)
+        internal bool LoadRecentRomFile(
+            string path,
+            Func<string, string?, bool>? loadRomOverride = null)
         {
-            CoreState.DecompProject = DecompProjectDetector.DetectForRom(path);
+            DecompProject? project = DecompProjectDetector.DetectForRom(path);
+            CoreState.DecompProject = project;
 
             bool ok = false;
             try
             {
-                Func<string, bool> loadRom = loadRomOverride ?? LoadRomFile;
-                ok = loadRom(path);
+                ok = loadRomOverride != null
+                    ? loadRomOverride(path, project?.ForceVersion)
+                    : LoadRomFile(path, project?.ForceVersion);
                 return ok;
             }
             finally

--- a/FEBuilderGBA.Avalonia/Views/WelcomeView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/WelcomeView.axaml.cs
@@ -107,7 +107,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 // Find the MainWindow and load the ROM directly
                 if (WindowManager.Instance.MainWindow is MainWindow mw)
                 {
-                    bool ok = mw.LoadRomFile(path);
+                    bool ok = mw.LoadRecentRomFile(path);
                     if (ok)
                     {
                         RequestClose();

--- a/FEBuilderGBA.Core.Tests/DecompProjectTests.cs
+++ b/FEBuilderGBA.Core.Tests/DecompProjectTests.cs
@@ -338,6 +338,40 @@ namespace FEBuilderGBA.Core.Tests
             finally { Directory.Delete(dir, true); }
         }
 
+        [SkippableFact]
+        public void DetectForRom_FinalSymlinkToBuiltRomMatchesProject()
+        {
+            string dir = NewIssue2071TestDir();
+            try
+            {
+                string outputDir = Path.Combine(dir, "build");
+                Directory.CreateDirectory(outputDir);
+                WriteFile(dir, DecompProject.ManifestFileName,
+                    "{ \"schemaVersion\": 1, \"builtRom\": \"build/game.gba\" }");
+                TouchGba(outputDir, "game.gba");
+                string builtRom = Path.Combine(outputDir, "game.gba");
+                string recentAlias = Path.Combine(outputDir, "recent.gba");
+                try
+                {
+                    File.CreateSymbolicLink(recentAlias, builtRom);
+                }
+                catch (Exception ex) when (
+                    ex is PlatformNotSupportedException
+                    or UnauthorizedAccessException
+                    or IOException)
+                {
+                    Skip.If(true, "Symbolic links are unavailable: " + ex.Message);
+                }
+
+                var project = DecompProjectDetector.DetectForRom(recentAlias);
+
+                Assert.NotNull(project);
+                Assert.Equal(Path.GetFullPath(dir), project.ProjectRoot);
+                Assert.Equal(Path.GetFullPath(builtRom), project.BuiltRomPath);
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
         [Fact]
         public void DetectForRom_InvalidPath_ReturnsNullNoThrow()
         {

--- a/FEBuilderGBA.Core.Tests/DecompProjectTests.cs
+++ b/FEBuilderGBA.Core.Tests/DecompProjectTests.cs
@@ -278,6 +278,30 @@ namespace FEBuilderGBA.Core.Tests
             finally { Directory.Delete(dir, true); }
         }
 
+        [SkippableFact]
+        public void DetectForRom_CaseDistinctExistingRomDoesNotMatch()
+        {
+            string dir = NewIssue2071TestDir();
+            try
+            {
+                string outputDir = Path.Combine(dir, "build");
+                Directory.CreateDirectory(outputDir);
+                WriteFile(dir, DecompProject.ManifestFileName,
+                    "{ \"schemaVersion\": 1, \"builtRom\": \"build/Game.gba\" }");
+                TouchGba(outputDir, "Game.gba");
+                TouchGba(outputDir, "game.gba");
+                string builtRom = Path.Combine(outputDir, "Game.gba");
+                string selectedRom = Path.Combine(outputDir, "game.gba");
+
+                Skip.If(
+                    BuildfilePathSafety.SamePhysicalFile(builtRom, selectedRom),
+                    "The test filesystem is case-insensitive.");
+
+                Assert.Null(DecompProjectDetector.DetectForRom(selectedRom));
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
         [Fact]
         public void DetectForRom_InvalidPath_ReturnsNullNoThrow()
         {

--- a/FEBuilderGBA.Core.Tests/DecompProjectTests.cs
+++ b/FEBuilderGBA.Core.Tests/DecompProjectTests.cs
@@ -25,6 +25,13 @@ namespace FEBuilderGBA.Core.Tests
             return dir;
         }
 
+        static string NewIssue2071TestDir()
+        {
+            string dir = Path.Combine(AppContext.BaseDirectory, "issue2071_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            return dir;
+        }
+
         static void WriteFile(string dir, string name, string content)
             => File.WriteAllText(Path.Combine(dir, name), content);
 
@@ -212,6 +219,72 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Null(DecompProjectDetector.Detect(dir));
             Assert.Null(DecompProjectDetector.Detect(null!));
             Assert.Null(DecompProjectDetector.Detect(""));
+        }
+
+        // ---- DetectForRom: recent/last-ROM project recovery -----------------
+
+        [Fact]
+        public void DetectForRom_MatchingNestedProject_RestoresBuiltRomPath()
+        {
+            string dir = NewIssue2071TestDir();
+            try
+            {
+                string outputDir = Path.Combine(dir, "build", "release");
+                Directory.CreateDirectory(outputDir);
+                WriteFile(dir, DecompProject.ManifestFileName,
+                    "{ \"schemaVersion\": 1, \"builtRom\": \"build/release/game.gba\" }");
+                TouchGba(outputDir, "game.gba");
+                string selectedRom = Path.Combine(outputDir, "game.gba");
+
+                var project = DecompProjectDetector.DetectForRom(selectedRom);
+
+                Assert.NotNull(project);
+                Assert.Equal(Path.GetFullPath(dir), project.ProjectRoot);
+                Assert.Equal(Path.GetFullPath(selectedRom), project.BuiltRomPath);
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void DetectForRom_PlainRomInDeepTree_ReturnsNullAndTerminatesAtRoot()
+        {
+            string dir = NewIssue2071TestDir();
+            try
+            {
+                string nested = Path.Combine(dir, "one", "two", "three");
+                Directory.CreateDirectory(nested);
+                TouchGba(nested, "plain.gba");
+
+                Assert.Null(DecompProjectDetector.DetectForRom(Path.Combine(nested, "plain.gba")));
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void DetectForRom_ProjectWithDifferentBuiltRom_ReturnsNull()
+        {
+            string dir = NewIssue2071TestDir();
+            try
+            {
+                string outputDir = Path.Combine(dir, "build");
+                Directory.CreateDirectory(outputDir);
+                WriteFile(dir, DecompProject.ManifestFileName,
+                    "{ \"schemaVersion\": 1, \"builtRom\": \"build/project.gba\" }");
+                TouchGba(outputDir, "project.gba");
+                TouchGba(outputDir, "other.gba");
+
+                Assert.Null(DecompProjectDetector.DetectForRom(Path.Combine(outputDir, "other.gba")));
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void DetectForRom_InvalidPath_ReturnsNullNoThrow()
+        {
+            Assert.Null(DecompProjectDetector.DetectForRom(null!));
+            Assert.Null(DecompProjectDetector.DetectForRom(""));
+            Assert.Null(DecompProjectDetector.DetectForRom(
+                Path.Combine(AppContext.BaseDirectory, "missing_" + Guid.NewGuid().ToString("N") + ".gba")));
         }
 
         // ---- ResolveBuiltRom -------------------------------------------------

--- a/FEBuilderGBA.Core.Tests/DecompProjectTests.cs
+++ b/FEBuilderGBA.Core.Tests/DecompProjectTests.cs
@@ -294,10 +294,46 @@ namespace FEBuilderGBA.Core.Tests
                 string selectedRom = Path.Combine(outputDir, "game.gba");
 
                 Skip.If(
-                    BuildfilePathSafety.SamePhysicalFile(builtRom, selectedRom),
+                    ProjectionFileSystemSafety.SameExistingFileSystemEntry(
+                        builtRom,
+                        selectedRom),
                     "The test filesystem is case-insensitive.");
 
                 Assert.Null(DecompProjectDetector.DetectForRom(selectedRom));
+            }
+            finally { Directory.Delete(dir, true); }
+        }
+
+        [Fact]
+        public void DetectForRom_IdentityFailureAtChildContinuesToParentProject()
+        {
+            string dir = NewIssue2071TestDir();
+            try
+            {
+                string child = Path.Combine(dir, "child");
+                string outputDir = Path.Combine(child, "build");
+                Directory.CreateDirectory(outputDir);
+                WriteFile(dir, DecompProject.ManifestFileName,
+                    "{ \"schemaVersion\": 1, \"builtRom\": \"child/build/game.gba\" }");
+                WriteFile(child, DecompProject.ManifestFileName,
+                    "{ \"schemaVersion\": 1, \"builtRom\": \"build/game.gba\" }");
+                TouchGba(outputDir, "game.gba");
+                string selectedRom = Path.Combine(outputDir, "game.gba");
+                int identityChecks = 0;
+
+                var project = DecompProjectDetector.DetectForRom(
+                    selectedRom,
+                    (_, _) =>
+                    {
+                        identityChecks++;
+                        if (identityChecks == 1)
+                            throw new IOException("simulated child identity failure");
+                        return true;
+                    });
+
+                Assert.NotNull(project);
+                Assert.Equal(Path.GetFullPath(dir), project.ProjectRoot);
+                Assert.Equal(2, identityChecks);
             }
             finally { Directory.Delete(dir, true); }
         }

--- a/FEBuilderGBA.Core/DecompProject.cs
+++ b/FEBuilderGBA.Core/DecompProject.cs
@@ -728,10 +728,6 @@ namespace FEBuilderGBA
                     return null;
 
                 string current = Path.GetDirectoryName(selectedRom);
-                StringComparison comparison =
-                    OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
-                        ? StringComparison.OrdinalIgnoreCase
-                        : StringComparison.Ordinal;
 
                 while (!string.IsNullOrEmpty(current))
                 {
@@ -743,7 +739,7 @@ namespace FEBuilderGBA
                             && !string.IsNullOrEmpty(resolved.Path))
                         {
                             string builtRom = Path.GetFullPath(resolved.Path);
-                            if (string.Equals(selectedRom, builtRom, comparison))
+                            if (BuildfilePathSafety.SamePhysicalFile(selectedRom, builtRom))
                             {
                                 project.BuiltRomPath = builtRom;
                                 return project;
@@ -756,7 +752,7 @@ namespace FEBuilderGBA
                         break;
 
                     string parentPath = Path.GetFullPath(parent.FullName);
-                    if (string.Equals(current, parentPath, comparison))
+                    if (string.Equals(current, parentPath, StringComparison.Ordinal))
                         break;
                     current = parentPath;
                 }

--- a/FEBuilderGBA.Core/DecompProject.cs
+++ b/FEBuilderGBA.Core/DecompProject.cs
@@ -719,7 +719,7 @@ namespace FEBuilderGBA
         public static DecompProject DetectForRom(string romPath)
             => DetectForRom(
                 romPath,
-                ProjectionFileSystemSafety.SameExistingFileSystemEntry);
+                SamePhysicalExistingFile);
 
         internal static DecompProject DetectForRom(
             string romPath,
@@ -790,6 +790,15 @@ namespace FEBuilderGBA
                 or NotSupportedException
                 or UnauthorizedAccessException
                 or System.Security.SecurityException;
+
+        static bool SamePhysicalExistingFile(string firstPath, string secondPath)
+        {
+            string physicalFirst = BuildfilePathSafety.ResolvePhysicalPath(firstPath);
+            string physicalSecond = BuildfilePathSafety.ResolvePhysicalPath(secondPath);
+            return ProjectionFileSystemSafety.SameExistingFileSystemEntry(
+                physicalFirst,
+                physicalSecond);
+        }
 
         /// <summary>
         /// Weighted heuristic score. Pure, guarded, never throws.

--- a/FEBuilderGBA.Core/DecompProject.cs
+++ b/FEBuilderGBA.Core/DecompProject.cs
@@ -717,10 +717,17 @@ namespace FEBuilderGBA
         /// decomp project whose resolved built ROM is that exact file. NEVER throws.
         /// </summary>
         public static DecompProject DetectForRom(string romPath)
+            => DetectForRom(
+                romPath,
+                ProjectionFileSystemSafety.SameExistingFileSystemEntry);
+
+        internal static DecompProject DetectForRom(
+            string romPath,
+            Func<string, string, bool> sameExistingEntry)
         {
             try
             {
-                if (string.IsNullOrEmpty(romPath))
+                if (string.IsNullOrEmpty(romPath) || sameExistingEntry == null)
                     return null;
 
                 string selectedRom = Path.GetFullPath(romPath);
@@ -739,7 +746,18 @@ namespace FEBuilderGBA
                             && !string.IsNullOrEmpty(resolved.Path))
                         {
                             string builtRom = Path.GetFullPath(resolved.Path);
-                            if (BuildfilePathSafety.SamePhysicalFile(selectedRom, builtRom))
+                            bool isSameEntry = false;
+                            try
+                            {
+                                isSameEntry = sameExistingEntry(selectedRom, builtRom);
+                            }
+                            catch (Exception ex) when (IsRecoverablePathException(ex))
+                            {
+                                // A broken/inaccessible child project must not hide a
+                                // valid matching project higher in the ancestor chain.
+                            }
+
+                            if (isSameEntry)
                             {
                                 project.BuiltRomPath = builtRom;
                                 return project;
@@ -757,12 +775,7 @@ namespace FEBuilderGBA
                     current = parentPath;
                 }
             }
-            catch (Exception ex) when (
-                ex is ArgumentException
-                or IOException
-                or NotSupportedException
-                or UnauthorizedAccessException
-                or System.Security.SecurityException)
+            catch (Exception ex) when (IsRecoverablePathException(ex))
             {
                 // Guard every filesystem/path fault; recent-file loading falls back
                 // to ordinary ROM mode when no matching project can be recovered.
@@ -770,6 +783,13 @@ namespace FEBuilderGBA
 
             return null;
         }
+
+        static bool IsRecoverablePathException(Exception ex)
+            => ex is ArgumentException
+                or IOException
+                or NotSupportedException
+                or UnauthorizedAccessException
+                or System.Security.SecurityException;
 
         /// <summary>
         /// Weighted heuristic score. Pure, guarded, never throws.

--- a/FEBuilderGBA.Core/DecompProject.cs
+++ b/FEBuilderGBA.Core/DecompProject.cs
@@ -713,6 +713,69 @@ namespace FEBuilderGBA
         }
 
         /// <summary>
+        /// Starting from a selected ROM, walk ancestor directories and recover the
+        /// decomp project whose resolved built ROM is that exact file. NEVER throws.
+        /// </summary>
+        public static DecompProject DetectForRom(string romPath)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(romPath))
+                    return null;
+
+                string selectedRom = Path.GetFullPath(romPath);
+                if (!File.Exists(selectedRom))
+                    return null;
+
+                string current = Path.GetDirectoryName(selectedRom);
+                StringComparison comparison =
+                    OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+                        ? StringComparison.OrdinalIgnoreCase
+                        : StringComparison.Ordinal;
+
+                while (!string.IsNullOrEmpty(current))
+                {
+                    var project = Detect(current);
+                    if (project != null)
+                    {
+                        var resolved = ResolveBuiltRom(current, project);
+                        if (resolved.Status == DecompResolveStatus.Ok
+                            && !string.IsNullOrEmpty(resolved.Path))
+                        {
+                            string builtRom = Path.GetFullPath(resolved.Path);
+                            if (string.Equals(selectedRom, builtRom, comparison))
+                            {
+                                project.BuiltRomPath = builtRom;
+                                return project;
+                            }
+                        }
+                    }
+
+                    var parent = Directory.GetParent(current);
+                    if (parent == null)
+                        break;
+
+                    string parentPath = Path.GetFullPath(parent.FullName);
+                    if (string.Equals(current, parentPath, comparison))
+                        break;
+                    current = parentPath;
+                }
+            }
+            catch (Exception ex) when (
+                ex is ArgumentException
+                or IOException
+                or NotSupportedException
+                or UnauthorizedAccessException
+                or System.Security.SecurityException)
+            {
+                // Guard every filesystem/path fault; recent-file loading falls back
+                // to ordinary ROM mode when no matching project can be recovered.
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Weighted heuristic score. Pure, guarded, never throws.
         /// Accept threshold (in <see cref="Detect"/>) is &gt;= 2.
         /// </summary>

--- a/FEBuilderGBA.Tests/Unit/AvaloniaEditorTests.cs
+++ b/FEBuilderGBA.Tests/Unit/AvaloniaEditorTests.cs
@@ -2569,7 +2569,7 @@ namespace FEBuilderGBA.Tests.Unit
             Assert.Contains("LoadRecentFiles()", src);
             Assert.Contains("RecentFile_Click", src);
             Assert.Contains("RecentFileKeyPrefix", src); // Uses shared constant from MainWindowViewModel
-            Assert.Contains("LoadRomFile", src); // Directly loads ROM via MainWindow
+            Assert.Contains("LoadRecentRomFile", src); // Uses the state-safe recent ROM loader
         }
 
         // ================================================================


### PR DESCRIPTION
## Summary

- recover a decomp project from a persisted ROM path only when its resolved build output is the same physical filesystem entry
- resolve recent ROM symlink aliases before comparing exact file identities
- preserve manifest `forceVersion` metadata when loading a recovered project
- route File > Recent Files, Welcome recent files, and Open Last ROM through one state-safe loading seam
- clear stale project mode on plain-ROM or failed loads while restoring the source-backed badge for decomp builds

Accepted plan: https://github.com/laqieer/FEBuilderGBA/issues/2071#issuecomment-5235404601
Plan amendment: https://github.com/laqieer/FEBuilderGBA/issues/2071#issuecomment-5236715378

Closes #2071

## Test plan

- [x] Targeted `DecompProjectTests.DetectForRom_*` — 6 passed, 1 skipped on the case-insensitive Windows filesystem
- [x] Targeted `RecentFileProjectModeTests` — 5 passed
- [x] Targeted `WelcomeView_CodeBehindLoadsRecentFiles` — 1 passed
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests/FEBuilderGBA.Avalonia.Tests.csproj -c Release` — 9,811 passed, 10 skipped
- [x] Release builds for `FEBuilderGBA.Core` and `FEBuilderGBA.Avalonia`
- [x] Real desktop-Skia harness invoked the production Recent Files handler for decomp → plain and plain → decomp transitions and asserted badge visibility
- [x] Full Core suite attempted — 7,531 passed, 18 skipped; one unrelated nested-submodule dead-link failure was reproduced unchanged in the issue-2070 worktree
- [x] Full `FEBuilderGBA.Tests` attempted — 2,356 passed; one unrelated clipboard test was desktop-session-sensitive and passes when isolated

## GUI Test Report

The production MainWindow was loaded with synthetic FE8U ROMs. Captures show the badge absent after switching to a plain ROM and restored after switching back to the decomp build through the Recent Files handler.

**After switching to a plain ROM — source-backed mode cleared**

![Plain ROM after Recent Files switch](https://github.com/user-attachments/assets/998f22e7-f478-4fc8-9460-69a10558ec61)

**After switching back to the decomp build — source-backed mode restored**

![Decomp ROM after Recent Files switch](https://github.com/user-attachments/assets/a91fd49e-18e6-42b7-b315-a61ad8356fb4)

Copilot CLI: 1.0.78
Model: GPT-5.6 Sol (gpt-5.6-sol)