### PR TITLE
fix(avalonia): localize item shop labels

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/ItemShopViewerView_LayoutTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ItemShopViewerView_LayoutTests.cs
@@ -101,6 +101,9 @@ namespace FEBuilderGBA.Avalonia.Tests
                 src.Split("CoreState.LanguageChanged -= OnLanguageChanged;").Length - 1);
             Assert.Contains("CoreState.LanguageChanged += OnLanguageChanged;", src);
             Assert.Contains("Dispatcher.UIThread.Post(ReloadShopListForLanguage);", src);
+            Assert.Contains("_isAttachedToVisualTree = true;", src);
+            Assert.Contains("_isAttachedToVisualTree = false;", src);
+            Assert.Contains("if (!_isAttachedToVisualTree) return;", src);
             Assert.Contains(
                 "ReloadShopListAndSelect(shopAddrToSelect, slotIndexToSelect);",
                 src);

--- a/FEBuilderGBA.Avalonia.Tests/ItemShopViewerView_LayoutTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ItemShopViewerView_LayoutTests.cs
@@ -104,7 +104,15 @@ namespace FEBuilderGBA.Avalonia.Tests
             Assert.Contains("_isAttachedToVisualTree = true;", src);
             Assert.Contains("_isAttachedToVisualTree = false;", src);
             Assert.Contains("if (!_isAttachedToVisualTree) return;", src);
+            Assert.Contains("ReloadShopListForLanguage();", src);
             Assert.Contains(
+                "ShopList.SelectedAddressChanged -= OnShopSelected;",
+                src);
+            Assert.Contains("ShopList.SetItemsPreserveSelection(", src);
+            Assert.Contains("_currentShopList,", src);
+            Assert.Contains("shopAddrToSelect);", src);
+            Assert.Contains("ShopNameLabel.Text = selectedShop.name;", src);
+            Assert.DoesNotContain(
                 "ReloadShopListAndSelect(shopAddrToSelect, slotIndexToSelect);",
                 src);
         }

--- a/FEBuilderGBA.Avalonia.Tests/ItemShopViewerView_LayoutTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ItemShopViewerView_LayoutTests.cs
@@ -112,6 +112,10 @@ namespace FEBuilderGBA.Avalonia.Tests
             Assert.Contains("_currentShopList,", src);
             Assert.Contains("shopAddrToSelect);", src);
             Assert.Contains("ShopNameLabel.Text = selectedShop.name;", src);
+            Assert.Contains(
+                "ItemShopViewerView.ReloadShopListForLanguage: {0}",
+                src);
+            Assert.Contains("Failed to refresh shop labels:", src);
             Assert.DoesNotContain(
                 "ReloadShopListAndSelect(shopAddrToSelect, slotIndexToSelect);",
                 src);

--- a/FEBuilderGBA.Avalonia.Tests/ItemShopViewerView_LayoutTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ItemShopViewerView_LayoutTests.cs
@@ -16,6 +16,15 @@ namespace FEBuilderGBA.Avalonia.Tests
     /// </summary>
     public class ItemShopViewerView_LayoutTests
     {
+        static string ReadViewSource()
+        {
+            string srcPath = System.IO.Path.Combine(
+                System.AppDomain.CurrentDomain.BaseDirectory,
+                "..", "..", "..", "..",
+                "FEBuilderGBA.Avalonia", "Views", "ItemShopViewerView.axaml.cs");
+            return System.IO.File.ReadAllText(srcPath);
+        }
+
         [AvaloniaFact]
         public void ItemShopViewerView_CanInstantiate()
         {
@@ -73,11 +82,7 @@ namespace FEBuilderGBA.Avalonia.Tests
         [AvaloniaFact]
         public void ItemShopViewerView_RelocationPreservesShopSelection()
         {
-            string srcPath = System.IO.Path.Combine(
-                System.AppDomain.CurrentDomain.BaseDirectory,
-                "..", "..", "..", "..",
-                "FEBuilderGBA.Avalonia", "Views", "ItemShopViewerView.axaml.cs");
-            string src = System.IO.File.ReadAllText(srcPath);
+            string src = ReadViewSource();
             // After Relocated outcome, the handler must call the
             // shop-preserving reload helper (not raw LoadShopList).
             Assert.Contains("ReloadShopListAndSelect(newShopAddr", src);
@@ -85,6 +90,20 @@ namespace FEBuilderGBA.Avalonia.Tests
             Assert.Contains("ShopList.SelectAddress(shopAddrToSelect)", src);
             // The helper must reselect the appended slot inside the relocated shop.
             Assert.Contains("SlotList.SelectAddress(slot.addr)", src);
+        }
+
+        [AvaloniaFact]
+        public void ItemShopViewerView_LanguageChangeReloadsLocalizedRows()
+        {
+            string src = ReadViewSource();
+
+            Assert.Equal(2,
+                src.Split("CoreState.LanguageChanged -= OnLanguageChanged;").Length - 1);
+            Assert.Contains("CoreState.LanguageChanged += OnLanguageChanged;", src);
+            Assert.Contains("Dispatcher.UIThread.Post(ReloadShopListForLanguage);", src);
+            Assert.Contains(
+                "ReloadShopListAndSelect(shopAddrToSelect, slotIndexToSelect);",
+                src);
         }
     }
 }

