### PR TITLE
fix(avalonia): prevent numeric layout overlap

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleAnimePalletParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleAnimePalletParityTests.cs
@@ -113,6 +113,7 @@ public class ImageBattleAnimePalletParityTests
         Assert.All(columns,
             column => Assert.Equal("124", column.Attribute("Width")?.Value));
         Assert.Contains("HorizontalScrollBarVisibility=\"Visible\"", ReadAxaml());
+        Assert.Contains("AllowAutoHide=\"False\"", ReadAxaml());
     }
 
     [Fact]

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleAnimePalletParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleAnimePalletParityTests.cs
@@ -98,6 +98,24 @@ public class ImageBattleAnimePalletParityTests
     }
 
     [Fact]
+    public void View_PaletteColumns_AccommodateGlobalNumericMinWidth()
+    {
+        XDocument doc = XDocument.Load(AxamlPath());
+        XElement grid = doc.Descendants()
+            .Single(e => e.Name.LocalName == "Grid"
+                && e.Attributes().Any(a => a.Name.LocalName == "Name"
+                    && a.Value == "PaletteGrid"));
+        XElement[] columns = grid.Descendants()
+            .Where(e => e.Name.LocalName == "ColumnDefinition")
+            .ToArray();
+
+        Assert.Equal(16, columns.Length);
+        Assert.All(columns,
+            column => Assert.Equal("124", column.Attribute("Width")?.Value));
+        Assert.Contains("HorizontalScrollBarVisibility=\"Auto\"", ReadAxaml());
+    }
+
+    [Fact]
     public void View_HasActionBar()
     {
         string axaml = ReadAxaml();

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleAnimePalletParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleAnimePalletParityTests.cs
@@ -112,7 +112,7 @@ public class ImageBattleAnimePalletParityTests
         Assert.Equal(16, columns.Length);
         Assert.All(columns,
             column => Assert.Equal("124", column.Attribute("Width")?.Value));
-        Assert.Contains("HorizontalScrollBarVisibility=\"Auto\"", ReadAxaml());
+        Assert.Contains("HorizontalScrollBarVisibility=\"Visible\"", ReadAxaml());
     }
 
     [Fact]

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/MonsterItemParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/MonsterItemParityTests.cs
@@ -229,7 +229,7 @@ public class MonsterItemParityTests
             axaml,
             "ColumnDefinitions=\"80,300,140,300\"").Count);
         Assert.Contains(
-            "<ScrollViewer Grid.Column=\"1\" Margin=\"4\" HorizontalScrollBarVisibility=\"Auto\">",
+            "<ScrollViewer Grid.Column=\"1\" Margin=\"4\" HorizontalScrollBarVisibility=\"Visible\">",
             axaml);
     }
 

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/MonsterItemParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/MonsterItemParityTests.cs
@@ -227,7 +227,7 @@ public class MonsterItemParityTests
 
         Assert.Equal(2, Regex.Matches(
             axaml,
-            "ColumnDefinitions=\"80,300,140,300\"").Count);
+            "ColumnDefinitions=\"80,420,140,420\"").Count);
         Assert.Contains(
             "<ScrollViewer Grid.Column=\"1\" Margin=\"4\" Name=\"HoldingDetailScroll\" HorizontalScrollBarVisibility=\"Visible\" AllowAutoHide=\"False\">",
             axaml);

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/MonsterItemParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/MonsterItemParityTests.cs
@@ -229,7 +229,7 @@ public class MonsterItemParityTests
             axaml,
             "ColumnDefinitions=\"80,300,140,300\"").Count);
         Assert.Contains(
-            "<ScrollViewer Grid.Column=\"1\" Margin=\"4\" HorizontalScrollBarVisibility=\"Visible\">",
+            "<ScrollViewer Grid.Column=\"1\" Margin=\"4\" Name=\"HoldingDetailScroll\" HorizontalScrollBarVisibility=\"Visible\" AllowAutoHide=\"False\">",
             axaml);
     }
 

--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/MonsterItemParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/MonsterItemParityTests.cs
@@ -220,6 +220,19 @@ public class MonsterItemParityTests
             axaml);
     }
 
