### PR TITLE
test(e2e): wait for editor windows deterministically

### DIFF
--- a/FEBuilderGBA.E2ETests/Helpers/WinAutomation.cs
+++ b/FEBuilderGBA.E2ETests/Helpers/WinAutomation.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
@@ -83,6 +84,130 @@ namespace FEBuilderGBA.E2ETests.Helpers
                 return true;
             }, IntPtr.Zero);
             return result;
+        }
+
+        /// <summary>
+        /// Waits for top-level process windows that are not present in
+        /// <paramref name="baselineWindows"/>. The result must remain unchanged for
+        /// several polls so a modal window and any immediately-created companions
+        /// are returned together.
+        /// </summary>
+        public static List<IntPtr> WaitForNewProcessWindows(
+            int processId,
+            IReadOnlySet<IntPtr> baselineWindows,
+            int timeoutMs = 5_000,
+            int pollMs = 100)
+        {
+            return WaitForNewWindows(
+                () => GetProcessWindows(processId),
+                baselineWindows,
+                timeoutMs,
+                pollMs,
+                stablePollCount: 5);
+        }
+
+        internal static List<IntPtr> WaitForNewWindows(
+            Func<IReadOnlyCollection<IntPtr>> windowProbe,
+            IReadOnlySet<IntPtr> baselineWindows,
+            int timeoutMs,
+            int pollMs,
+            int stablePollCount)
+        {
+            ArgumentNullException.ThrowIfNull(windowProbe);
+            ArgumentNullException.ThrowIfNull(baselineWindows);
+            ArgumentOutOfRangeException.ThrowIfNegative(timeoutMs);
+            ArgumentOutOfRangeException.ThrowIfNegative(pollMs);
+            ArgumentOutOfRangeException.ThrowIfLessThan(stablePollCount, 1);
+
+            var sw = Stopwatch.StartNew();
+            HashSet<IntPtr>? latestNewWindows = null;
+            int stablePolls = 0;
+
+            while (true)
+            {
+                var newWindows = new HashSet<IntPtr>(windowProbe());
+                newWindows.ExceptWith(baselineWindows);
+
+                if (newWindows.Count == 0)
+                {
+                    latestNewWindows = null;
+                    stablePolls = 0;
+                }
+                else if (latestNewWindows != null &&
+                         latestNewWindows.SetEquals(newWindows))
+                {
+                    stablePolls++;
+                }
+                else
+                {
+                    latestNewWindows = newWindows;
+                    stablePolls = 1;
+                }
+
+                if (latestNewWindows != null && stablePolls >= stablePollCount)
+                    return latestNewWindows.ToList();
+
+                if (sw.ElapsedMilliseconds >= timeoutMs)
+                    return latestNewWindows?.ToList() ?? new List<IntPtr>();
+
+                WaitForNextPoll(sw, timeoutMs, pollMs);
+            }
+        }
+
+        /// <summary>
+        /// Waits until every target handle is absent from the process's top-level
+        /// windows, allowing asynchronous WM_CLOSE messages to complete.
+        /// </summary>
+        public static bool WaitForProcessWindowsClosed(
+            int processId,
+            IReadOnlyCollection<IntPtr> targetWindows,
+            int timeoutMs = 2_000,
+            int pollMs = 100)
+        {
+            return WaitForWindowsClosed(
+                () => GetProcessWindows(processId),
+                targetWindows,
+                timeoutMs,
+                pollMs);
+        }
+
+        internal static bool WaitForWindowsClosed(
+            Func<IReadOnlyCollection<IntPtr>> windowProbe,
+            IReadOnlyCollection<IntPtr> targetWindows,
+            int timeoutMs,
+            int pollMs)
+        {
+            ArgumentNullException.ThrowIfNull(windowProbe);
+            ArgumentNullException.ThrowIfNull(targetWindows);
+            ArgumentOutOfRangeException.ThrowIfNegative(timeoutMs);
+            ArgumentOutOfRangeException.ThrowIfNegative(pollMs);
+
+            var targets = new HashSet<IntPtr>(targetWindows);
+            var sw = Stopwatch.StartNew();
+
+            while (true)
+            {
+                var openWindows = new HashSet<IntPtr>(windowProbe());
+                if (!targets.Overlaps(openWindows))
+                    return true;
+
+                if (sw.ElapsedMilliseconds >= timeoutMs)
+                    return false;
+
+                WaitForNextPoll(sw, timeoutMs, pollMs);
+            }
+        }
+
+        private static void WaitForNextPoll(Stopwatch sw, int timeoutMs, int pollMs)
+        {
+            if (pollMs == 0)
+            {
+                Thread.Yield();
+                return;
+            }
+
+            int remainingMs = Math.Max(1, timeoutMs - (int)sw.ElapsedMilliseconds);
+            Thread.Sleep(Math.Min(pollMs, remainingMs));
         }
 
         /// <summary>

