### PR TITLE
fix(avalonia): select macOS emulator app bundles

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/ExternalToolAppBundleTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ExternalToolAppBundleTests.cs
@@ -5,6 +5,7 @@ using global::Avalonia.Controls;
 using global::Avalonia.Headless.XUnit;
 using global::Avalonia.Threading;
 using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Dialogs;
 using FEBuilderGBA.Avalonia.ViewModels;
 using FEBuilderGBA.Avalonia.Views;
 using Xunit;
@@ -52,6 +53,46 @@ public sealed class ExternalToolAppBundleTests : IDisposable
 
         Assert.Equal(expected, mainPath);
         Assert.Equal(expected, diffPath);
+    }
+
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    [InlineData(true, true, true)]
+    public void ExternalToolPickerMode_UsesFolderOnlyForMacApplicationBundles(
+        bool isMacOS,
+        bool allowMacApplicationBundle,
+        bool expectedFolder)
+    {
+        var expected = expectedFolder
+            ? ExternalToolPickerMode.Folder
+            : ExternalToolPickerMode.File;
+        Assert.Equal(expected, FileDialogHelper.GetExternalToolPickerMode(
+            isMacOS, allowMacApplicationBundle));
+    }
+
+    [Theory]
+    [InlineData("EmulatorTextBox", true)]
+    [InlineData("Emulator2TextBox", true)]
+    [InlineData("EventAssemblerTextBox", false)]
+    [InlineData("GitPathTextBox", false)]
+    public void OptionsView_RequestsBundleModeOnlyForEmulatorFields(
+        string targetName,
+        bool expected)
+    {
+        Assert.Equal(expected, OptionsView.AllowsMacApplicationBundlePicker(targetName));
+    }
+
+    [Fact]
+    public void RawMacExecutablePath_RemainsUnchangedAtLaunchBoundary()
+    {
+        string executable = Path.Combine(_root, "mGBA");
+        File.WriteAllText(executable, "not executed");
+
+        Assert.True(MainWindow.TryResolveExternalToolForLaunch(
+            executable, isMacOS: true, File.Exists, out string resolved));
+        Assert.Equal(executable, resolved);
     }
 
     [Fact]

--- a/FEBuilderGBA.Avalonia/Dialogs/FileDialogHelper.cs
+++ b/FEBuilderGBA.Avalonia/Dialogs/FileDialogHelper.cs
@@ -9,6 +9,12 @@ using FEBuilderGBA;
 
 namespace FEBuilderGBA.Avalonia.Dialogs
 {
+    internal enum ExternalToolPickerMode
+    {
+        File,
+        Folder,
+    }
+
     /// <summary>
     /// Helper for file open/save dialogs using Avalonia 11 StorageProvider API.
     /// All user-visible strings are wrapped with R._() for i18n.
@@ -217,6 +223,7 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         // Reuse static pattern arrays to avoid repeated allocations
         static readonly string[] GbaPatterns = new[] { "*.gba" };
         static readonly string[] AllPatterns = new[] { "*" };
+        static readonly string[] ExecutablePatterns = new[] { "*.exe", "*.app", "*" };
         static readonly string[] UpsPatterns = new[] { "*.ups" };
         static readonly string[] PngPatterns = new[] { "*.png" };
         static readonly string[] ImagePatterns = new[] { "*.png", "*.bmp" };
@@ -237,6 +244,28 @@ namespace FEBuilderGBA.Avalonia.Dialogs
                 Log.Error($"FileDialogHelper.{operation}: TopLevel or StorageProvider is unavailable.");
             }
             return provider;
+        }
+
+        internal static ExternalToolPickerMode GetExternalToolPickerMode(
+            bool isMacOS,
+            bool allowMacApplicationBundle)
+            => isMacOS && allowMacApplicationBundle
+                ? ExternalToolPickerMode.Folder
+                : ExternalToolPickerMode.File;
+
+        static string? ResolveExternalToolLocalPath<T>(IReadOnlyList<T> items)
+            where T : IStorageItem
+        {
+            if (items.Count == 0)
+                return null;
+
+            string? path = items[0].TryGetLocalPath();
+            if (string.IsNullOrEmpty(path))
+            {
+                CoreState.Services?.ShowInfo(R._("This setting configures an external tool path and requires desktop file-system access; it is not available on this device."));
+                return null;
+            }
+            return path;
         }
 
         internal static FilePickerOpenOptions CreateProblemReportBackupOpenOptions()