+    [Fact]
+    public void View_HoldingsGrids_ReserveNonOverlappingControlWidths()
+    {
+        string axaml = ReadAxaml();
+
+        Assert.Equal(2, Regex.Matches(
+            axaml,
+            "ColumnDefinitions=\"80,300,140,300\"").Count);
+        Assert.Contains(
+            "<ScrollViewer Grid.Column=\"1\" Margin=\"4\" HorizontalScrollBarVisibility=\"Auto\">",
+            axaml);
+    }
+
     /// <summary>
     /// B31 is the trailing unknown byte in the 32-byte holdings record.
     /// WF labels it with the literal "00" (per designer.cs label56). The

--- a/FEBuilderGBA.Avalonia.Tests/ItemStatBonusesPatchedParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ItemStatBonusesPatchedParityTests.cs
@@ -13,6 +13,9 @@
 // reads the booster block, and persists writes (Venno preserving its
 // non-editable +0x0F padding byte). The parity helper now maps both editors
 // and no longer classifies them as context-dependent.
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
 using Xunit;
@@ -31,6 +34,19 @@ public class ItemStatBonusesPatchedParityTests : System.IDisposable
     // per test). Without this, later SharedState-collection parity tests see
     // our throwaway synthetic ROM and fail.
     readonly ROM? _prevRom = CoreState.ROM;
+
+    static string SkillSystemsAxamlPath()
+    {
+        string? dir = System.AppContext.BaseDirectory;
+        while (dir != null &&
+               !File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+        Assert.NotNull(dir);
+        return Path.Combine(dir!, "FEBuilderGBA.Avalonia", "Views",
+            "ItemStatBonusesSkillSystemsView.axaml");
+    }
 
     public void Dispose()
     {
@@ -129,6 +145,34 @@ public class ItemStatBonusesPatchedParityTests : System.IDisposable
 
         Assert.Equal(7u, rom.u8(BlockAddr + 0));
         Assert.Equal(-9, (sbyte)rom.u8(BlockAddr + 4));
+    }
+
+    [Fact]
+    public void SkillSystems_View_ReflowsTenStatsIntoTwoRows()
+    {
+        XDocument doc = XDocument.Load(SkillSystemsAxamlPath());
+        XElement grid = doc.Descendants()
+            .Single(e => e.Name.LocalName == "Grid"
+                && e.Attributes().Any(a => a.Name.LocalName == "Name"
+                    && a.Value == "StatBonusGrid"));
+
+        Assert.Equal("128,128,128,128,128",
+            grid.Attribute("ColumnDefinitions")?.Value);
+        Assert.Equal("Auto,Auto,Auto,Auto",
+            grid.Attribute("RowDefinitions")?.Value);
+
+        XElement[] inputs = grid.Descendants()
+            .Where(e => e.Name.LocalName == "NumericUpDown")
+            .ToArray();
+        Assert.Equal(10, inputs.Length);
+        Assert.All(inputs,
+            input => Assert.Equal("120", input.Attribute("Width")?.Value));
+
+        XElement magic = inputs.Single(input =>
+            input.Attributes().Any(a => a.Name.LocalName == "Name"
+                && a.Value == "MagicOrUnknownBox"));
+        Assert.Equal("3", magic.Attribute("Grid.Row")?.Value);
+        Assert.Equal("4", magic.Attribute("Grid.Column")?.Value);
     }
 
     // ------------------------------------------------------------------

--- a/FEBuilderGBA.Avalonia.Tests/ItemStatBonusesPatchedParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ItemStatBonusesPatchedParityTests.cs
@@ -173,6 +173,28 @@ public class ItemStatBonusesPatchedParityTests : System.IDisposable
                 && a.Value == "MagicOrUnknownBox"));
         Assert.Equal("3", magic.Attribute("Grid.Row")?.Value);
         Assert.Equal("4", magic.Attribute("Grid.Column")?.Value);