--- a/FEBuilderGBA.Avalonia.Tests/ItemShopViewerView_LayoutTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ItemShopViewerView_LayoutTests.cs
@@ -115,7 +115,9 @@ namespace FEBuilderGBA.Avalonia.Tests
             Assert.Contains(
                 "ItemShopViewerView.ReloadShopListForLanguage: {0}",
                 src);
-            Assert.Contains("Failed to refresh shop labels:", src);
+            Assert.Contains(
+                "R._(\"Failed to refresh shop labels: {0}\", ex.Message)",
+                src);
             Assert.DoesNotContain(
                 "ReloadShopListAndSelect(shopAddrToSelect, slotIndexToSelect);",
                 src);

--- a/FEBuilderGBA.Avalonia/Views/ItemShopViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemShopViewerView.axaml.cs
@@ -75,36 +75,47 @@ namespace FEBuilderGBA.Avalonia.Views
         {
             if (!_isAttachedToVisualTree) return;
 
-            uint shopAddrToSelect = ShopList.SelectedItem?.addr ?? _vm.CurrentShopAddr;
-            ShopList.SelectedAddressChanged -= OnShopSelected;
             try
             {
-                _currentShopList = _vm.LoadShopList();
-                ShopList.SetItemsPreserveSelection(
-                    _currentShopList,
-                    shopAddrToSelect);
-            }
-            finally
-            {
-                ShopList.SelectedAddressChanged += OnShopSelected;
-            }
+                uint shopAddrToSelect =
+                    ShopList.SelectedItem?.addr ?? _vm.CurrentShopAddr;
+                ShopList.SelectedAddressChanged -= OnShopSelected;
+                try
+                {
+                    _currentShopList = _vm.LoadShopList();
+                    ShopList.SetItemsPreserveSelection(
+                        _currentShopList,
+                        shopAddrToSelect);
+                }
+                finally
+                {
+                    ShopList.SelectedAddressChanged += OnShopSelected;
+                }
 
-            AddrResult? selectedShop = ShopList.SelectedItem;
-            if (selectedShop == null) return;
+                AddrResult? selectedShop = ShopList.SelectedItem;
+                if (selectedShop == null) return;
 
-            bool wasLoading = _vm.IsLoading;
-            _vm.IsLoading = true;
-            try
-            {
-                _vm.CurrentShopAddr = selectedShop.addr;
-                _vm.CurrentShopPointerAddr = selectedShop.tag;
-                _vm.CurrentShopName = selectedShop.name;
+                bool wasLoading = _vm.IsLoading;
+                _vm.IsLoading = true;
+                try
+                {
+                    _vm.CurrentShopAddr = selectedShop.addr;
+                    _vm.CurrentShopPointerAddr = selectedShop.tag;
+                    _vm.CurrentShopName = selectedShop.name;
+                }
+                finally
+                {
+                    _vm.IsLoading = wasLoading;
+                }
+                ShopNameLabel.Text = selectedShop.name;
             }
-            finally
+            catch (Exception ex)
             {
-                _vm.IsLoading = wasLoading;
+                Log.ErrorF(
+                    "ItemShopViewerView.ReloadShopListForLanguage: {0}",
+                    ex.Message);
+                StatusLabel.Text = $"Failed to refresh shop labels: {ex.Message}";
             }
-            ShopNameLabel.Text = selectedShop.name;
         }
 
         // ===================================================================