@@ -508,6 +537,46 @@ namespace FEBuilderGBA.Avalonia.Dialogs
                 SuggestedFileName = suggestedName ?? "anim.txt",
                 FileTypeChoices = new[] { fileType, MakeAllFileType() },
             });
+        }
+
+        /// <summary>
+        /// Pick a local external-tool path. macOS callers may explicitly request
+        /// a folder picker for an application bundle; every other case uses the
+        /// ordinary executable file picker.
+        /// </summary>
+        public static async Task<string?> OpenExternalTool(
+            TopLevel? owner,
+            string title,
+            bool allowMacApplicationBundle = false)
+        {
+            var provider = GetStorageProvider(owner, nameof(OpenExternalTool));
+            if (provider == null)
+                return null;
+
+            string localizedTitle = R._(title);
+            if (GetExternalToolPickerMode(
+                OperatingSystem.IsMacOS(),
+                allowMacApplicationBundle) == ExternalToolPickerMode.Folder)
+            {
+                var folders = await provider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+                {
+                    Title = localizedTitle,
+                    AllowMultiple = false,
+                });
+                return ResolveExternalToolLocalPath(folders);
+            }
+
+            var executableFiles = new FilePickerFileType(R._("Executables"))
+            {
+                Patterns = ExecutablePatterns,
+            };
+            var files = await provider.OpenFilePickerAsync(new FilePickerOpenOptions
+            {
+                Title = localizedTitle,
+                AllowMultiple = false,
+                FileTypeFilter = new[] { executableFiles, MakeAllFileType() },
+            });
+            return ResolveExternalToolLocalPath(files);
         }
 
         /// <summary>Open any file with custom filter.</summary>

--- a/FEBuilderGBA.Avalonia/Views/OptionsView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OptionsView.axaml.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
 using global::Avalonia.Platform.Storage;
+using FEBuilderGBA.Avalonia.Dialogs;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
 
@@ -29,6 +30,9 @@ namespace FEBuilderGBA.Avalonia.Views
         /// Never used by production code.
         /// </summary>
         internal OptionsViewModel ViewModelForTests => _vm;