+
+        XElement growthGrid = doc.Descendants()
+            .Single(e => e.Name.LocalName == "Grid"
+                && e.Attributes().Any(a => a.Name.LocalName == "Name"
+                    && a.Value == "GrowthBonusGrid"));
+        Assert.Equal("128,128,128,128",
+            growthGrid.Attribute("ColumnDefinitions")?.Value);
+        Assert.Equal("Auto,Auto,Auto,Auto",
+            growthGrid.Attribute("RowDefinitions")?.Value);
+
+        XElement[] growthInputs = growthGrid.Descendants()
+            .Where(e => e.Name.LocalName == "NumericUpDown")
+            .ToArray();
+        Assert.Equal(8, growthInputs.Length);
+        Assert.All(growthInputs,
+            input => Assert.Equal("120", input.Attribute("Width")?.Value));
+
+        XElement unknown = growthInputs.Single(input =>
+            input.Attributes().Any(a => a.Name.LocalName == "Name"
+                && a.Value == "GrowUnknownBox"));
+        Assert.Equal("3", unknown.Attribute("Grid.Row")?.Value);
+        Assert.Equal("3", unknown.Attribute("Grid.Column")?.Value);
     }
 
     // ------------------------------------------------------------------

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml
@@ -84,22 +84,22 @@
                       VerticalScrollBarVisibility="Disabled">
         <Grid Name="PaletteGrid" RowDefinitions="36,32,32,32">
           <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="62" />
-            <ColumnDefinition Width="62" />
-            <ColumnDefinition Width="62" />
-            <ColumnDefinition Width="62" />
-            <ColumnDefinition Width="62" />
-            <ColumnDefinition Width="62" />
-            <ColumnDefinition Width="62" />
-            <ColumnDefinition Width="62" />
-            <ColumnDefinition Width="62" />
-            <ColumnDefinition Width="62" />
-            <ColumnDefinition Width="62" />
-            <ColumnDefinition Width="62" />
-            <ColumnDefinition Width="62" />
-            <ColumnDefinition Width="62" />
-            <ColumnDefinition Width="62" />
-            <ColumnDefinition Width="62" />
+            <ColumnDefinition Width="124" />
+            <ColumnDefinition Width="124" />
+            <ColumnDefinition Width="124" />
+            <ColumnDefinition Width="124" />
+            <ColumnDefinition Width="124" />
+            <ColumnDefinition Width="124" />
+            <ColumnDefinition Width="124" />
+            <ColumnDefinition Width="124" />
+            <ColumnDefinition Width="124" />
+            <ColumnDefinition Width="124" />
+            <ColumnDefinition Width="124" />
+            <ColumnDefinition Width="124" />
+            <ColumnDefinition Width="124" />
+            <ColumnDefinition Width="124" />
+            <ColumnDefinition Width="124" />
+            <ColumnDefinition Width="124" />
           </Grid.ColumnDefinitions>
 
           <!-- Column 1 (PALETTE_P_1 swatch + label7 '1' + PALETTE_R_1/G_1/B_1) -->

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml
@@ -80,7 +80,7 @@
              still carries its WF-parity AutomationId so Roslyn-static tests
              can detect them.
              =========================================================== -->
-        <ScrollViewer Grid.Column="1" HorizontalScrollBarVisibility="Auto"
+        <ScrollViewer Grid.Column="1" HorizontalScrollBarVisibility="Visible"
                       VerticalScrollBarVisibility="Disabled">
         <Grid Name="PaletteGrid" RowDefinitions="36,32,32,32">
           <Grid.ColumnDefinitions>

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml
@@ -81,6 +81,7 @@
              can detect them.
              =========================================================== -->
         <ScrollViewer Grid.Column="1" HorizontalScrollBarVisibility="Visible"
+                      AllowAutoHide="False"
                       VerticalScrollBarVisibility="Disabled">
         <Grid Name="PaletteGrid" RowDefinitions="36,32,32,32">
           <Grid.ColumnDefinitions>

--- a/FEBuilderGBA.Avalonia/Views/ItemStatBonusesSkillSystemsView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ItemStatBonusesSkillSystemsView.axaml
@@ -5,7 +5,7 @@
   <Grid ColumnDefinitions="250,*">
     <controls:AddressListControl AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_Entry_List" Grid.Column="0" Name="EntryList" Margin="4" />
 
-    <ScrollViewer Grid.Column="1" Margin="4">
+    <ScrollViewer Grid.Column="1" Margin="4" HorizontalScrollBarVisibility="Auto">
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="Stat Bonuses (Skill Systems)" FontSize="18" FontWeight="Bold" />
 
