### PR TITLE
ci: stabilize serialized test execution

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,6 +30,7 @@ permissions:
 jobs:
   build:
     runs-on: windows-latest
+    timeout-minutes: 120
 
     steps:
     - uses: actions/checkout@v4
@@ -147,7 +148,38 @@ jobs:
       run: dotnet msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} /t:build /restore /warnaserror ${{env.SOLUTION_FILE_PATH}}
 
     - name: Run Tests
-      run: dotnet test --configuration ${{env.BUILD_CONFIGURATION}} --no-build --verbosity normal --logger "trx" --collect:"XPlat Code Coverage" --settings coverlet.runsettings
+      shell: pwsh
+      timeout-minutes: 90
+      run: |
+        $projects = @(
+          "FEBuilderGBA.Core.Tests/FEBuilderGBA.Core.Tests.csproj"
+          "FEBuilderGBA.Avalonia.Tests/FEBuilderGBA.Avalonia.Tests.csproj"
+          "FEBuilderGBA.Tests/FEBuilderGBA.Tests.csproj"
+          "FEBuilderGBA.E2ETests/FEBuilderGBA.E2ETests.csproj"
+        )
+        $failedProjects = @()
+        foreach ($project in $projects) {
+          Write-Host "::group::dotnet test $project"
+          dotnet test $project `
+            --configuration ${{env.BUILD_CONFIGURATION}} `
+            --no-build `
+            --verbosity normal `
+            --logger "trx" `
+            --collect "XPlat Code Coverage" `
+            --settings coverlet.runsettings `
+            --blame-hang `
+            --blame-hang-timeout 20m
+          $exitCode = $LASTEXITCODE
+          Write-Host "::endgroup::"
+          if ($exitCode -ne 0) {
+            $failedProjects += $project
+            Write-Host "::error title=Test project failed::$project exited with code $exitCode"
+          }
+        }
+        if ($failedProjects.Count -gt 0) {
+          Write-Host "::error title=Test projects failed::$($failedProjects -join ', ')"
+          exit 1
+        }
 
     - name: Publish Test Results
       if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -192,15 +192,15 @@ jobs:
         fail-on-error: true
 
     - name: Install ReportGenerator
-      if: github.event_name == 'pull_request'
+      if: ${{ !cancelled() && github.event_name == 'pull_request' }}
       run: dotnet tool install --global dotnet-reportgenerator-globaltool
 
     - name: Generate Coverage Report
-      if: github.event_name == 'pull_request'
+      if: ${{ !cancelled() && github.event_name == 'pull_request' }}
       run: reportgenerator -reports:**/coverage.cobertura.xml -targetdir:coverage-report -reporttypes:"MarkdownSummaryGithub"
 
     - name: Comment PR with Coverage
-      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+      if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && hashFiles('coverage-report/SummaryGithub.md') != '' }}
       uses: marocchino/sticky-pull-request-comment@v2
       with:
         path: coverage-report/SummaryGithub.md

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -151,6 +151,7 @@ jobs:
       shell: pwsh
       timeout-minutes: 90
       run: |
