### PR TITLE
fix(avalonia): stabilize counter reinforcement tooltip

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/EventCondParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/EventCondParityTests.cs
@@ -1552,6 +1552,24 @@ public class EventCondParityTests
         Assert.Contains(automationId, content);
     }
 
+    [Fact]
+    public void View_AllocCounterTooltip_UsesRightPlacement()
+    {
+        string repoRoot = FindRepoRoot();
+        string axamlPath = Path.Combine(repoRoot, "FEBuilderGBA.Avalonia", "Views",
+            "EventCondView.axaml");
+        XDocument doc = XDocument.Load(axamlPath);
+        XElement button = doc.Descendants()
+            .Single(e => e.Name.LocalName == "Button"
+                && e.Attributes().Any(a => a.Name.LocalName == "Name"
+                    && a.Value == "AllocCounterBtn"));
+
+        XAttribute? placement = button.Attributes()
+            .SingleOrDefault(a => a.Name.LocalName == "ToolTip.Placement");
+        Assert.NotNull(placement);
+        Assert.Equal("Right", placement!.Value);
+    }
+
     [Theory]
     [InlineData("AllocCallEndEvent_Click")]
     [InlineData("AllocCall1_Click")]

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/EventCondParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/EventCondParityTests.cs
@@ -16,6 +16,10 @@ using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
+using global::Avalonia;
+using global::Avalonia.Controls;
+using global::Avalonia.Headless.XUnit;
+using global::Avalonia.LogicalTree;
 using FEBuilderGBA.Avalonia.GapSweep;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
@@ -1568,6 +1572,35 @@ public class EventCondParityTests
             .SingleOrDefault(a => a.Name.LocalName == "ToolTip.Placement");
         Assert.NotNull(placement);
         Assert.Equal("Right", placement!.Value);
+    }
+
+    [AvaloniaFact]
+    public void View_AllocCounterTooltip_FocusedLayoutIsVisible()
+    {
+        var view = new EventCondView();
+        Border? panel = view.FindControl<Border>("AllocTemplatePanel");
+        Button? button = view.FindControl<Button>("AllocCounterBtn");
+        Assert.NotNull(panel);
+        Assert.NotNull(button);
+
+        panel!.IsVisible = true;
+        button!.IsVisible = true;
+        Assert.Equal(PlacementMode.Right, ToolTip.GetPlacement(button));
+
+        const int width = 1100;
+        const int height = 820;
+        view.Measure(new Size(width, height));
+        view.Arrange(new Rect(0, 0, width, height));
+
+        ScrollViewer? scroll = view.GetLogicalDescendants()
+            .OfType<ScrollViewer>()
+            .FirstOrDefault();
+        Assert.NotNull(scroll);
+        scroll!.Offset = new Vector(
+            0,
+            Math.Max(0, scroll.Extent.Height - scroll.Viewport.Height));
+        Assert.True(panel.IsVisible);
+        Assert.True(button.IsVisible);
     }
 
     [Theory]

--- a/FEBuilderGBA.Avalonia/Views/EventCondView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EventCondView.axaml
@@ -353,7 +353,7 @@
               <Button AutomationProperties.AutomationId="EventCond_AllocCallEndEvent_Button" Content="CALL EndEvent" Name="AllocCallEndEventBtn" Click="AllocCallEndEvent_Click" ToolTip.Tip="Call the chapter end-event and set the victory flag (W2=3)" />
               <Button AutomationProperties.AutomationId="EventCond_AllocCall1_Button" Content="CALL 1" Name="AllocCall1Btn" Click="AllocCall1_Click" ToolTip.Tip="Write the literal event-pointer value 1" />
             </StackPanel>
-            <Button AutomationProperties.AutomationId="EventCond_AllocCounter_Button" Content="Counter Reinforcement" Name="AllocCounterBtn" Click="AllocCounter_Click" IsVisible="False" ToolTip.Tip="Allocate a counter-reinforcement event and set this TURN to 1-255 (B8=1, B9=255)" />
+            <Button AutomationProperties.AutomationId="EventCond_AllocCounter_Button" Content="Counter Reinforcement" Name="AllocCounterBtn" Click="AllocCounter_Click" IsVisible="False" ToolTip.Placement="Right" ToolTip.Tip="Allocate a counter-reinforcement event and set this TURN to 1-255 (B8=1, B9=255)" />
           </StackPanel>
         </Border>
 


### PR DESCRIPTION
## Summary

- place the Counter Reinforcement tooltip to the right of its bottom-edge button
- add AXAML and focused real-view coverage for the conditional button/panel
- avoid shared tooltip style or dependency changes

Accepted plan: https://github.com/laqieer/FEBuilderGBA/issues/2086#issuecomment-5292246650

Closes #2086

## Test plan

- [x] focused tooltip tests (2 passed)
- [x] full Avalonia tests (9,823 passed, 10 real-ROM skips)
- [x] hosted FE8U E2E run 31793036866 passed on production commit 0a2f50370; current 20fbc18f9 only adds test coverage

## GUI Test Report

The hosted FE8U Event Condition editor renders without overlap or clipping in its default state. The Counter Reinforcement panel is conditional and is not visible in this default screenshot; View_AllocCounterTooltip_FocusedLayoutIsVisible instantiates the real view, exposes that panel/button, and asserts PlacementMode.Right.

![FE8U Event Condition Editor](https://github.com/user-attachments/assets/38e4946b-69dc-433f-9209-5cbb5ce5bf22)

Copilot CLI: 1.0.79
Model: GPT-5.6 Sol (gpt-5.6-sol)