@@ -16,28 +16,30 @@
 
         <!-- Stat Bonuses Row -->
         <TextBlock Text="Stat Bonuses" FontWeight="Bold" Margin="0,8,0,0" />
-        <Grid ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" RowDefinitions="Auto,Auto">
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="HP" Width="70" Margin="2" HorizontalAlignment="Center" />
-          <TextBlock Grid.Row="0" Grid.Column="1" Text="Str/Mag" Width="70" Margin="2" HorizontalAlignment="Center" />
-          <TextBlock Grid.Row="0" Grid.Column="2" Text="Skill" Width="70" Margin="2" HorizontalAlignment="Center" />
-          <TextBlock Grid.Row="0" Grid.Column="3" Text="Speed" Width="70" Margin="2" HorizontalAlignment="Center" />
-          <TextBlock Grid.Row="0" Grid.Column="4" Text="Defense" Width="70" Margin="2" HorizontalAlignment="Center" />
-          <TextBlock Grid.Row="0" Grid.Column="5" Text="Resistance" Width="70" Margin="2" HorizontalAlignment="Center" />
-          <TextBlock Grid.Row="0" Grid.Column="6" Text="Luck" Width="70" Margin="2" HorizontalAlignment="Center" />
-          <TextBlock Grid.Row="0" Grid.Column="7" Text="Move" Width="70" Margin="2" HorizontalAlignment="Center" />
-          <TextBlock Grid.Row="0" Grid.Column="8" Text="Con" Width="70" Margin="2" HorizontalAlignment="Center" />
-          <TextBlock Grid.Row="0" Grid.Column="9" Text="Magic/??" Width="70" Margin="2" HorizontalAlignment="Center" />
+        <Grid Name="StatBonusGrid" ColumnDefinitions="128,128,128,128,128" RowDefinitions="Auto,Auto,Auto,Auto">
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="HP" Width="120" Margin="2" HorizontalAlignment="Center" />
+          <TextBlock Grid.Row="0" Grid.Column="1" Text="Str/Mag" Width="120" Margin="2" HorizontalAlignment="Center" />
+          <TextBlock Grid.Row="0" Grid.Column="2" Text="Skill" Width="120" Margin="2" HorizontalAlignment="Center" />
+          <TextBlock Grid.Row="0" Grid.Column="3" Text="Speed" Width="120" Margin="2" HorizontalAlignment="Center" />
+          <TextBlock Grid.Row="0" Grid.Column="4" Text="Defense" Width="120" Margin="2" HorizontalAlignment="Center" />
 