--- a/FEBuilderGBA.Avalonia/Views/ItemShopViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemShopViewerView.axaml.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using global::Avalonia.Controls;
 using global::Avalonia.Input;
 using global::Avalonia.Interactivity;
+using global::Avalonia.Threading;
 using FEBuilderGBA;
 using FEBuilderGBA.Avalonia.Controls;
 using FEBuilderGBA.Avalonia.Services;
@@ -43,11 +44,33 @@ namespace FEBuilderGBA.Avalonia.Views
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {
             base.OnAttachedToVisualTree(e);
+            CoreState.LanguageChanged -= OnLanguageChanged;
+            CoreState.LanguageChanged += OnLanguageChanged;
             if (!_hasLoadedList)
             {
                 _hasLoadedList = true;
                 LoadShopList();
             }
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            CoreState.LanguageChanged -= OnLanguageChanged;
+            base.OnDetachedFromVisualTree(e);
+        }
+
+        void OnLanguageChanged()
+        {
+            Dispatcher.UIThread.Post(ReloadShopListForLanguage);
+        }
+
+        void ReloadShopListForLanguage()
+        {
+            uint shopAddrToSelect = ShopList.SelectedItem?.addr ?? _vm.CurrentShopAddr;
+            uint slotAddrToSelect = SlotList.SelectedItem?.addr ?? _vm.CurrentAddr;
+            int slotIndexToSelect =
+                _currentSlotList.FindIndex(slot => slot.addr == slotAddrToSelect);
+            ReloadShopListAndSelect(shopAddrToSelect, slotIndexToSelect);
         }
 
         // ===================================================================

--- a/FEBuilderGBA.Avalonia/Views/ItemShopViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemShopViewerView.axaml.cs
@@ -26,6 +26,7 @@ namespace FEBuilderGBA.Avalonia.Views
         readonly ItemShopViewerViewModel _vm = new();
         readonly UndoService _undoService = new();
         bool _hasLoadedList;
+        bool _isAttachedToVisualTree;
         List<AddrResult> _currentShopList = new();
         List<AddrResult> _currentSlotList = new();
 
@@ -44,6 +45,7 @@ namespace FEBuilderGBA.Avalonia.Views
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {
             base.OnAttachedToVisualTree(e);
+            _isAttachedToVisualTree = true;
             CoreState.LanguageChanged -= OnLanguageChanged;
             CoreState.LanguageChanged += OnLanguageChanged;
             if (!_hasLoadedList)
@@ -55,6 +57,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
         {
+            _isAttachedToVisualTree = false;
             CoreState.LanguageChanged -= OnLanguageChanged;
             base.OnDetachedFromVisualTree(e);
         }
@@ -66,6 +69,8 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void ReloadShopListForLanguage()
         {
+            if (!_isAttachedToVisualTree) return;
+
             uint shopAddrToSelect = ShopList.SelectedItem?.addr ?? _vm.CurrentShopAddr;
             uint slotAddrToSelect = SlotList.SelectedItem?.addr ?? _vm.CurrentAddr;
             int slotIndexToSelect =

--- a/FEBuilderGBA.Avalonia/Views/ItemShopViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemShopViewerView.axaml.cs
@@ -114,7 +114,8 @@ namespace FEBuilderGBA.Avalonia.Views
                 Log.ErrorF(
                     "ItemShopViewerView.ReloadShopListForLanguage: {0}",
                     ex.Message);
-                StatusLabel.Text = $"Failed to refresh shop labels: {ex.Message}";
+                StatusLabel.Text =
+                    R._("Failed to refresh shop labels: {0}", ex.Message);
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Views/ItemShopViewerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemShopViewerView.axaml.cs
@@ -53,6 +53,10 @@ namespace FEBuilderGBA.Avalonia.Views
                 _hasLoadedList = true;
                 LoadShopList();
             }
+            else
+            {
+                ReloadShopListForLanguage();
+            }
         }
 
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
@@ -72,10 +76,35 @@ namespace FEBuilderGBA.Avalonia.Views
             if (!_isAttachedToVisualTree) return;
 
             uint shopAddrToSelect = ShopList.SelectedItem?.addr ?? _vm.CurrentShopAddr;