--- a/FEBuilderGBA.E2ETests/Tests/FormSmokeTests.cs
+++ b/FEBuilderGBA.E2ETests/Tests/FormSmokeTests.cs
@@ -31,6 +31,8 @@ namespace FEBuilderGBA.E2ETests.Tests
         /// Prevents indefinite hangs when a button opens a blocking modal dialog.
         /// </summary>
         private const int ButtonLoopTimeoutMs = 120_000; // 2 minutes per ROM
+        private const int WindowOpenTimeoutMs = 5_000;
+        private const int WindowCloseTimeoutMs = 2_000;
 
         public FormSmokeTests(ITestOutputHelper output)
         {
@@ -110,11 +112,12 @@ namespace FEBuilderGBA.E2ETests.Tests
                 var before = new HashSet<IntPtr>(WinAutomation.GetProcessWindows(_process.Id));
 
                 WinAutomation.ClickButton(btnHWnd);
-                Thread.Sleep(500);
-
-                // Detect newly opened windows
-                var after = WinAutomation.GetProcessWindows(_process.Id);
-                var newWindows = after.Where(w => !before.Contains(w)).ToList();
+                int remainingMs = Math.Max(
+                    0, ButtonLoopTimeoutMs - (int)loopSw.ElapsedMilliseconds);
+                var newWindows = WinAutomation.WaitForNewProcessWindows(
+                    _process.Id,
+                    before,
+                    timeoutMs: Math.Min(WindowOpenTimeoutMs, remainingMs));
 
                 if (newWindows.Count > 0)
                 {
@@ -126,7 +129,22 @@ namespace FEBuilderGBA.E2ETests.Tests
                         ScreenshotHelper.CaptureWindow(nw, $"Form_{romName}_{safeText}");
                         WinAutomation.CloseWindow(nw);
                     }
-                    Thread.Sleep(500);
+
+                    int closeTimeoutMs = Math.Min(
+                        WindowCloseTimeoutMs,
+                        Math.Max(0, ButtonLoopTimeoutMs - (int)loopSw.ElapsedMilliseconds));
+                    bool closed = WinAutomation.WaitForProcessWindowsClosed(
+                        _process.Id,
+                        newWindows,
+                        timeoutMs: closeTimeoutMs);
+                    if (!closed)
+                        _output.WriteLine($"{romName}: {btnText} windows did not close within " +
+                            $"{closeTimeoutMs}ms");
+                }
+                else
+                {
+                    _output.WriteLine($"{romName}: {btnText} opened no top-level window within " +
+                        $"{Math.Min(WindowOpenTimeoutMs, remainingMs)}ms");
                 }
 
                 // Close any unexpected windows that may have appeared