-          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_HP_Input" FormatString="0" Grid.Row="1" Grid.Column="0" Name="HPBox" Minimum="-128" Maximum="127" Width="70" Margin="2" />
-          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_Str_Input" FormatString="0" Grid.Row="1" Grid.Column="1" Name="StrBox" Minimum="-128" Maximum="127" Width="70" Margin="2" />
-          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_Skill_Input" FormatString="0" Grid.Row="1" Grid.Column="2" Name="SkillBox" Minimum="-128" Maximum="127" Width="70" Margin="2" />
-          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_Speed_Input" FormatString="0" Grid.Row="1" Grid.Column="3" Name="SpeedBox" Minimum="-128" Maximum="127" Width="70" Margin="2" />
-          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_Def_Input" FormatString="0" Grid.Row="1" Grid.Column="4" Name="DefBox" Minimum="-128" Maximum="127" Width="70" Margin="2" />
-          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_Res_Input" FormatString="0" Grid.Row="1" Grid.Column="5" Name="ResBox" Minimum="-128" Maximum="127" Width="70" Margin="2" />
-          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_Luck_Input" FormatString="0" Grid.Row="1" Grid.Column="6" Name="LuckBox" Minimum="-128" Maximum="127" Width="70" Margin="2" />
-          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_Move_Input" FormatString="0" Grid.Row="1" Grid.Column="7" Name="MoveBox" Minimum="-128" Maximum="127" Width="70" Margin="2" />
-          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_Con_Input" FormatString="0" Grid.Row="1" Grid.Column="8" Name="ConBox" Minimum="-128" Maximum="127" Width="70" Margin="2" />
-          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_MagicOrUnknown_Input" FormatString="0" Grid.Row="1" Grid.Column="9" Name="MagicOrUnknownBox" Minimum="-128" Maximum="127" Width="70" Margin="2" />
+          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_HP_Input" FormatString="0" Grid.Row="1" Grid.Column="0" Name="HPBox" Minimum="-128" Maximum="127" Width="120" Margin="2" />
+          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_Str_Input" FormatString="0" Grid.Row="1" Grid.Column="1" Name="StrBox" Minimum="-128" Maximum="127" Width="120" Margin="2" />
+          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_Skill_Input" FormatString="0" Grid.Row="1" Grid.Column="2" Name="SkillBox" Minimum="-128" Maximum="127" Width="120" Margin="2" />
+          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_Speed_Input" FormatString="0" Grid.Row="1" Grid.Column="3" Name="SpeedBox" Minimum="-128" Maximum="127" Width="120" Margin="2" />
+          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_Def_Input" FormatString="0" Grid.Row="1" Grid.Column="4" Name="DefBox" Minimum="-128" Maximum="127" Width="120" Margin="2" />
+
+          <TextBlock Grid.Row="2" Grid.Column="0" Text="Resistance" Width="120" Margin="2" HorizontalAlignment="Center" />
+          <TextBlock Grid.Row="2" Grid.Column="1" Text="Luck" Width="120" Margin="2" HorizontalAlignment="Center" />
+          <TextBlock Grid.Row="2" Grid.Column="2" Text="Move" Width="120" Margin="2" HorizontalAlignment="Center" />
+          <TextBlock Grid.Row="2" Grid.Column="3" Text="Con" Width="120" Margin="2" HorizontalAlignment="Center" />
+          <TextBlock Grid.Row="2" Grid.Column="4" Text="Magic/??" Width="120" Margin="2" HorizontalAlignment="Center" />
+
+          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_Res_Input" FormatString="0" Grid.Row="3" Grid.Column="0" Name="ResBox" Minimum="-128" Maximum="127" Width="120" Margin="2" />
+          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_Luck_Input" FormatString="0" Grid.Row="3" Grid.Column="1" Name="LuckBox" Minimum="-128" Maximum="127" Width="120" Margin="2" />
+          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_Move_Input" FormatString="0" Grid.Row="3" Grid.Column="2" Name="MoveBox" Minimum="-128" Maximum="127" Width="120" Margin="2" />
+          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_Con_Input" FormatString="0" Grid.Row="3" Grid.Column="3" Name="ConBox" Minimum="-128" Maximum="127" Width="120" Margin="2" />
+          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_MagicOrUnknown_Input" FormatString="0" Grid.Row="3" Grid.Column="4" Name="MagicOrUnknownBox" Minimum="-128" Maximum="127" Width="120" Margin="2" />
         </Grid>
 
         <!-- Growth Rate Bonuses Row -->

--- a/FEBuilderGBA.Avalonia/Views/ItemStatBonusesSkillSystemsView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ItemStatBonusesSkillSystemsView.axaml
@@ -44,24 +44,26 @@
 
         <!-- Growth Rate Bonuses Row -->
         <TextBlock Text="Growth Rate Bonuses" FontWeight="Bold" Margin="0,8,0,0" />