+
+        internal static bool AllowsMacApplicationBundlePicker(string targetName)
+            => targetName is "EmulatorTextBox" or "Emulator2TextBox";
 
         public OptionsView()
         {
@@ -239,30 +243,13 @@ namespace FEBuilderGBA.Avalonia.Views
             var target = this.FindControl<TextBox>(targetName);
             if (target == null) return;
 
-            var allFiles = new FilePickerFileType(R._("All Files")) { Patterns = new[] { "*" } };
-            var exeFiles = new FilePickerFileType(R._("Executables")) { Patterns = new[] { "*.exe", "*.app", "*" } };
-            var storage = TopLevel.GetTopLevel(this)?.StorageProvider;
-            if (storage == null) return;
-            var files = await storage.OpenFilePickerAsync(new FilePickerOpenOptions
-            {
-                Title = R._("Select File"),
-                AllowMultiple = false,
-                FileTypeFilter = new[] { exeFiles, allFiles },
-            });
-            if (files.Count > 0)
-            {
-                // #1639: these options configure paths to EXTERNAL tool
-                // executables that are launched as processes (devkitARM / EA),
-                // so a real filesystem path is required. On Android (no local
-                // path) leave the field and message instead of silently doing
-                // nothing.
-                string? path = files[0].TryGetLocalPath();
-                if (path != null)
-                    target.Text = path;
-                else
-                    CoreState.Services?.ShowInfo(R._("This setting configures an external tool path and requires desktop file-system access; it is not available on this device."));
-                RefreshFEMapCreatorStatus();
-            }
+            string? path = await FileDialogHelper.OpenExternalTool(
+                TopLevel.GetTopLevel(this),
+                "Select File",
+                AllowsMacApplicationBundlePicker(targetName));
+            if (path != null)
+                target.Text = path;
+            RefreshFEMapCreatorStatus();
         }
 
         async void BrowseFolder_Click(object? sender, RoutedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/ToolInitWizardView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolInitWizardView.axaml.cs
@@ -27,7 +27,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
-using global::Avalonia.Platform.Storage;
 using FEBuilderGBA.Avalonia.Dialogs;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
@@ -201,7 +200,9 @@ namespace FEBuilderGBA.Avalonia.Views
 
         async void OnRefEmulator_Click(object? sender, RoutedEventArgs e)
         {
-            string? picked = await PickExeFileAsync("Select Emulator");
+            string? picked = await PickExeFileAsync(
+                "Select Emulator",
+                allowMacApplicationBundle: true);
             if (picked != null)
                 _vm.PendingEmulatorPath = picked;
         }
@@ -876,32 +877,16 @@ namespace FEBuilderGBA.Avalonia.Views
         // ===================================================================
 
         /// <summary>
-        /// Avalonia file picker. Returns the local path of the chosen file,
-        /// or null if cancelled / no local path. Matches the pattern used by
-        /// OptionsView.BrowseFile_Click — file-type labels and title are
-        /// localised via R._() so the dialog reads correctly in ja/zh.
+        /// Centralized external-tool picker. The emulator step opts into the
+        /// macOS application-bundle folder picker; all other steps keep file
+        /// selection.
         /// </summary>
-        async System.Threading.Tasks.Task<string?> PickExeFileAsync(string title)
-        {
-            var storage = TopLevel.GetTopLevel(this)?.StorageProvider;
-            if (storage == null)
-                return null;
-            var allFiles = new FilePickerFileType(FEBuilderGBA.R._("All Files")) { Patterns = new[] { "*" } };
-            var exeFiles = new FilePickerFileType(FEBuilderGBA.R._("Executables")) { Patterns = new[] { "*.exe", "*.app", "*" } };
-            var files = await storage.OpenFilePickerAsync(new FilePickerOpenOptions
-            {
-                Title = FEBuilderGBA.R._(title),
-                AllowMultiple = false,
-                FileTypeFilter = new[] { exeFiles, allFiles },
-            });
-            // #1639: this picks an EXECUTABLE whose path is later launched as an
-            // external process (devkitARM / EA). External tools need a real
-            // filesystem path and have no meaning under Android scoped storage,
-            // so the path-only result is intentional here — a SAF pick (no local
-            // path) simply leaves the configured tool path unchanged.
-            if (files.Count > 0)
-                return files[0].TryGetLocalPath();
-            return null;
-        }
+        System.Threading.Tasks.Task<string?> PickExeFileAsync(
+            string title,
+            bool allowMacApplicationBundle = false)
+            => FileDialogHelper.OpenExternalTool(
+                TopLevel.GetTopLevel(this),
+                title,
+                allowMacApplicationBundle);
     }
 }


### PR DESCRIPTION
## Summary

- centralize external-tool path picking in `FileDialogHelper`
- use a folder picker only for macOS emulator fields so Avalonia can return `.app` bundles
- preserve ordinary executable-file picking for all other tools and platforms

Accepted plan: https://github.com/laqieer/FEBuilderGBA/issues/2070#issuecomment-5235404613

Closes #2070

## Test plan

- [x] Targeted `ExternalToolAppBundleTests` — 12 passed
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests/FEBuilderGBA.Avalonia.Tests.csproj -c Release` — 9,820 passed, 10 skipped
- [x] `dotnet build FEBuilderGBA.Avalonia/FEBuilderGBA.Avalonia.csproj -c Release`
- [x] Real desktop-Skia render of `OptionsView` with External Tools selected and `/Applications/mGBA.app` preserved in the emulator field

## GUI Test Report

The production `OptionsView` was rendered through a real desktop Avalonia/Skia application harness after selecting External Tools.

![External Tools with macOS mGBA app bundle path](https://github.com/user-attachments/assets/d46f1040-d7f1-46ff-ad7e-a385ab51ee46)

Copilot CLI: 1.0.78
Model: GPT-5.6 Sol (gpt-5.6-sol)