-            uint slotAddrToSelect = SlotList.SelectedItem?.addr ?? _vm.CurrentAddr;
-            int slotIndexToSelect =
-                _currentSlotList.FindIndex(slot => slot.addr == slotAddrToSelect);
-            ReloadShopListAndSelect(shopAddrToSelect, slotIndexToSelect);
+            ShopList.SelectedAddressChanged -= OnShopSelected;
+            try
+            {
+                _currentShopList = _vm.LoadShopList();
+                ShopList.SetItemsPreserveSelection(
+                    _currentShopList,
+                    shopAddrToSelect);
+            }
+            finally
+            {
+                ShopList.SelectedAddressChanged += OnShopSelected;
+            }
+
+            AddrResult? selectedShop = ShopList.SelectedItem;
+            if (selectedShop == null) return;
+
+            bool wasLoading = _vm.IsLoading;
+            _vm.IsLoading = true;
+            try
+            {
+                _vm.CurrentShopAddr = selectedShop.addr;
+                _vm.CurrentShopPointerAddr = selectedShop.tag;
+                _vm.CurrentShopName = selectedShop.name;
+            }
+            finally
+            {
+                _vm.IsLoading = wasLoading;
+            }
+            ShopNameLabel.Text = selectedShop.name;
         }
 
         // ===================================================================

--- a/FEBuilderGBA.Core.Tests/ItemShopCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/ItemShopCoreTests.cs
@@ -118,6 +118,8 @@ namespace FEBuilderGBA.Core.Tests
         [Theory]
         [InlineData("Ide@001F", "Ide")]
         [InlineData("Serafew@001F", "Serafew")]
+        [InlineData("Ide\u001F", "Ide")]
+        [InlineData("Serafew\u001F", "Serafew")]
         public void NormalizeDecodedWorldMapPointName_RemovesPaddingToken(
             string decoded,
             string expected)

--- a/FEBuilderGBA.Core.Tests/ItemShopCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/ItemShopCoreTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using FEBuilderGBA;
 using Xunit;
 
@@ -21,30 +20,15 @@ namespace FEBuilderGBA.Core.Tests
     public class ItemShopCoreTests
     {
         // ---------- helpers ----------
-        sealed class ShopTranslationScope : IDisposable
+        static string TranslateShopLabel(string shopLabel)
         {
-            readonly string _path;
-
-            public ShopTranslationScope()
+            return shopLabel switch
             {
-                _path = Path.GetTempFileName();
-                File.WriteAllText(_path,
-                    ":武器屋\n" +
-                    "Armory\n" +
-                    "\n" +
-                    ":道具屋\n" +
-                    "Vendor\n" +
-                    "\n" +
-                    ":秘密屋\n" +
-                    "Secret Shop\n");
-                MyTranslateResource.LoadResource(_path);
-            }
-
-            public void Dispose()
-            {
-                MyTranslateResource.Clear();
-                File.Delete(_path);
-            }
+                "武器屋" => "Armory",
+                "道具屋" => "Vendor",
+                "秘密屋" => "Secret Shop",
+                _ => shopLabel,
+            };
         }
 
         static void WriteU32(byte[] data, int offset, uint value)