-        <Grid ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" RowDefinitions="Auto,Auto">
-          <TextBlock Grid.Row="0" Grid.Column="0" Text="HP" Width="70" Margin="2" HorizontalAlignment="Center" />
-          <TextBlock Grid.Row="0" Grid.Column="1" Text="Str/Mag" Width="70" Margin="2" HorizontalAlignment="Center" />
-          <TextBlock Grid.Row="0" Grid.Column="2" Text="Skill" Width="70" Margin="2" HorizontalAlignment="Center" />
-          <TextBlock Grid.Row="0" Grid.Column="3" Text="Speed" Width="70" Margin="2" HorizontalAlignment="Center" />
-          <TextBlock Grid.Row="0" Grid.Column="4" Text="Defense" Width="70" Margin="2" HorizontalAlignment="Center" />
-          <TextBlock Grid.Row="0" Grid.Column="5" Text="Resistance" Width="70" Margin="2" HorizontalAlignment="Center" />
-          <TextBlock Grid.Row="0" Grid.Column="6" Text="Luck" Width="70" Margin="2" HorizontalAlignment="Center" />
-          <TextBlock Grid.Row="0" Grid.Column="7" Text="??" Width="70" Margin="2" HorizontalAlignment="Center" />
+        <Grid Name="GrowthBonusGrid" ColumnDefinitions="128,128,128,128" RowDefinitions="Auto,Auto,Auto,Auto">
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="HP" Width="120" Margin="2" HorizontalAlignment="Center" />
+          <TextBlock Grid.Row="0" Grid.Column="1" Text="Str/Mag" Width="120" Margin="2" HorizontalAlignment="Center" />
+          <TextBlock Grid.Row="0" Grid.Column="2" Text="Skill" Width="120" Margin="2" HorizontalAlignment="Center" />
+          <TextBlock Grid.Row="0" Grid.Column="3" Text="Speed" Width="120" Margin="2" HorizontalAlignment="Center" />
 
-          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_GrowHP_Input" FormatString="0" Grid.Row="1" Grid.Column="0" Name="GrowHPBox" Minimum="-128" Maximum="127" Width="70" Margin="2" />
-          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_GrowStr_Input" FormatString="0" Grid.Row="1" Grid.Column="1" Name="GrowStrBox" Minimum="-128" Maximum="127" Width="70" Margin="2" />
-          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_GrowSkill_Input" FormatString="0" Grid.Row="1" Grid.Column="2" Name="GrowSkillBox" Minimum="-128" Maximum="127" Width="70" Margin="2" />
-          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_GrowSpeed_Input" FormatString="0" Grid.Row="1" Grid.Column="3" Name="GrowSpeedBox" Minimum="-128" Maximum="127" Width="70" Margin="2" />
-          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_GrowDef_Input" FormatString="0" Grid.Row="1" Grid.Column="4" Name="GrowDefBox" Minimum="-128" Maximum="127" Width="70" Margin="2" />
-          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_GrowRes_Input" FormatString="0" Grid.Row="1" Grid.Column="5" Name="GrowResBox" Minimum="-128" Maximum="127" Width="70" Margin="2" />
-          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_GrowLuck_Input" FormatString="0" Grid.Row="1" Grid.Column="6" Name="GrowLuckBox" Minimum="-128" Maximum="127" Width="70" Margin="2" />
-          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_GrowUnknown_Input" FormatString="0" Grid.Row="1" Grid.Column="7" Name="GrowUnknownBox" Minimum="-128" Maximum="127" Width="70" Margin="2" />
+          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_GrowHP_Input" FormatString="0" Grid.Row="1" Grid.Column="0" Name="GrowHPBox" Minimum="-128" Maximum="127" Width="120" Margin="2" />
+          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_GrowStr_Input" FormatString="0" Grid.Row="1" Grid.Column="1" Name="GrowStrBox" Minimum="-128" Maximum="127" Width="120" Margin="2" />
+          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_GrowSkill_Input" FormatString="0" Grid.Row="1" Grid.Column="2" Name="GrowSkillBox" Minimum="-128" Maximum="127" Width="120" Margin="2" />
+          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_GrowSpeed_Input" FormatString="0" Grid.Row="1" Grid.Column="3" Name="GrowSpeedBox" Minimum="-128" Maximum="127" Width="120" Margin="2" />
+
+          <TextBlock Grid.Row="2" Grid.Column="0" Text="Defense" Width="120" Margin="2" HorizontalAlignment="Center" />
+          <TextBlock Grid.Row="2" Grid.Column="1" Text="Resistance" Width="120" Margin="2" HorizontalAlignment="Center" />
+          <TextBlock Grid.Row="2" Grid.Column="2" Text="Luck" Width="120" Margin="2" HorizontalAlignment="Center" />
+          <TextBlock Grid.Row="2" Grid.Column="3" Text="??" Width="120" Margin="2" HorizontalAlignment="Center" />
+
+          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_GrowDef_Input" FormatString="0" Grid.Row="3" Grid.Column="0" Name="GrowDefBox" Minimum="-128" Maximum="127" Width="120" Margin="2" />
+          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_GrowRes_Input" FormatString="0" Grid.Row="3" Grid.Column="1" Name="GrowResBox" Minimum="-128" Maximum="127" Width="120" Margin="2" />
+          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_GrowLuck_Input" FormatString="0" Grid.Row="3" Grid.Column="2" Name="GrowLuckBox" Minimum="-128" Maximum="127" Width="120" Margin="2" />
+          <NumericUpDown AutomationProperties.AutomationId="ItemStatBonusesSkillSystems_GrowUnknown_Input" FormatString="0" Grid.Row="3" Grid.Column="3" Name="GrowUnknownBox" Minimum="-128" Maximum="127" Width="120" Margin="2" />
         </Grid>
 
         <!-- Padding Row -->