+        $PSNativeCommandUseErrorActionPreference = $false
         $projects = @(
           "FEBuilderGBA.Core.Tests/FEBuilderGBA.Core.Tests.csproj"
           "FEBuilderGBA.Avalonia.Tests/FEBuilderGBA.Avalonia.Tests.csproj"

--- a/FEBuilderGBA.Core.Tests/UHttpAsyncTests.cs
+++ b/FEBuilderGBA.Core.Tests/UHttpAsyncTests.cs
@@ -153,35 +153,54 @@ namespace FEBuilderGBA.Core.Tests
         [Fact]
         public async Task HttpHeadLastModifiedAsync_CallerCancellation_Throws()
         {
+            var handlerEntered = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
             var handler = new RecordingHandler(async (_, token) =>
             {
-                await Task.Delay(TimeSpan.FromSeconds(30), token);
+                handlerEntered.TrySetResult(true);
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
                 return new HttpResponseMessage(HttpStatusCode.OK);
             });
-            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(20));
+            using var cts = new CancellationTokenSource();
 
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
-                U.HttpHeadLastModifiedAsync(
-                    "https://example.test/slow", handler, TimeSpan.FromSeconds(5), cts.Token));
+            Task<string?> request = U.HttpHeadLastModifiedAsync(
+                "https://example.test/slow",
+                handler,
+                TimeSpan.FromSeconds(5),
+                cts.Token);
+            await handlerEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => request);
         }
 
         [Fact]
         public async Task HttpGetAsync_CallerCancellation_Throws()
         {
+            var handlerEntered = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
             var handler = new RecordingHandler(async (_, token) =>
             {
-                await Task.Delay(TimeSpan.FromSeconds(30), token);
+                handlerEntered.TrySetResult(true);
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
                 return new HttpResponseMessage(HttpStatusCode.OK)
                 {
                     Content = new StringContent("late"),
                 };
             });
-            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(20));
+            using var cts = new CancellationTokenSource();
 
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
-                U.HttpGetAsync(
-                    "https://example.test/slow", "", null,
-                    handler, TimeSpan.FromSeconds(5), cts.Token));
+            Task<string> request = U.HttpGetAsync(
+                "https://example.test/slow",
+                "",
+                null,
+                handler,
+                TimeSpan.FromSeconds(5),
+                cts.Token);
+            await handlerEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => request);
         }
 
         [Fact]

--- a/FEBuilderGBA.Core.Tests/UHttpAsyncTests.cs
+++ b/FEBuilderGBA.Core.Tests/UHttpAsyncTests.cs
@@ -166,12 +166,13 @@ namespace FEBuilderGBA.Core.Tests
             Task<string?> request = U.HttpHeadLastModifiedAsync(
                 "https://example.test/slow",
                 handler,
-                TimeSpan.FromSeconds(5),
+                Timeout.InfiniteTimeSpan,
                 cts.Token);
             await handlerEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
             cts.Cancel();
 
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => request);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => request.WaitAsync(TimeSpan.FromSeconds(5)));
         }
 
         [Fact]
@@ -195,12 +196,13 @@ namespace FEBuilderGBA.Core.Tests
                 "",
                 null,
                 handler,
-                TimeSpan.FromSeconds(5),
+                Timeout.InfiniteTimeSpan,
                 cts.Token);
             await handlerEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
             cts.Cancel();
 
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => request);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => request.WaitAsync(TimeSpan.FromSeconds(5)));
         }
 
         [Fact]

--- a/scripts/tests/test_build_warning_contract.py
+++ b/scripts/tests/test_build_warning_contract.py
@@ -336,6 +336,101 @@ jobs:
 
 
 class BuildWarningContractTests(unittest.TestCase):