@@ -138,7 +122,6 @@ namespace FEBuilderGBA.Core.Tests
         [Fact]
         public void MakeShopList_IncludesWorldMapShops_OnSyntheticRom()
         {
-            using var translation = new ShopTranslationScope();
             var rom = MakeFE8UWithHenseiShop();
 
             // Set up one worldmap point at offset 0x400.
@@ -175,7 +158,7 @@ namespace FEBuilderGBA.Core.Tests
             rom.Data[0x502] = 0x00; // terminator
             rom.Data[0x503] = 0x00;
 
-            var shops = ItemShopCore.MakeShopList(rom);
+            var shops = ItemShopCore.MakeShopList(rom, TranslateShopLabel);
 
             // Expect at least 2 entries: hensei (0x200) + worldmap armory (0x500).
             Assert.Contains(shops, s =>
@@ -219,7 +202,6 @@ namespace FEBuilderGBA.Core.Tests
         [Fact]
         public void MakeShopList_IncludesEventCondShops_OnSyntheticRom()
         {
-            using var translation = new ShopTranslationScope();
             // Build the chain: map_setting_pointer -> map[0] -> PLIST byte -> event-cond block
             //   -> slot[2] (OBJECT) -> object record -> shop address.
             var rom = MakeFE8UWithHenseiShop();
@@ -280,7 +262,7 @@ namespace FEBuilderGBA.Core.Tests
             rom.Data[0x1302] = 0x00;
             rom.Data[0x1303] = 0x00;
 
-            var shops = ItemShopCore.MakeShopList(rom);
+            var shops = ItemShopCore.MakeShopList(rom, TranslateShopLabel);
 
             // We expect: hensei (0x200) + the event-cond armory shop (0x1300).
             Assert.Contains(shops, s =>

--- a/FEBuilderGBA.Core.Tests/ItemShopCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/ItemShopCoreTests.cs
@@ -115,6 +115,17 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Empty(shops);
         }
 
+        [Theory]
+        [InlineData("Ide@001F", "Ide")]
+        [InlineData("Serafew@001F", "Serafew")]
+        public void NormalizeDecodedWorldMapPointName_RemovesPaddingToken(
+            string decoded,
+            string expected)
+        {
+            Assert.Equal(expected,
+                ItemShopCore.NormalizeDecodedWorldMapPointName(decoded));
+        }
+
         // ===================================================================
         // MakeShopList: worldmap (FE8)
         // ===================================================================

--- a/FEBuilderGBA.Core.Tests/ItemShopCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/ItemShopCoreTests.cs
@@ -171,7 +171,8 @@ namespace FEBuilderGBA.Core.Tests
             rom.Data[0x502] = 0x00; // terminator
             rom.Data[0x503] = 0x00;
 
-            var shops = ItemShopCore.MakeShopList(rom, TranslateShopLabel);
+            var shops =
+                ItemShopCore.MakeShopListWithTranslator(rom, TranslateShopLabel);
 
             // Expect at least 2 entries: hensei (0x200) + worldmap armory (0x500).
             Assert.Contains(shops, s =>
@@ -275,7 +276,8 @@ namespace FEBuilderGBA.Core.Tests
             rom.Data[0x1302] = 0x00;
             rom.Data[0x1303] = 0x00;
 
-            var shops = ItemShopCore.MakeShopList(rom, TranslateShopLabel);
+            var shops =
+                ItemShopCore.MakeShopListWithTranslator(rom, TranslateShopLabel);
 
             // We expect: hensei (0x200) + the event-cond armory shop (0x1300).
             Assert.Contains(shops, s =>

--- a/FEBuilderGBA.Core.Tests/ItemShopCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/ItemShopCoreTests.cs
@@ -1,6 +1,8 @@
-using Xunit;
-using FEBuilderGBA;
+using System;
 using System.Collections.Generic;
+using System.IO;
+using FEBuilderGBA;
+using Xunit;
 
 namespace FEBuilderGBA.Core.Tests
 {
@@ -19,6 +21,32 @@ namespace FEBuilderGBA.Core.Tests
     public class ItemShopCoreTests
     {
         // ---------- helpers ----------
+        sealed class ShopTranslationScope : IDisposable
+        {
+            readonly string _path;
+
+            public ShopTranslationScope()
+            {
+                _path = Path.GetTempFileName();
+                File.WriteAllText(_path,
+                    ":武器屋\n" +
+                    "Armory\n" +
+                    "\n" +
+                    ":道具屋\n" +
+                    "Vendor\n" +
+                    "\n" +
+                    ":秘密屋\n" +
+                    "Secret Shop\n");
+                MyTranslateResource.LoadResource(_path);
+            }
+
+            public void Dispose()
+            {
+                MyTranslateResource.Clear();
+                File.Delete(_path);
+            }
+        }
+
         static void WriteU32(byte[] data, int offset, uint value)
         {
             data[offset + 0] = (byte)(value & 0xFF);
@@ -110,6 +138,7 @@ namespace FEBuilderGBA.Core.Tests
         [Fact]
         public void MakeShopList_IncludesWorldMapShops_OnSyntheticRom()
         {
+            using var translation = new ShopTranslationScope();
             var rom = MakeFE8UWithHenseiShop();
 
             // Set up one worldmap point at offset 0x400.
@@ -149,7 +178,9 @@ namespace FEBuilderGBA.Core.Tests
             var shops = ItemShopCore.MakeShopList(rom);
 
             // Expect at least 2 entries: hensei (0x200) + worldmap armory (0x500).
-            Assert.Contains(shops, s => s.addr == 0x500);
+            Assert.Contains(shops, s =>
+                s.addr == 0x500 &&
+                s.name.EndsWith("Armory", StringComparison.Ordinal));
         }
 
         [Fact]
@@ -188,6 +219,7 @@ namespace FEBuilderGBA.Core.Tests
         [Fact]
         public void MakeShopList_IncludesEventCondShops_OnSyntheticRom()
         {
+            using var translation = new ShopTranslationScope();
             // Build the chain: map_setting_pointer -> map[0] -> PLIST byte -> event-cond block
             //   -> slot[2] (OBJECT) -> object record -> shop address.
             var rom = MakeFE8UWithHenseiShop();
@@ -251,7 +283,9 @@ namespace FEBuilderGBA.Core.Tests
             var shops = ItemShopCore.MakeShopList(rom);
 
             // We expect: hensei (0x200) + the event-cond armory shop (0x1300).
-            Assert.Contains(shops, s => s.addr == 0x1300);
+            Assert.Contains(shops, s =>
+                s.addr == 0x1300 &&
+                s.name.EndsWith("Armory", StringComparison.Ordinal));
         }
 
         [Fact]

--- a/FEBuilderGBA.Core/ItemShopCore.cs
+++ b/FEBuilderGBA.Core/ItemShopCore.cs
@@ -113,12 +113,18 @@ namespace FEBuilderGBA
                 // ItemShopForm then additionally skips shops whose first item byte
                 // is 0x00 (the `rom.u8(shopAddr) == 0` check below).
                 AddWorldMapShopIfValid(rom, pointAddr + 12, armoryPtr,
-                    rom.RomInfo.get_shop_name(0x16), pointName, result);
+                    GetLocalizedShopLabel(rom, 0x16), pointName, result);
                 AddWorldMapShopIfValid(rom, pointAddr + 16, vendorPtr,
-                    rom.RomInfo.get_shop_name(0x17), pointName, result);
+                    GetLocalizedShopLabel(rom, 0x17), pointName, result);
                 AddWorldMapShopIfValid(rom, pointAddr + 20, secretPtr,
-                    rom.RomInfo.get_shop_name(0x18), pointName, result);
+                    GetLocalizedShopLabel(rom, 0x18), pointName, result);
             }
+        }
+
+        static string GetLocalizedShopLabel(ROM rom, uint shopObject)
+        {
+            string shopLabel = rom.RomInfo.get_shop_name(shopObject);
+            return string.IsNullOrEmpty(shopLabel) ? shopLabel : R._(shopLabel);
         }
 
         /// <summary>
@@ -203,7 +209,7 @@ namespace FEBuilderGBA
 
                         // Look up the shop's display label by object type at +10.
                         uint objType = rom.u8(recAddr + 10);
-                        string shopLabel = rom.RomInfo.get_shop_name(objType);
+                        string shopLabel = GetLocalizedShopLabel(rom, objType);
                         if (string.IsNullOrEmpty(shopLabel)) continue;
 
                         // WinForms ItemShopForm filter: skip empty shops.

--- a/FEBuilderGBA.Core/ItemShopCore.cs
+++ b/FEBuilderGBA.Core/ItemShopCore.cs
@@ -45,10 +45,12 @@ namespace FEBuilderGBA
         /// <see cref="RelocateShopList"/>).</returns>
         public static List<AddrResult> MakeShopList(ROM rom)
         {
-            return MakeShopList(rom, static shopLabel => R._(shopLabel));
+            return MakeShopListWithTranslator(
+                rom,
+                static shopLabel => R._(shopLabel));
         }
 
-        internal static List<AddrResult> MakeShopList(
+        internal static List<AddrResult> MakeShopListWithTranslator(
             ROM rom,
             Func<string, string> translateShopLabel)
         {

--- a/FEBuilderGBA.Core/ItemShopCore.cs
+++ b/FEBuilderGBA.Core/ItemShopCore.cs
@@ -409,7 +409,7 @@ namespace FEBuilderGBA
         /// <param name="newQuantity">Quantity to append.</param>
         /// <param name="pointerAddr">Address of the 4-byte pointer slot that
         ///   references the shop (i.e. the <c>tag</c> field of the
-        ///   <see cref="AddrResult"/> returned by <see cref="MakeShopList"/>).
+        ///   <see cref="AddrResult"/> returned by <see cref="MakeShopList(ROM)"/>).
         ///   This is the slot that gets rewritten to point at the new location.</param>
         public static uint RelocateShopList(ROM rom, uint oldShopAddr, byte newItemId,
             byte newQuantity, uint pointerAddr)

--- a/FEBuilderGBA.Core/ItemShopCore.cs
+++ b/FEBuilderGBA.Core/ItemShopCore.cs
@@ -165,7 +165,8 @@ namespace FEBuilderGBA
         {
             if (string.IsNullOrEmpty(text)) return text;
             text = text.Replace("@001F", "");
-            return ToolTranslateROMCore.ConvertEscapeText(text);
+            text = ToolTranslateROMCore.ConvertEscapeText(text);
+            return U.ToOneLineCaption(text);
         }
 
         static void AddWorldMapShopIfValid(ROM rom, uint pointerSlotAddr, uint shopPtr,

--- a/FEBuilderGBA.Core/ItemShopCore.cs
+++ b/FEBuilderGBA.Core/ItemShopCore.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace FEBuilderGBA
@@ -44,6 +45,14 @@ namespace FEBuilderGBA
         /// <see cref="RelocateShopList"/>).</returns>
         public static List<AddrResult> MakeShopList(ROM rom)
         {
+            return MakeShopList(rom, static shopLabel => R._(shopLabel));
+        }
+
+        internal static List<AddrResult> MakeShopList(
+            ROM rom,
+            Func<string, string> translateShopLabel)
+        {
+            ArgumentNullException.ThrowIfNull(translateShopLabel);
             var result = new List<AddrResult>();
             if (rom == null || rom.RomInfo == null)
                 return result;
@@ -64,16 +73,19 @@ namespace FEBuilderGBA
             // --- 2. FE8 worldmap shops ---
             if (rom.RomInfo.version >= 8)
             {
-                AppendWorldMapShops(rom, result);
+                AppendWorldMapShops(rom, result, translateShopLabel);
             }
 
             // --- 3. Per-map event-cond shops ---
-            AppendEventCondShops(rom, result);
+            AppendEventCondShops(rom, result, translateShopLabel);
 
             return result;
         }
 
-        static void AppendWorldMapShops(ROM rom, List<AddrResult> result)
+        static void AppendWorldMapShops(
+            ROM rom,
+            List<AddrResult> result,
+            Func<string, string> translateShopLabel)
         {
             uint wmPtrLoc = rom.RomInfo.worldmap_point_pointer;
             if (wmPtrLoc == 0) return;
@@ -113,18 +125,23 @@ namespace FEBuilderGBA
                 // ItemShopForm then additionally skips shops whose first item byte
                 // is 0x00 (the `rom.u8(shopAddr) == 0` check below).
                 AddWorldMapShopIfValid(rom, pointAddr + 12, armoryPtr,
-                    GetLocalizedShopLabel(rom, 0x16), pointName, result);
+                    GetLocalizedShopLabel(rom, 0x16, translateShopLabel), pointName, result);
                 AddWorldMapShopIfValid(rom, pointAddr + 16, vendorPtr,
-                    GetLocalizedShopLabel(rom, 0x17), pointName, result);
+                    GetLocalizedShopLabel(rom, 0x17, translateShopLabel), pointName, result);
                 AddWorldMapShopIfValid(rom, pointAddr + 20, secretPtr,
-                    GetLocalizedShopLabel(rom, 0x18), pointName, result);
+                    GetLocalizedShopLabel(rom, 0x18, translateShopLabel), pointName, result);
             }
         }
 
-        static string GetLocalizedShopLabel(ROM rom, uint shopObject)
+        static string GetLocalizedShopLabel(
+            ROM rom,
+            uint shopObject,
+            Func<string, string> translateShopLabel)
         {
             string shopLabel = rom.RomInfo.get_shop_name(shopObject);
-            return string.IsNullOrEmpty(shopLabel) ? shopLabel : R._(shopLabel);
+            return string.IsNullOrEmpty(shopLabel)
+                ? shopLabel
+                : translateShopLabel(shopLabel);
         }
 
         /// <summary>
@@ -166,7 +183,10 @@ namespace FEBuilderGBA
             result.Add(new AddrResult(shopAddr, name, pointerSlotAddr));
         }
 
-        static void AppendEventCondShops(ROM rom, List<AddrResult> result)
+        static void AppendEventCondShops(
+            ROM rom,
+            List<AddrResult> result,
+            Func<string, string> translateShopLabel)
         {
             // Iterate every map; for each, resolve the event-cond block and scan
             // only the OBJECT condition slots. Use ROM-pinned overloads so this
@@ -209,7 +229,8 @@ namespace FEBuilderGBA
 
                         // Look up the shop's display label by object type at +10.
                         uint objType = rom.u8(recAddr + 10);
-                        string shopLabel = GetLocalizedShopLabel(rom, objType);
+                        string shopLabel =
+                            GetLocalizedShopLabel(rom, objType, translateShopLabel);
                         if (string.IsNullOrEmpty(shopLabel)) continue;
 
                         // WinForms ItemShopForm filter: skip empty shops.

--- a/FEBuilderGBA.Core/ItemShopCore.cs
+++ b/FEBuilderGBA.Core/ItemShopCore.cs
@@ -154,10 +154,18 @@ namespace FEBuilderGBA
             try
             {
                 string text = textId != 0 ? FETextDecode.Direct(textId) : "";
+                text = NormalizeDecodedWorldMapPointName(text);
                 if (!string.IsNullOrEmpty(text)) return text;
             }
             catch { /* fall through to fallback */ }
             return "Point " + U.ToHexString(index);
+        }
+
+        internal static string NormalizeDecodedWorldMapPointName(string text)
+        {
+            if (string.IsNullOrEmpty(text)) return text;
+            text = text.Replace("@001F", "");
+            return ToolTranslateROMCore.ConvertEscapeText(text);
         }
 
         static void AddWorldMapShopIfValid(ROM rom, uint pointerSlotAddr, uint shopPtr,

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -12849,6 +12849,9 @@ OBJタイルシートからビットマップを作成できませんでした�
 :Import succeeded ({0} bytes) but UI refresh failed: {1}. Re-select the Map Style entry to refresh the view.
 インポートは成功しました（{0}バイト）が、UIの更新に失敗しました: {1}。マップスタイルの項目を選び直して表示を更新してください。
 
+:Failed to refresh shop labels: {0}
+ショップラベルの更新に失敗しました: {0}
+
 :Imported {0} bytes of map chip config.
 マップチップ設定を{0}バイトインポートしました。
 

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -26680,6 +26680,9 @@ AI脚本已写入。
 :Import succeeded ({0} bytes) but UI refresh failed: {1}. Re-select the Map Style entry to refresh the view.
 导入成功（{0} 字节），但界面刷新失败：{1}。请重新选择该地图样式项以刷新视图。
 
+:Failed to refresh shop labels: {0}
+刷新商店标签失败：{0}
+
 :Imported {0} bytes of map chip config.
 已导入 {0} 字节的地图图块配置。
 


### PR DESCRIPTION
## Summary

- localize ROM-provided shop type keys for world-map and event-condition shops
- sanitize decoded world-map captions so control characters cannot render as tofu
- refresh localized shop rows on language changes and reattach without discarding pending slot edits
- keep the injected test translator isolated from production and localize recoverable refresh errors

Accepted plan: https://github.com/laqieer/FEBuilderGBA/issues/2080#issuecomment-5281122105

Closes #2080

## Test plan

- [x] targeted ItemShopCoreTests (26 passed)
- [x] targeted ItemShopViewerView_LayoutTests (7 passed)
- [x] Avalonia localization contract tests (9 passed)
- [x] full Core tests (7,538 passed, 19 platform/fixture skips)
- [x] full Avalonia tests (9,821 passed, 10 real-ROM skips)
- [x] local Android Release build with warnings as errors (0 warnings, 0 errors)
- [x] hosted FE8U E2E run 31775196093 passed on visual-behavior head f1b485c5370f275e594150ff847f847acb4a758f
- [x] final 2b94b5571 current-head PR CI passed; later commits only harden/localize the exceptional refresh path

## GUI Test Report

The hosted FE8U Avalonia Item Shop Editor shows English Armory, Vendor, and Secret Shop labels. Rows including Ide WorldMap Armory and Serafew WorldMap Vendor contain no tofu boxes. The screenshot is from f1b485c53; subsequent commits affect only refresh lifecycle/error behavior and translations.

![FE8U Item Shop Editor with localized, sanitized shop labels](https://github.com/user-attachments/assets/1666f400-1348-46e0-b36a-8087dee14c5f)

Copilot CLI: 1.0.79
Model: GPT-5.6 Sol (gpt-5.6-sol)