--- a/FEBuilderGBA.Avalonia/Views/MonsterItemViewerView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MonsterItemViewerView.axaml
@@ -250,7 +250,7 @@
         <controls:AddressListControl AutomationProperties.AutomationId="MonsterItemViewer_Holding_Entry_List"
                                      Grid.Column="0" Name="HoldingEntryList" Margin="4" />
 
-        <ScrollViewer Grid.Column="1" Margin="4">
+        <ScrollViewer Grid.Column="1" Margin="4" HorizontalScrollBarVisibility="Auto">
           <StackPanel Spacing="8" Margin="8">
             <TextBlock Text="Holdings Table" FontSize="18" FontWeight="Bold" />
 
@@ -297,7 +297,7 @@
 
             <!-- Holdings Set 1 — 5 slots (B1..B5 / B11..B15 / B21..B25). -->
             <TextBlock Text="Holdings Set 1" FontSize="14" FontWeight="Bold" Margin="0,8,0,0" />
-            <Grid ColumnDefinitions="100,100,100,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto">
+            <Grid ColumnDefinitions="80,300,140,300" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto">
               <TextBlock Grid.Row="0" Grid.Column="0" Text="Slot" FontWeight="Bold" />
               <TextBlock Grid.Row="0" Grid.Column="1" Text="Candidate" FontWeight="Bold"
                          ToolTip.Tip="1-based index into the Item Table (Tab 1) — NOT a FE item ID. Click the field to Jump to the matching row." />
@@ -368,7 +368,7 @@
 
             <!-- Holdings Set 2 — 5 slots (B6..B10 / B16..B20 / B26..B30). -->
             <TextBlock Text="Holdings Set 2" FontSize="14" FontWeight="Bold" Margin="0,8,0,0" />
-            <Grid ColumnDefinitions="100,100,100,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto">
+            <Grid ColumnDefinitions="80,300,140,300" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto">
               <TextBlock Grid.Row="0" Grid.Column="0" Text="Slot" FontWeight="Bold" />
               <TextBlock Grid.Row="0" Grid.Column="1" Text="Candidate" FontWeight="Bold"
                          ToolTip.Tip="1-based index into the Item Table (Tab 1) — NOT a FE item ID. Click the field to Jump to the matching row." />

--- a/FEBuilderGBA.Avalonia/Views/MonsterItemViewerView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MonsterItemViewerView.axaml
@@ -297,7 +297,7 @@
 
             <!-- Holdings Set 1 — 5 slots (B1..B5 / B11..B15 / B21..B25). -->
             <TextBlock Text="Holdings Set 1" FontSize="14" FontWeight="Bold" Margin="0,8,0,0" />
-            <Grid ColumnDefinitions="80,300,140,300" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto">
+            <Grid ColumnDefinitions="80,420,140,420" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto">
               <TextBlock Grid.Row="0" Grid.Column="0" Text="Slot" FontWeight="Bold" />
               <TextBlock Grid.Row="0" Grid.Column="1" Text="Candidate" FontWeight="Bold"
                          ToolTip.Tip="1-based index into the Item Table (Tab 1) — NOT a FE item ID. Click the field to Jump to the matching row." />
@@ -368,7 +368,7 @@
 
             <!-- Holdings Set 2 — 5 slots (B6..B10 / B16..B20 / B26..B30). -->
             <TextBlock Text="Holdings Set 2" FontSize="14" FontWeight="Bold" Margin="0,8,0,0" />