--- a/FEBuilderGBA.E2ETests/Tests/WinAutomationTests.cs
+++ b/FEBuilderGBA.E2ETests/Tests/WinAutomationTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using FEBuilderGBA.E2ETests.Helpers;
+using Xunit;
+
+namespace FEBuilderGBA.E2ETests.Tests
+{
+    public class WinAutomationTests
+    {
+        [Fact]
+        public void WaitForNewWindows_WaitsForStableNewSet()
+        {
+            var baseline = new HashSet<IntPtr> { new(1) };
+            var probe = CreateProbe(
+                new[] { new IntPtr(1) },
+                new[] { new IntPtr(1), new IntPtr(2) },
+                new[] { new IntPtr(1), new IntPtr(2), new IntPtr(3) },
+                new[] { new IntPtr(1), new IntPtr(2), new IntPtr(3) });
+
+            List<IntPtr> result = WinAutomation.WaitForNewWindows(
+                probe, baseline, timeoutMs: 1_000, pollMs: 0, stablePollCount: 2);
+
+            Assert.Equal(2, result.Count);
+            Assert.Contains(new IntPtr(2), result);
+            Assert.Contains(new IntPtr(3), result);
+        }
+
+        [Fact]
+        public void WaitForNewWindows_ReturnsEmptyWhenTimeoutExpires()
+        {
+            var baseline = new HashSet<IntPtr> { new(1) };
+            var probe = CreateProbe(new[] { new IntPtr(1) });
+
+            List<IntPtr> result = WinAutomation.WaitForNewWindows(
+                probe, baseline, timeoutMs: 0, pollMs: 0, stablePollCount: 2);
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void WaitForNewWindows_ReturnsObservedSetWhenStabilityTimesOut()
+        {
+            var baseline = new HashSet<IntPtr> { new(1) };
+            var probe = CreateProbe(new[] { new IntPtr(1), new IntPtr(2) });
+
+            List<IntPtr> result = WinAutomation.WaitForNewWindows(
+                probe, baseline, timeoutMs: 0, pollMs: 0, stablePollCount: 2);
+
+            Assert.Equal(new[] { new IntPtr(2) }, result);
+        }
+
+        [Fact]
+        public void WaitForWindowsClosed_WaitsForTargetsToDisappear()
+        {
+            var targets = new HashSet<IntPtr> { new(2), new(3) };
+            var probe = CreateProbe(
+                new[] { new IntPtr(1), new IntPtr(2), new IntPtr(3) },
+                new[] { new IntPtr(1), new IntPtr(3) },
+                new[] { new IntPtr(1) });
+
+            bool closed = WinAutomation.WaitForWindowsClosed(
+                probe, targets, timeoutMs: 1_000, pollMs: 0);
+
+            Assert.True(closed);
+        }
+
+        [Fact]
+        public void WaitForWindowsClosed_ReturnsFalseWhenTimeoutExpires()
+        {
+            var targets = new HashSet<IntPtr> { new(2) };
+            var probe = CreateProbe(new[] { new IntPtr(1), new IntPtr(2) });
+
+            bool closed = WinAutomation.WaitForWindowsClosed(
+                probe, targets, timeoutMs: 0, pollMs: 0);
+
+            Assert.False(closed);
+        }
+
+        private static Func<IReadOnlyCollection<IntPtr>> CreateProbe(params IntPtr[][] snapshots)
+        {
+            int index = 0;
+            return () =>
+            {
+                int current = Math.Min(index, snapshots.Length - 1);
+                index++;
+                return snapshots[current];
+            };
+        }
+    }
+}

--- a/FEBuilderGBA.E2ETests/Tests/WinFormsScreenshotAllTests.cs
+++ b/FEBuilderGBA.E2ETests/Tests/WinFormsScreenshotAllTests.cs
@@ -24,6 +24,8 @@ namespace FEBuilderGBA.E2ETests.Tests
         private Process? _process;
 
         private const int ButtonLoopTimeoutMs = 120_000; // 2 minutes per ROM
+        private const int WindowOpenTimeoutMs = 5_000;
+        private const int WindowCloseTimeoutMs = 2_000;
 
         public WinFormsScreenshotAllTests(ITestOutputHelper output)
         {
@@ -110,10 +112,12 @@ namespace FEBuilderGBA.E2ETests.Tests
                 var before = new HashSet<IntPtr>(WinAutomation.GetProcessWindows(_process.Id));
 
                 WinAutomation.ClickButton(btnHWnd);
-                Thread.Sleep(500);
-
-                var after = WinAutomation.GetProcessWindows(_process.Id);
-                var newWindows = after.Where(w => !before.Contains(w)).ToList();
+                int remainingMs = Math.Max(
+                    0, ButtonLoopTimeoutMs - (int)loopSw.ElapsedMilliseconds);
+                var newWindows = WinAutomation.WaitForNewProcessWindows(
+                    _process.Id,
+                    before,
+                    timeoutMs: Math.Min(WindowOpenTimeoutMs, remainingMs));
 
                 if (newWindows.Count > 0)
                 {
@@ -129,7 +133,22 @@ namespace FEBuilderGBA.E2ETests.Tests
                         }
                         WinAutomation.CloseWindow(nw);
                     }
-                    Thread.Sleep(500);
+
+                    int closeTimeoutMs = Math.Min(
+                        WindowCloseTimeoutMs,
+                        Math.Max(0, ButtonLoopTimeoutMs - (int)loopSw.ElapsedMilliseconds));
+                    bool closed = WinAutomation.WaitForProcessWindowsClosed(
+                        _process.Id,
+                        newWindows,
+                        timeoutMs: closeTimeoutMs);
+                    if (!closed)
+                        _output.WriteLine($"{romName}: {btnText} windows did not close within " +
+                            $"{closeTimeoutMs}ms");
+                }
+                else
+                {
+                    _output.WriteLine($"{romName}: {btnText} opened no top-level window within " +
+                        $"{Math.Min(WindowOpenTimeoutMs, remainingMs)}ms");
                 }
 
                 WinAutomation.CloseUnexpectedWindows(_process.Id, before);


### PR DESCRIPTION
## Summary

- replace fixed post-click snapshots with bounded, baseline-aware window discovery
- wait for asynchronously closed editor windows before continuing toolbar traversal
- add deterministic coverage for delayed appearance, multi-window settling, and timeout behavior

Accepted plan: https://github.com/laqieer/FEBuilderGBA/issues/2081#issuecomment-5278071395

Closes #2081

## Test plan

- [x] synchronization helper tests pass 25 consecutive local runs
- [x] Release/x86 solution build passes with warnings as errors
- [x] full no-ROM E2E project passes (579 total: 290 passed, 289 ROM-gated skipped)
- [x] FE7J hosted workflow passes three independent runs: 31686004223, 31686009601, 31686015647
- [x] FE6, FE7U, FE8J, and FE8U hosted workflows pass: 31686020917, 31686025958, 31686030732, 31686035710

Copilot CLI: 1.0.79
Model: GPT-5.6 Sol (gpt-5.6-sol)