+    def test_check_workflow_serializes_test_projects_and_bounds_hangs(self) -> None:
+        workflow = (WORKFLOWS_DIR / "check.yml").read_text(encoding="utf-8")
+
+        build_match = re.search(
+            r"(?ms)^  build:\s*\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\s*$|\Z)",
+            workflow,
+        )
+        self.assertIsNotNone(build_match)
+        build_block = build_match.group("body")
+        self.assertEqual(
+            ["120"],
+            re.findall(r"(?m)^    timeout-minutes:\s*(\d+)\s*$", build_block),
+        )
+
+        test_step_match = re.search(
+            r"(?ms)^    - name: Run Tests\s*\n(?P<body>.*?)(?=^    - |\Z)",
+            build_block,
+        )
+        self.assertIsNotNone(test_step_match)
+        test_step_block = test_step_match.group("body")
+        self.assertEqual(
+            ["90"],
+            re.findall(r"(?m)^      timeout-minutes:\s*(\d+)\s*$", test_step_block),
+        )
+        self.assertEqual(
+            ["pwsh"],
+            re.findall(r"(?m)^      shell:\s*(\S+)\s*$", test_step_block),
+        )
+
+        run_steps = [
+            step
+            for step in parse_workflow_runs(workflow, "check.yml")
+            if step.job == "build" and step.name == "Run Tests"
+        ]
+        self.assertEqual(1, len(run_steps))
+        command = run_steps[0].command
+        expected_projects = [
+            "FEBuilderGBA.Core.Tests/FEBuilderGBA.Core.Tests.csproj",
+            "FEBuilderGBA.Avalonia.Tests/FEBuilderGBA.Avalonia.Tests.csproj",
+            "FEBuilderGBA.Tests/FEBuilderGBA.Tests.csproj",
+            "FEBuilderGBA.E2ETests/FEBuilderGBA.E2ETests.csproj",
+        ]
+        self.assertEqual(
+            expected_projects,
+            re.findall(r'"([^"]+Tests/[^"]+Tests\.csproj)"', command),
+        )
+
+        invocations = dotnet_invocations(run_steps[0])
+        self.assertEqual(1, len(invocations))
+        tokens = invocations[0].tokens
+        self.assertEqual("test", invocations[0].verb)
+        self.assertEqual("$project", invocations[0].project)
+        for required in (
+            "--no-build",
+            "--blame-hang",
+            "--logger",
+            "--collect",
+            "--settings",
+        ):
+            self.assertTrue(
+                any(
+                    token.lower() == required
+                    or token.lower().startswith(required + ":")
+                    or token.lower().startswith(required + "=")
+                    for token in tokens
+                ),
+                required,
+            )
+        self.assertEqual("20m", option_value(tokens, "--blame-hang-timeout"))
+        self.assertEqual("trx", option_value(tokens, "--logger"))
+        self.assertEqual(
+            "XPlatCodeCoverage",
+            option_value(tokens, "--collect"),
+        )
+        self.assertEqual(
+            "coverlet.runsettings",
+            option_value(tokens, "--settings"),
+        )
+
+        self.assertIn("$failedProjects = @()", command)
+        self.assertIn("foreach ($project in $projects)", command)
+        self.assertIn("$exitCode = $LASTEXITCODE", command)
+        self.assertIn("$failedProjects += $project", command)
+        self.assertIn("if ($failedProjects.Count -gt 0)", command)
+        self.assertRegex(command, r"(?m)^\s*exit 1\s*$")
+        self.assertNotIn("break", command)
+        self.assertLess(
+            command.index("$exitCode = $LASTEXITCODE"),
+            command.index("$failedProjects += $project"),
+        )
+        self.assertLess(
+            command.index("$failedProjects += $project"),
+            command.index("if ($failedProjects.Count -gt 0)"),
+        )
+
     def test_every_workflow_compilation_is_warning_as_error(self) -> None:
         missing: list[str] = []
         for invocation in all_dotnet_invocations():

--- a/scripts/tests/test_build_warning_contract.py
+++ b/scripts/tests/test_build_warning_contract.py
@@ -416,12 +416,14 @@ class BuildWarningContractTests(unittest.TestCase):
         )
 
         self.assertIn("$failedProjects = @()", command)
+        self.assertIn("$PSNativeCommandUseErrorActionPreference = $false", command)
         self.assertIn("foreach ($project in $projects)", command)
         self.assertIn("$exitCode = $LASTEXITCODE", command)
         self.assertIn("$failedProjects += $project", command)
         self.assertIn("if ($failedProjects.Count -gt 0)", command)
-        self.assertRegex(command, r"(?m)^\s*exit 1\s*$")
         self.assertNotIn("break", command)