-            <Grid ColumnDefinitions="80,300,140,300" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto">
+            <Grid ColumnDefinitions="80,420,140,420" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto">
               <TextBlock Grid.Row="0" Grid.Column="0" Text="Slot" FontWeight="Bold" />
               <TextBlock Grid.Row="0" Grid.Column="1" Text="Candidate" FontWeight="Bold"
                          ToolTip.Tip="1-based index into the Item Table (Tab 1) — NOT a FE item ID. Click the field to Jump to the matching row." />

--- a/FEBuilderGBA.Avalonia/Views/MonsterItemViewerView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MonsterItemViewerView.axaml
@@ -250,7 +250,7 @@
         <controls:AddressListControl AutomationProperties.AutomationId="MonsterItemViewer_Holding_Entry_List"
                                      Grid.Column="0" Name="HoldingEntryList" Margin="4" />
 
-        <ScrollViewer Grid.Column="1" Margin="4" HorizontalScrollBarVisibility="Visible">
+        <ScrollViewer Grid.Column="1" Margin="4" Name="HoldingDetailScroll" HorizontalScrollBarVisibility="Visible" AllowAutoHide="False">
           <StackPanel Spacing="8" Margin="8">
             <TextBlock Text="Holdings Table" FontSize="18" FontWeight="Bold" />
 

--- a/FEBuilderGBA.Avalonia/Views/MonsterItemViewerView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/MonsterItemViewerView.axaml
@@ -250,7 +250,7 @@
         <controls:AddressListControl AutomationProperties.AutomationId="MonsterItemViewer_Holding_Entry_List"
                                      Grid.Column="0" Name="HoldingEntryList" Margin="4" />
 
-        <ScrollViewer Grid.Column="1" Margin="4" HorizontalScrollBarVisibility="Auto">
+        <ScrollViewer Grid.Column="1" Margin="4" HorizontalScrollBarVisibility="Visible">
           <StackPanel Spacing="8" Margin="8">
             <TextBlock Text="Holdings Table" FontSize="18" FontWeight="Bold" />
 


### PR DESCRIPTION
## Summary

- widen Monster Holdings columns for complete IdFieldControl groups and keep a named, non-auto-hidden horizontal fallback
- reflow Skill Systems stat and growth bonuses into two rows sized for 120-DIP spinners
- widen all 16 Battle Animation Palette columns and keep its scrollbar visible without auto-hide

Accepted plan: https://github.com/laqieer/FEBuilderGBA/issues/2087#issuecomment-5295866669

Closes #2087
Closes #2088
Closes #2089

## Test plan

- [x] focused layout tests (3 passed)
- [x] full Avalonia tests (9,843 passed, 10 real-ROM skips)
- [x] exact-head hosted FE8U E2E run 31830849163 passed on 924f3ab40
- [x] isolated macOS runner-loss rerun passed unchanged
- [x] real desktop focused Monster Holdings render completed on the exact layout

## GUI Test Report

### Monster Item Editor — Holdings (#2087)

The focused narrow desktop capture shows the selected Holdings tab with Candidate controls and spinner arrows aligned without overlap. The complete grid is intentionally wider than this 756-DIP proof viewport; HoldingDetailScroll is named, visible, and AllowAutoHide=False, with 420-DIP columns enforced by tests for the off-screen Probability and Item Probability groups.

![Monster Item Holdings layout](https://github.com/user-attachments/assets/8c3c0f51-8353-4c1f-bae0-200d72710106)

### Stat Bonuses (Skill Systems) (#2088)

Both stat and growth fields use two rows. Magic and the final growth field are fully visible with both arrows.

![Skill Systems stat bonuses layout](https://github.com/user-attachments/assets/af9eb320-f10a-44c6-827e-ea12522c972a)

### Battle Animation Palette (#2089)

RGB controls no longer overlap. The visible, non-auto-hidden horizontal scrollbar provides access to the remaining widened columns.

![Battle Animation Palette layout](https://github.com/user-attachments/assets/7dcfe518-8885-41e7-9165-54b95af07244)

Copilot CLI: 1.0.79
Model: GPT-5.6 Sol (gpt-5.6-sol)