+        exit_matches = list(re.finditer(r"(?m)^\s*exit 1\s*$", command))
+        self.assertEqual(1, len(exit_matches))
         self.assertLess(
             command.index("$exitCode = $LASTEXITCODE"),
             command.index("$failedProjects += $project"),
@@ -429,6 +431,10 @@ class BuildWarningContractTests(unittest.TestCase):
         self.assertLess(
             command.index("$failedProjects += $project"),
             command.index("if ($failedProjects.Count -gt 0)"),
+        )
+        self.assertLess(
+            command.index("if ($failedProjects.Count -gt 0)"),
+            exit_matches[0].start(),
         )
 
     def test_every_workflow_compilation_is_warning_as_error(self) -> None:

--- a/scripts/tests/test_build_warning_contract.py
+++ b/scripts/tests/test_build_warning_contract.py
@@ -419,6 +419,7 @@ class BuildWarningContractTests(unittest.TestCase):
         self.assertIn("$PSNativeCommandUseErrorActionPreference = $false", command)
         self.assertIn("foreach ($project in $projects)", command)
         self.assertIn("$exitCode = $LASTEXITCODE", command)
+        self.assertIn("if ($exitCode -ne 0)", command)
         self.assertIn("$failedProjects += $project", command)
         self.assertIn("if ($failedProjects.Count -gt 0)", command)
         self.assertNotIn("break", command)
@@ -436,6 +437,29 @@ class BuildWarningContractTests(unittest.TestCase):
             command.index("if ($failedProjects.Count -gt 0)"),
             exit_matches[0].start(),
         )
+
+        coverage_conditions = {
+            "Install ReportGenerator":
+                "${{ !cancelled() && github.event_name == 'pull_request' }}",
+            "Generate Coverage Report":
+                "${{ !cancelled() && github.event_name == 'pull_request' }}",
+            "Comment PR with Coverage":
+                "${{ !cancelled() && github.event_name == 'pull_request' "
+                "&& github.event.pull_request.head.repo.full_name == github.repository "
+                "&& hashFiles('coverage-report/SummaryGithub.md') != '' }}",
+        }
+        for step_name, expected_condition in coverage_conditions.items():
+            step_match = re.search(
+                rf"(?ms)^    - name: {re.escape(step_name)}\s*\n"
+                rf"(?P<body>.*?)(?=^    - |\Z)",
+                build_block,
+            )
+            self.assertIsNotNone(step_match, step_name)
+            self.assertEqual(
+                [expected_condition],
+                re.findall(r"(?m)^      if:\s*(.+?)\s*$", step_match.group("body")),
+                step_name,
+            )
 
     def test_every_workflow_compilation_is_warning_as_error(self) -> None:
         missing: list[str] = []


### PR DESCRIPTION
## Summary

- replace timer-based HTTP caller cancellation with a deterministic handler-entry handshake
- disable the client timeout in caller-cancellation tests so only the caller token can satisfy the assertion
- run the four solution test projects sequentially while preserving each project’s internal parallelism
- continue through all projects to retain complete TRX and coverage evidence, then fail once if any project failed
- explicitly prevent PowerShell from promoting native non-zero exits into terminating errors mid-loop
- process and comment coverage after test failures when the job was not cancelled
- add 20-minute testhost hang diagnostics plus 90-minute test-step and 120-minute job bounds
- pin project order, exact failure guards, coverage-after-failure conditions, and a single trailing aggregate exit with fail-closed Python contracts

Accepted final plan: https://github.com/laqieer/FEBuilderGBA/issues/2077#issuecomment-5240079640

Closes #2077

## Test plan

- [x] Both strict caller-cancellation tests passed 100 consecutive invocations without retries
- [x] Full `test_build_warning_contract.py` suite — 9 passed
- [x] Native fail-then-pass aggregation simulation retained the failure and exited once
- [x] Exact x86 Debug build and serialized four-project coverage loop passed on the first post-change run
- [x] Serialized timings: Core 32.84m, Avalonia 5.88m, WinForms-host 2.59m, E2E 2.07m
- [x] `git diff --check` and actual-path risk classification (`high` due to `check.yml`)

## CI acceptance

The first `Check` workflow run for final head `6bd7d73d7` must pass without rerunning. A retry does not satisfy this PR’s acceptance criterion.

Copilot CLI: 1.0.78
Model: GPT-5.6 Sol (gpt-5.6-sol)