### PR TITLE
feat(avalonia): add Song Table data expansion

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/SongTableExpandTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/SongTableExpandTests.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    [Collection("SharedState")]
+    public class SongTableExpandTests : IDisposable
+    {
+        const uint TableBase = 0x3000;
+        readonly ROM? _savedRom = CoreState.ROM;
+
+        public void Dispose()
+        {
+            CoreState.ROM = _savedRom;
+            NameResolver.ClearCache();
+        }
+
+        [Fact]
+        public void LoadSongList_ScansBeyondFormer1024Cap()
+        {
+            CoreState.ROM = MakeRomWithSongTable(1025);
+            var vm = new SongTableViewModel();
+
+            List<AddrResult> rows = vm.LoadSongList();
+
+            Assert.Equal(1025, rows.Count);
+            Assert.Equal(1024u, rows[^1].tag);
+        }
+
+        [Fact]
+        public void ShouldShowExpansion_MatchesConfigOrExpandedAddress()
+        {
+            ROM rom = MakeRomWithSongTable(3);
+
+            Assert.False(SongTableViewModel.ShouldShowExpansion(
+                rom, configuredShow: false));
+            Assert.True(SongTableViewModel.ShouldShowExpansion(
+                rom, configuredShow: true));
+
+            WriteU32(rom.Data, (int)rom.RomInfo.sound_table_pointer,
+                rom.RomInfo.extends_address);
+            Assert.True(SongTableViewModel.ShouldShowExpansion(
+                rom, configuredShow: false));
+        }
+
+        [Fact]
+        public void ExpandSongTable_CopiesSilenceRowAndRepointsEveryReference()
+        {
+            ROM rom = MakeRomWithSongTable(3);
+            CoreState.ROM = rom;
+            uint pointerSlot = rom.RomInfo.sound_table_pointer;
+            const uint extraReference = 0x200;
+            WriteU32(rom.Data, (int)extraReference, U.toPointer(TableBase));
+            byte[] row0 = rom.getBinaryData(TableBase, 8);
+            FillFreeSpace(rom, 0x100000, 0x2000);
+            var vm = new SongTableViewModel();
+
+            DataExpansionCore.ExpandResult result = vm.ExpandSongTable(5);
+
+            Assert.True(result.Success, result.Error);
+            Assert.Equal(5u, result.NewCount);
+            Assert.NotEqual(TableBase, result.NewBaseAddress);
+            Assert.Equal(result.NewBaseAddress, rom.p32(pointerSlot));
+            Assert.Equal(U.toPointer(result.NewBaseAddress),
+                rom.u32(extraReference));
+            Assert.Equal(row0, rom.getBinaryData(
+                result.NewBaseAddress + 3 * 8, 8));
+            Assert.Equal(row0, rom.getBinaryData(
+                result.NewBaseAddress + 4 * 8, 8));
+            Assert.Equal(0xFFFFFFFFu,
+                rom.u32(result.NewBaseAddress + 5 * 8));
+            Assert.All(rom.getBinaryData(TableBase, 3 * 8),
+                value => Assert.Equal(0, value));
+            Assert.Contains(pointerSlot, result.RepointedSlots);
+            Assert.Contains(extraReference, result.RepointedSlots);
+        }
+
+        [Theory]
+        [InlineData(2u)]
+        [InlineData(3u)]
+        [InlineData(32767u)]
+        public void ExpandSongTable_RejectsNonGrowthOrOverMaximum(
+            uint newCount)
+        {
+            ROM rom = MakeRomWithSongTable(3);
+            CoreState.ROM = rom;
+            byte[] snapshot = (byte[])rom.Data.Clone();
+            var vm = new SongTableViewModel();
+
+            DataExpansionCore.ExpandResult result =
+                vm.ExpandSongTable(newCount);
+
+            Assert.False(result.Success);
+            Assert.Equal(snapshot, rom.Data);
+        }
+
+        [Fact]
+        public void ExpandSongTable_ImplausibleReferenceFloodRestoresRomAndUndo()
+        {
+            ROM rom = MakeRomWithSongTable(3);
+            CoreState.ROM = rom;
+            for (uint i = 0; i < 65; i++)
+                WriteU32(rom.Data, (int)(0x200 + i * 4),
+                    U.toPointer(TableBase));
+            FillFreeSpace(rom, 0x100000, 0x2000);
+            byte[] snapshot = (byte[])rom.Data.Clone();
+            var undo = new Undo.UndoData
+            {
+                time = DateTime.Now,
+                name = "Rejected Song table expand",
+                list = new List<Undo.UndoPostion>(),
+                filesize = (uint)rom.Data.Length,
+            };
+            var vm = new SongTableViewModel();
+
+            DataExpansionCore.ExpandResult result;
+            using (ROM.BeginUndoScope(undo))
+            {
+                result = vm.ExpandSongTable(5);
+            }
+
+            Assert.False(result.Success);
+            Assert.Contains("implausible", result.Error);
+            Assert.Equal(snapshot, rom.Data);
+            Assert.Empty(undo.list);
+        }
+
+        [Fact]
+        public void ExpandSongTable_AmbientUndoRestoresRom()
+        {
+            ROM rom = MakeRomWithSongTable(3);
+            CoreState.ROM = rom;
+            FillFreeSpace(rom, 0x100000, 0x2000);
+            byte[] snapshot = (byte[])rom.Data.Clone();
+            var undo = new Undo.UndoData
+            {
+                time = DateTime.Now,
+                name = "Song table expand",
+                list = new List<Undo.UndoPostion>(),
+                filesize = (uint)rom.Data.Length,
+            };
+            var vm = new SongTableViewModel();
+
+            using (ROM.BeginUndoScope(undo))
+            {
+                DataExpansionCore.ExpandResult result =
+                    vm.ExpandSongTable(5);
+                Assert.True(result.Success, result.Error);
+            }
+
+            for (int i = undo.list.Count - 1; i >= 0; i--)
+            {
+                Undo.UndoPostion position = undo.list[i];
+                Array.Copy(position.data, 0, rom.Data, position.addr,
+                    position.data.Length);
+            }
+            Assert.Equal(snapshot, rom.Data);
+        }
+
+        static ROM MakeRomWithSongTable(uint count)
+        {
+            var rom = new ROM();
+            rom.LoadLow("song-expand.gba", new byte[0x1000000],
+                "BE8E01");
+            WriteU32(rom.Data, (int)rom.RomInfo.sound_table_pointer,
+                U.toPointer(TableBase));
+
+            for (uint i = 0; i < count; i++)
+            {
+                uint addr = TableBase + i * 8;
+                WriteU32(rom.Data, (int)addr,
+                    U.toPointer(0x4000 + (i % 8) * 0x20));
+                WriteU32(rom.Data, (int)(addr + 4), i);
+            }
+            WriteU32(rom.Data, (int)(TableBase + count * 8),
+                0xFFFFFFFF);
+            return rom;
+        }
+
+        static void FillFreeSpace(ROM rom, uint start, uint length)
+        {
+            for (uint i = 0; i < length; i++)
+                rom.Data[start + i] = 0xFF;
+        }
+
+        static void WriteU32(byte[] data, int offset, uint value)
+        {
+            data[offset + 0] = (byte)(value & 0xFF);
+            data[offset + 1] = (byte)((value >> 8) & 0xFF);
+            data[offset + 2] = (byte)((value >> 16) & 0xFF);
+            data[offset + 3] = (byte)((value >> 24) & 0xFF);
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/SongTableWriteProtectionTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/SongTableWriteProtectionTests.cs
@@ -192,6 +192,17 @@ namespace FEBuilderGBA.Avalonia.Tests
             Assert.Contains("NumberInputDialog.Show", code);
             Assert.Contains("_vm.ExpandSongTable(newCount)", code);
             Assert.Contains("SongList.SetItemsPreserveSelection", code);
+
+            int refreshIdx = code.IndexOf(
+                "ReloadSongListPreserveSelection(",
+                code.IndexOf("_vm.ExpandSongTable(newCount)",
+                    StringComparison.Ordinal),
+                StringComparison.Ordinal);
+            int commitIdx = code.IndexOf(
+                "_undoService.Commit()",
+                StringComparison.Ordinal);
+            Assert.True(refreshIdx >= 0 && commitIdx > refreshIdx,
+                "Song Table list refresh must finish before the expansion undo transaction commits.");
         }
 
         // ------------------------------------------------------------------

--- a/FEBuilderGBA.Avalonia.Tests/SongTableWriteProtectionTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/SongTableWriteProtectionTests.cs
@@ -178,6 +178,22 @@ namespace FEBuilderGBA.Avalonia.Tests
                 "The 'if (_vm.IsSongIdZero)' guard must appear before the undo scope opens.");
         }
 
+        [Fact]
+        public void SongTableView_HasExpansionButtonAndSafeHandler()
+        {
+            string axaml = File.ReadAllText(
+                ViewPath("SongTableView.axaml"));
+            string code = File.ReadAllText(
+                ViewPath("SongTableView.axaml.cs"));
+
+            Assert.Contains("SongTable_Expand_Button", axaml);
+            Assert.Contains("Content=\"Data Expansion\"", axaml);
+            Assert.Contains("CoreState.IsDecompMode", code);
+            Assert.Contains("NumberInputDialog.Show", code);
+            Assert.Contains("_vm.ExpandSongTable(newCount)", code);
+            Assert.Contains("SongList.SetItemsPreserveSelection", code);
+        }
+
         // ------------------------------------------------------------------
         // Helpers
         // ------------------------------------------------------------------

--- a/FEBuilderGBA.Avalonia/ViewModels/SongTableViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SongTableViewModel.cs
@@ -6,6 +6,11 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 {
     public class SongTableViewModel : ViewModelBase, IDataVerifiable
     {
+        public const uint MaxSongCount = 32766;
+
+        const uint SongEntrySize = 8;
+        const int MaxPlausibleRepointSlots = 64;
+
         uint _currentAddr;
         uint _songIndex;
         uint _songHeaderPointer;
@@ -47,16 +52,16 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             ROM rom = CoreState.ROM;
             if (rom?.RomInfo == null) return new List<AddrResult>();
 
-            uint ptr = rom.RomInfo.sound_table_pointer;
+            uint ptr = ResolveSongTablePointerSlot(rom);
             if (ptr == 0) return new List<AddrResult>();
 
             uint baseAddr = rom.p32(ptr);
-            if (!U.isSafetyOffset(baseAddr)) return new List<AddrResult>();
+            if (baseAddr >= (uint)rom.Data.Length) return new List<AddrResult>();
 
             var result = new List<AddrResult>();
-            for (uint i = 0; i < 0x400; i++) // reasonable max
+            for (uint i = 0; i < MaxSongCount; i++)
             {
-                uint addr = (uint)(baseAddr + i * 8);
+                uint addr = baseAddr + i * SongEntrySize;
                 if (addr + 7 >= (uint)rom.Data.Length) break;
 
                 uint headerPtr = rom.u32(addr);
@@ -67,6 +72,125 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 result.Add(new AddrResult(addr, name, i));
             }
             return result;
+        }
+
+        /// <summary>
+        /// WinForms parity for the normally-hidden Song Table expansion button:
+        /// show it when explicitly enabled in config, or once the table already
+        /// resides in the ROM's expansion area.
+        /// </summary>
+        internal static bool ShouldShowExpansion(ROM rom, bool configuredShow)
+        {
+            if (configuredShow) return true;
+            if (rom?.RomInfo == null) return false;
+
+            uint ptr = ResolveSongTablePointerSlot(rom);
+            if (ptr == 0 || ptr + 3 >= (uint)rom.Data.Length) return false;
+            return rom.u32(ptr) >= rom.RomInfo.extends_address;
+        }
+
+        public bool ShouldShowExpansion()
+        {
+            bool configuredShow =
+                U.atoi(CoreState.Config?.at("func_show_song_table_extends", "0") ?? "0") == 1;
+            ROM rom = CoreState.ROM;
+            return rom != null && ShouldShowExpansion(rom, configuredShow);
+        }
+
+        /// <summary>
+        /// Relocates and grows the Song Table using WinForms-compatible row-0
+        /// fill semantics, then repoints every raw/LDR reference to the old base.
+        /// Any failed expansion or audit restores the ROM byte-identically.
+        /// </summary>
+        public DataExpansionCore.ExpandResult ExpandSongTable(uint newCount)
+        {
+            ROM rom = CoreState.ROM;
+            if (rom?.RomInfo == null)
+                return ExpansionFailure("ROM not loaded.");
+
+            uint ptr = ResolveSongTablePointerSlot(rom);
+            if (ptr == 0 || ptr + 3 >= (uint)rom.Data.Length)
+                return ExpansionFailure("This ROM has no valid Song Table pointer.");
+
+            uint baseAddr = rom.p32(ptr);
+            if (baseAddr >= (uint)rom.Data.Length)
+                return ExpansionFailure("The Song Table pointer is out of ROM bounds.");
+
+            uint currentCount = CountSongEntries(rom, baseAddr);
+            if (currentCount == 0)
+                return ExpansionFailure("Cannot expand an empty Song Table because row 0 is unavailable.");
+            if (newCount <= currentCount)
+                return ExpansionFailure(
+                    $"New count ({newCount}) must be greater than current count ({currentCount}).");
+            if (newCount > MaxSongCount)
+                return ExpansionFailure(
+                    $"New count ({newCount}) exceeds the maximum ({MaxSongCount}).");
+
+            byte[] snapshot = (byte[])rom.Data.Clone();
+            Undo.UndoData? undo = ROM.GetAmbientUndoData();
+            int undoStart = undo?.list?.Count ?? 0;
+
+            try
+            {
+                DataExpansionCore.ExpandResult result =
+                    DataExpansionCore.ExpandTableTo(
+                        rom,
+                        ptr,
+                        SongEntrySize,
+                        currentCount,
+                        newCount,
+                        new DataExpansionCore.ExpandOptions
+                        {
+                            Fill = DataExpansionCore.ExpandFill.First,
+                            Repoint = DataExpansionCore.ExpandRepoint.RawAndLdrAll,
+                            FullZeroTerminatorRow = false,
+                        });
+
+                if (!result.Success)
+                {
+                    RestoreSnapshot(rom, snapshot, undo, undoStart);
+                    return result;
+                }
+
+                IReadOnlyList<uint> slots =
+                    result.RepointedSlots ?? Array.Empty<uint>();
+                if (slots.Count == 0)
+                {
+                    RestoreSnapshot(rom, snapshot, undo, undoStart);
+                    return ExpansionFailure(
+                        "Song Table expansion found no references to repoint.");
+                }
+
+                bool canonicalCovered = false;
+                foreach (uint slot in slots)
+                {
+                    if (slot == ptr)
+                    {
+                        canonicalCovered = true;
+                        break;
+                    }
+                }
+                if (!canonicalCovered)
+                {
+                    RestoreSnapshot(rom, snapshot, undo, undoStart);
+                    return ExpansionFailure(
+                        "Song Table expansion did not repoint the canonical pointer slot.");
+                }
+                if (slots.Count > MaxPlausibleRepointSlots)
+                {
+                    RestoreSnapshot(rom, snapshot, undo, undoStart);
+                    return ExpansionFailure(
+                        $"Song Table expansion found an implausible {slots.Count} references.");
+                }
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                RestoreSnapshot(rom, snapshot, undo, undoStart);
+                Log.Error("SongTableViewModel.ExpandSongTable failed: " + ex.ToString());
+                return ExpansionFailure("Song Table expansion failed: " + ex.Message);
+            }
         }
 
         public void LoadSong(uint addr)
@@ -111,13 +235,56 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         static uint ComputeSongIndex(ROM rom, uint addr)
         {
             if (rom?.RomInfo == null) return uint.MaxValue;
-            uint ptr = rom.RomInfo.sound_table_pointer;
+            uint ptr = ResolveSongTablePointerSlot(rom);
             // Guard the full 4-byte read: ROM.p32 only checks ptr >= Data.Length,
             // so a ptr within the last 3 bytes of the buffer can throw.
             if (ptr == 0 || ptr + 3 >= (uint)rom.Data.Length) return uint.MaxValue;
             uint baseAddr = rom.p32(ptr);
-            if (!U.isSafetyOffset(baseAddr) || addr < baseAddr) return uint.MaxValue;
-            return (addr - baseAddr) / 8;
+            if (baseAddr >= (uint)rom.Data.Length || addr < baseAddr) return uint.MaxValue;
+            return (addr - baseAddr) / SongEntrySize;
+        }
+
+        static uint ResolveSongTablePointerSlot(ROM rom)
+        {
+            return RebuildProducerCore.GetSoundTablePointer(rom);
+        }
+
+        static uint CountSongEntries(ROM rom, uint baseAddr)
+        {
+            uint count = 0;
+            while (count < MaxSongCount)
+            {
+                uint addr = baseAddr + count * SongEntrySize;
+                if (addr + SongEntrySize - 1 >= (uint)rom.Data.Length)
+                    break;
+                if (!U.isPointer(rom.u32(addr)))
+                    break;
+                count++;
+            }
+            return count;
+        }
+
+        static DataExpansionCore.ExpandResult ExpansionFailure(string error)
+        {
+            return new DataExpansionCore.ExpandResult
+            {
+                Success = false,
+                Error = error,
+            };
+        }
+
+        static void RestoreSnapshot(
+            ROM rom,
+            byte[] snapshot,
+            Undo.UndoData? undo,
+            int undoStart)
+        {
+            if (rom.Data.Length != snapshot.Length)
+                rom.write_resize_data((uint)snapshot.Length);
+            Array.Copy(snapshot, rom.Data, snapshot.Length);
+
+            if (undo?.list != null && undo.list.Count > undoStart)
+                undo.list.RemoveRange(undoStart, undo.list.Count - undoStart);
         }
 
         /// <summary>

--- a/FEBuilderGBA.Avalonia/ViewModels/SongTableViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SongTableViewModel.cs
@@ -6,10 +6,10 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 {
     public class SongTableViewModel : ViewModelBase, IDataVerifiable
     {
-        public const uint MaxSongCount = 32766;
+        public const uint MaxSongCount =
+            SongTableExpansionCore.MaxSongCount;
 
         const uint SongEntrySize = 8;
-        const int MaxPlausibleRepointSlots = 64;
 
         uint _currentAddr;
         uint _songIndex;
@@ -82,12 +82,8 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// </summary>
         internal static bool ShouldShowExpansion(ROM rom, bool configuredShow)
         {
-            if (configuredShow) return true;
-            if (rom?.RomInfo == null) return false;
-
-            uint ptr = rom.RomInfo.sound_table_pointer;
-            if (ptr == 0 || ptr + 3 >= (uint)rom.Data.Length) return false;
-            return rom.u32(ptr) >= rom.RomInfo.extends_address;
+            return SongTableExpansionCore.ShouldShowExpansion(
+                rom, configuredShow);
         }
 
         public bool ShouldShowExpansion()
@@ -105,93 +101,8 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// </summary>
         public DataExpansionCore.ExpandResult ExpandSongTable(uint newCount)
         {
-            ROM rom = CoreState.ROM;
-            if (rom?.RomInfo == null)
-                return ExpansionFailure("ROM not loaded.");
-
-            uint ptr = ResolveSongTablePointerSlot(rom);
-            if (ptr == 0 || ptr + 3 >= (uint)rom.Data.Length)
-                return ExpansionFailure("This ROM has no valid Song Table pointer.");
-
-            uint baseAddr = rom.p32(ptr);
-            if (baseAddr >= (uint)rom.Data.Length)
-                return ExpansionFailure("The Song Table pointer is out of ROM bounds.");
-
-            uint currentCount = CountSongEntries(rom, baseAddr);
-            if (currentCount == 0)
-                return ExpansionFailure("Cannot expand an empty Song Table because row 0 is unavailable.");
-            if (newCount <= currentCount)
-                return ExpansionFailure(
-                    $"New count ({newCount}) must be greater than current count ({currentCount}).");
-            if (newCount > MaxSongCount)
-                return ExpansionFailure(
-                    $"New count ({newCount}) exceeds the maximum ({MaxSongCount}).");
-
-            byte[] snapshot = (byte[])rom.Data.Clone();
-            Undo.UndoData? undo = ROM.GetAmbientUndoData();
-            int undoStart = undo?.list?.Count ?? 0;
-
-            try
-            {
-                DataExpansionCore.ExpandResult result =
-                    DataExpansionCore.ExpandTableTo(
-                        rom,
-                        ptr,
-                        SongEntrySize,
-                        currentCount,
-                        newCount,
-                        new DataExpansionCore.ExpandOptions
-                        {
-                            Fill = DataExpansionCore.ExpandFill.First,
-                            Repoint = DataExpansionCore.ExpandRepoint.RawAndLdrAll,
-                            FullZeroTerminatorRow = false,
-                        });
-
-                if (!result.Success)
-                {
-                    RestoreSnapshot(rom, snapshot, undo, undoStart);
-                    return result;
-                }
-
-                IReadOnlyList<uint> slots =
-                    result.RepointedSlots ?? Array.Empty<uint>();
-                if (slots.Count == 0)
-                {
-                    RestoreSnapshot(rom, snapshot, undo, undoStart);
-                    return ExpansionFailure(
-                        "Song Table expansion found no references to repoint.");
-                }
-
-                bool canonicalCovered = false;
-                foreach (uint slot in slots)
-                {
-                    if (slot == ptr)
-                    {
-                        canonicalCovered = true;
-                        break;
-                    }
-                }
-                if (!canonicalCovered)
-                {
-                    RestoreSnapshot(rom, snapshot, undo, undoStart);
-                    return ExpansionFailure(
-                        "Song Table expansion did not repoint the canonical pointer slot.");
-                }
-                if (slots.Count > MaxPlausibleRepointSlots)
-                {
-                    RestoreSnapshot(rom, snapshot, undo, undoStart);
-                    return ExpansionFailure(
-                        $"Song Table expansion found an implausible {slots.Count} references.");
-                }
-
-                return result;
-            }
-            catch (Exception ex)
-            {
-                RestoreSnapshot(rom, snapshot, undo, undoStart);
-                Log.Error("SongTableViewModel.ExpandSongTable failed: " + ex.ToString());
-                return ExpansionFailure("Song Table expansion failed: " + ex.Message);
-            }
+            return SongTableExpansionCore.Expand(
+                CoreState.ROM, newCount);
         }
 
         public void LoadSong(uint addr)
@@ -243,49 +154,6 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             uint baseAddr = rom.p32(ptr);
             if (!U.isSafetyOffset(baseAddr) || addr < baseAddr) return uint.MaxValue;
             return (addr - baseAddr) / SongEntrySize;
-        }
-
-        static uint ResolveSongTablePointerSlot(ROM rom)
-        {
-            return RebuildProducerCore.GetSoundTablePointer(rom);
-        }
-
-        static uint CountSongEntries(ROM rom, uint baseAddr)
-        {
-            uint count = 0;
-            while (count < MaxSongCount)
-            {
-                uint addr = baseAddr + count * SongEntrySize;
-                if (addr + SongEntrySize - 1 >= (uint)rom.Data.Length)
-                    break;
-                if (!U.isPointer(rom.u32(addr)))
-                    break;
-                count++;
-            }
-            return count;
-        }
-
-        static DataExpansionCore.ExpandResult ExpansionFailure(string error)
-        {
-            return new DataExpansionCore.ExpandResult
-            {
-                Success = false,
-                Error = error,
-            };
-        }
-
-        static void RestoreSnapshot(
-            ROM rom,
-            byte[] snapshot,
-            Undo.UndoData? undo,
-            int undoStart)
-        {
-            if (rom.Data.Length != snapshot.Length)
-                rom.write_resize_data((uint)snapshot.Length);
-            Array.Copy(snapshot, rom.Data, snapshot.Length);
-
-            if (undo?.list != null && undo.list.Count > undoStart)
-                undo.list.RemoveRange(undoStart, undo.list.Count - undoStart);
         }
 
         /// <summary>

--- a/FEBuilderGBA.Avalonia/ViewModels/SongTableViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/SongTableViewModel.cs
@@ -52,16 +52,17 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             ROM rom = CoreState.ROM;
             if (rom?.RomInfo == null) return new List<AddrResult>();
 
-            uint ptr = ResolveSongTablePointerSlot(rom);
-            if (ptr == 0) return new List<AddrResult>();
+            uint ptr = rom.RomInfo.sound_table_pointer;
+            if (ptr == 0 || ptr + 3 >= (uint)rom.Data.Length)
+                return new List<AddrResult>();
 
             uint baseAddr = rom.p32(ptr);
-            if (baseAddr >= (uint)rom.Data.Length) return new List<AddrResult>();
+            if (!U.isSafetyOffset(baseAddr)) return new List<AddrResult>();
 
             var result = new List<AddrResult>();
             for (uint i = 0; i < MaxSongCount; i++)
             {
-                uint addr = baseAddr + i * SongEntrySize;
+                uint addr = baseAddr + i * 8;
                 if (addr + 7 >= (uint)rom.Data.Length) break;
 
                 uint headerPtr = rom.u32(addr);
@@ -84,7 +85,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             if (configuredShow) return true;
             if (rom?.RomInfo == null) return false;
 
-            uint ptr = ResolveSongTablePointerSlot(rom);
+            uint ptr = rom.RomInfo.sound_table_pointer;
             if (ptr == 0 || ptr + 3 >= (uint)rom.Data.Length) return false;
             return rom.u32(ptr) >= rom.RomInfo.extends_address;
         }
@@ -235,12 +236,12 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         static uint ComputeSongIndex(ROM rom, uint addr)
         {
             if (rom?.RomInfo == null) return uint.MaxValue;
-            uint ptr = ResolveSongTablePointerSlot(rom);
+            uint ptr = rom.RomInfo.sound_table_pointer;
             // Guard the full 4-byte read: ROM.p32 only checks ptr >= Data.Length,
             // so a ptr within the last 3 bytes of the buffer can throw.
             if (ptr == 0 || ptr + 3 >= (uint)rom.Data.Length) return uint.MaxValue;
             uint baseAddr = rom.p32(ptr);
-            if (baseAddr >= (uint)rom.Data.Length || addr < baseAddr) return uint.MaxValue;
+            if (!U.isSafetyOffset(baseAddr) || addr < baseAddr) return uint.MaxValue;
             return (addr - baseAddr) / SongEntrySize;
         }
 

--- a/FEBuilderGBA.Avalonia/Views/SongTableView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/SongTableView.axaml
@@ -3,7 +3,20 @@
              xmlns:controls="clr-namespace:FEBuilderGBA.Avalonia.Controls"
              x:Class="FEBuilderGBA.Avalonia.Views.SongTableView">
   <Grid ColumnDefinitions="250,*">
-    <controls:AddressListControl AutomationProperties.AutomationId="SongTable_Song_List" Grid.Column="0" Name="SongList" Margin="4" />
+    <Grid Grid.Column="0" RowDefinitions="*,Auto">
+      <controls:AddressListControl AutomationProperties.AutomationId="SongTable_Song_List"
+                                   Grid.Row="0"
+                                   Name="SongList"
+                                   Margin="4" />
+      <Button AutomationProperties.AutomationId="SongTable_Expand_Button"
+              Grid.Row="1"
+              Name="SongTable_Expand_Button"
+              Content="Data Expansion"
+              Click="DataExpansion_Click"
+              IsVisible="False"
+              HorizontalAlignment="Stretch"
+              Margin="4" />
+    </Grid>
 
     <ScrollViewer Grid.Column="1" Margin="4">
       <StackPanel Spacing="8" Margin="8">

--- a/FEBuilderGBA.Avalonia/Views/SongTableView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SongTableView.axaml.cs
@@ -106,6 +106,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 uint selectedTag = SongList.SelectedItem?.tag ?? 0;
 
                 _undoService.Begin("Expand Song Table");
+                bool expanded = false;
                 try
                 {
                     DataExpansionCore.ExpandResult result =
@@ -118,41 +119,48 @@ namespace FEBuilderGBA.Avalonia.Views
                         return;
                     }
 
-                    _undoService.Commit();
-                    _vm.MarkClean();
-
-                    List<AddrResult> items = _vm.LoadSongList();
-                    uint preserveAddress = 0;
-                    if (hadSelection)
-                    {
-                        foreach (AddrResult item in items)
-                        {
-                            if (item.tag == selectedTag)
-                            {
-                                preserveAddress = item.addr;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (preserveAddress != 0)
-                        SongList.SetItemsPreserveSelection(items, preserveAddress);
-                    else
-                        SongList.SetItems(items);
-
+                    ReloadSongListPreserveSelection(
+                        hadSelection, selectedTag);
                     SongTable_Expand_Button.IsVisible =
                         _vm.ShouldShowExpansion();
-                    CoreState.Services?.ShowInfo(R._(
-                        "Expanded Song Table to {0} entries.", newCount));
+
+                    _undoService.Commit();
+                    _vm.MarkClean();
+                    expanded = true;
                 }
                 catch (Exception inner)
                 {
-                    _undoService.Rollback();
+                    bool canRollback = _undoService.HasPendingUndo;
+                    if (canRollback)
+                    {
+                        _undoService.Rollback();
+                        try
+                        {
+                            ReloadSongListPreserveSelection(
+                                hadSelection, selectedTag);
+                            SongTable_Expand_Button.IsVisible =
+                                _vm.ShouldShowExpansion();
+                        }
+                        catch (Exception refreshEx)
+                        {
+                            Log.Error(
+                                "SongTableView.DataExpansion_Click rollback refresh failed: " +
+                                refreshEx.ToString());
+                        }
+                    }
                     Log.Error(
                         "SongTableView.DataExpansion_Click inner failed: " +
                         inner.ToString());
-                    CoreState.Services?.ShowError(
-                        R._("List expansion failed: {0}", inner.Message));
+                    if (canRollback)
+                    {
+                        CoreState.Services?.ShowError(
+                            R._("List expansion failed: {0}", inner.Message));
+                    }
+                }
+                if (expanded)
+                {
+                    CoreState.Services?.ShowInfo(R._(
+                        "Expanded Song Table to {0} entries.", newCount));
                 }
             }
             catch (Exception ex)
@@ -161,6 +169,30 @@ namespace FEBuilderGBA.Avalonia.Views
                     "SongTableView.DataExpansion_Click failed: " +
                     ex.ToString());
             }
+        }
+
+        void ReloadSongListPreserveSelection(
+            bool hadSelection,
+            uint selectedTag)
+        {
+            List<AddrResult> items = _vm.LoadSongList();
+            uint preserveAddress = 0;
+            if (hadSelection)
+            {
+                foreach (AddrResult item in items)
+                {
+                    if (item.tag == selectedTag)
+                    {
+                        preserveAddress = item.addr;
+                        break;
+                    }
+                }
+            }
+
+            if (preserveAddress != 0)
+                SongList.SetItemsPreserveSelection(items, preserveAddress);
+            else
+                SongList.SetItems(items);
         }
 
         void OnSongSelected(uint addr)

--- a/FEBuilderGBA.Avalonia/Views/SongTableView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/SongTableView.axaml.cs
@@ -2,6 +2,7 @@ using global::Avalonia;
 using System;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
+using System.Collections.Generic;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
 
@@ -44,6 +45,8 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 var items = _vm.LoadSongList();
                 SongList.SetItems(items);
+                SongTable_Expand_Button.IsVisible =
+                    _vm.ShouldShowExpansion();
             }
             catch (Exception ex)
             {
@@ -53,6 +56,110 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 _vm.IsLoading = false;
                 _vm.MarkClean();
+            }
+        }
+
+        async void DataExpansion_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (CoreState.IsDecompMode)
+                {
+                    CoreState.Services?.ShowError(R._(
+                        "This is a source-backed decomp project. The built ROM is a preview and cannot be saved over. Edit the source and rebuild instead."));
+                    return;
+                }
+                if (CoreState.ROM == null)
+                {
+                    CoreState.Services?.ShowInfo(R._("Load a ROM first."));
+                    return;
+                }
+
+                uint currentCount = (uint)SongList.ItemCount;
+                if (currentCount == 0)
+                {
+                    CoreState.Services?.ShowError(
+                        R._("Cannot expand: list is empty."));
+                    return;
+                }
+                if (currentCount >= SongTableViewModel.MaxSongCount)
+                {
+                    CoreState.Services?.ShowInfo(R._(
+                        "New count ({0}) exceeds the maximum ({1}).",
+                        currentCount + 1,
+                        SongTableViewModel.MaxSongCount));
+                    return;
+                }
+
+                uint? chosen = await Dialogs.NumberInputDialog.Show(
+                    TopLevel.GetTopLevel(this) as Window,
+                    R._("Enter the new entry count for the Song Table (current: {0}, max: {1}).",
+                        currentCount, SongTableViewModel.MaxSongCount),
+                    R._("Data Expansion"),
+                    currentCount + 1,
+                    currentCount + 1,
+                    SongTableViewModel.MaxSongCount);
+                if (chosen == null) return;
+                uint newCount = chosen.Value;
+
+                bool hadSelection = SongList.SelectedItem != null;
+                uint selectedTag = SongList.SelectedItem?.tag ?? 0;
+
+                _undoService.Begin("Expand Song Table");
+                try
+                {
+                    DataExpansionCore.ExpandResult result =
+                        _vm.ExpandSongTable(newCount);
+                    if (!result.Success)
+                    {
+                        _undoService.Rollback();
+                        CoreState.Services?.ShowError(
+                            R._("List expansion failed: {0}", result.Error));
+                        return;
+                    }
+
+                    _undoService.Commit();
+                    _vm.MarkClean();
+
+                    List<AddrResult> items = _vm.LoadSongList();
+                    uint preserveAddress = 0;
+                    if (hadSelection)
+                    {
+                        foreach (AddrResult item in items)
+                        {
+                            if (item.tag == selectedTag)
+                            {
+                                preserveAddress = item.addr;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (preserveAddress != 0)
+                        SongList.SetItemsPreserveSelection(items, preserveAddress);
+                    else
+                        SongList.SetItems(items);
+
+                    SongTable_Expand_Button.IsVisible =
+                        _vm.ShouldShowExpansion();
+                    CoreState.Services?.ShowInfo(R._(
+                        "Expanded Song Table to {0} entries.", newCount));
+                }
+                catch (Exception inner)
+                {
+                    _undoService.Rollback();
+                    Log.Error(
+                        "SongTableView.DataExpansion_Click inner failed: " +
+                        inner.ToString());
+                    CoreState.Services?.ShowError(
+                        R._("List expansion failed: {0}", inner.Message));
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(
+                    "SongTableView.DataExpansion_Click failed: " +
+                    ex.ToString());
             }
         }
 

--- a/FEBuilderGBA.Core.Tests/DecreaseColorSubFlagTests.cs
+++ b/FEBuilderGBA.Core.Tests/DecreaseColorSubFlagTests.cs
@@ -6,6 +6,7 @@ namespace FEBuilderGBA.Core.Tests
     /// Tests for DecreaseColorCore.Quantize sub-flags:
     /// noScale, noReserve1stColor, ignoreTSA.
     /// </summary>
+    [Collection("SharedState")]
     public class DecreaseColorSubFlagTests
     {
 

--- a/FEBuilderGBA.Core.Tests/HeadlessEtcCacheTests.cs
+++ b/FEBuilderGBA.Core.Tests/HeadlessEtcCacheTests.cs
@@ -2,7 +2,6 @@ using Xunit;
 using FEBuilderGBA;
 using System;
 using System.Collections.Generic;
-using System.IO;
 
 namespace FEBuilderGBA.Core.Tests
 {
@@ -112,40 +111,30 @@ namespace FEBuilderGBA.Core.Tests
             seed.Update(0x180, "value");
             Assert.True(seed.TryCaptureAll(out var seedSnapshot));
 
-            string savedBase = CoreState.BaseDirectory;
-            try
-            {
-                CoreState.BaseDirectory = Path.GetTempPath();
-                var cache = new EtcCache(
-                    "snapshot-test-" + Guid.NewGuid().ToString("N"));
-                Assert.True(cache.TryRestoreAll(seedSnapshot));
-                Assert.True(cache.TryCaptureAll(out var captured));
+            var cache = new EtcCache();
+            Assert.True(cache.TryRestoreAll(seedSnapshot));
+            Assert.True(cache.TryCaptureAll(out var captured));
 
-                Assert.True(captured.Entries.ContainsKey(0x100));
-                Assert.Equal("", captured.Entries[0x100]);
-                Assert.Equal("value", captured.Entries[0x180]);
+            Assert.True(captured.Entries.ContainsKey(0x100));
+            Assert.Equal("", captured.Entries[0x100]);
+            Assert.Equal("value", captured.Entries[0x180]);
 
-                var ranges =
-                    new[] { new EtcCacheRange(0x100, 0x100u) };
-                Assert.True(
-                    cache.TryCaptureRanges(ranges, out var rangeSnapshot));
-                cache.Remove(0x100);
-                cache.Update(0x180, "changed");
-                cache.Update(0x1F0, "new");
-                Assert.True(cache.TryRestoreRanges(rangeSnapshot));
-                Assert.True(cache.TryGetValue(0x100, out string empty));
-                Assert.Equal("", empty);
-                Assert.Equal("value", cache.At(0x180));
-                Assert.False(cache.CheckFast(0x1F0));
+            var ranges =
+                new[] { new EtcCacheRange(0x100, 0x100u) };
+            Assert.True(
+                cache.TryCaptureRanges(ranges, out var rangeSnapshot));
+            cache.Remove(0x100);
+            cache.Update(0x180, "changed");
+            cache.Update(0x1F0, "new");
+            Assert.True(cache.TryRestoreRanges(rangeSnapshot));
+            Assert.True(cache.TryGetValue(0x100, out string empty));
+            Assert.Equal("", empty);
+            Assert.Equal("value", cache.At(0x180));
+            Assert.False(cache.CheckFast(0x1F0));
 
-                cache.Update(0x200, "destination");
-                cache.RepointEtcData(0x180, 1, 0x200);
-                Assert.Equal("value", cache.At(0x200));
-            }
-            finally
-            {
-                CoreState.BaseDirectory = savedBase;
-            }
+            cache.Update(0x200, "destination");
+            cache.RepointEtcData(0x180, 1, 0x200);
+            Assert.Equal("value", cache.At(0x200));
         }
 
         [Fact]

--- a/FEBuilderGBA.Core.Tests/HeadlessEtcCacheTests.cs
+++ b/FEBuilderGBA.Core.Tests/HeadlessEtcCacheTests.cs
@@ -1,5 +1,8 @@
 using Xunit;
 using FEBuilderGBA;
+using System;
+using System.Collections.Generic;
+using System.IO;
 
 namespace FEBuilderGBA.Core.Tests
 {
@@ -77,6 +80,85 @@ namespace FEBuilderGBA.Core.Tests
         {
             IEtcCache cache = new HeadlessEtcCache();
             Assert.NotNull(cache);
+        }
+
+        [Fact]
+        public void SnapshotRanges_RestoresExactValuesIncludingEmpty()
+        {
+            var cache = new HeadlessEtcCache();
+            cache.Update(0x100, "");
+            cache.Update(0x180, "inside");
+            cache.Update(0x300, "outside");
+            var ranges = new[] { new EtcCacheRange(0x100, 0x100u) };
+
+            Assert.True(cache.TryCaptureRanges(ranges, out var snapshot));
+            cache.Update(0x100, "changed");
+            cache.Remove(0x180);
+            cache.Update(0x1F0, "new");
+
+            Assert.True(cache.TryRestoreRanges(snapshot));
+            Assert.True(cache.TryGetValue(0x100, out string empty));
+            Assert.Equal("", empty);
+            Assert.Equal("inside", cache.At(0x180));
+            Assert.False(cache.CheckFast(0x1F0));
+            Assert.Equal("outside", cache.At(0x300));
+        }
+
+        [Fact]
+        public void CoreEtcCache_SnapshotRoundTrip_PreservesEmptyValue()
+        {
+            var seed = new HeadlessEtcCache();
+            seed.Update(0x100, "");
+            seed.Update(0x180, "value");
+            Assert.True(seed.TryCaptureAll(out var seedSnapshot));
+
+            string savedBase = CoreState.BaseDirectory;
+            try
+            {
+                CoreState.BaseDirectory = Path.GetTempPath();
+                var cache = new EtcCache(
+                    "snapshot-test-" + Guid.NewGuid().ToString("N"));
+                Assert.True(cache.TryRestoreAll(seedSnapshot));
+                Assert.True(cache.TryCaptureAll(out var captured));
+
+                Assert.True(captured.Entries.ContainsKey(0x100));
+                Assert.Equal("", captured.Entries[0x100]);
+                Assert.Equal("value", captured.Entries[0x180]);
+
+                var ranges =
+                    new[] { new EtcCacheRange(0x100, 0x100u) };
+                Assert.True(
+                    cache.TryCaptureRanges(ranges, out var rangeSnapshot));
+                cache.Remove(0x100);
+                cache.Update(0x180, "changed");
+                cache.Update(0x1F0, "new");
+                Assert.True(cache.TryRestoreRanges(rangeSnapshot));
+                Assert.True(cache.TryGetValue(0x100, out string empty));
+                Assert.Equal("", empty);
+                Assert.Equal("value", cache.At(0x180));
+                Assert.False(cache.CheckFast(0x1F0));
+
+                cache.Update(0x200, "destination");
+                cache.RepointEtcData(0x180, 1, 0x200);
+                Assert.Equal("value", cache.At(0x200));
+            }
+            finally
+            {
+                CoreState.BaseDirectory = savedBase;
+            }
+        }
+
+        [Fact]
+        public void RepointEtcData_SourceEntryWinsDestinationCollision()
+        {
+            var cache = new HeadlessEtcCache();
+            cache.Update(0x100, "moved");
+            cache.Update(0x200, "destination");
+
+            cache.RepointEtcData(0x100, 1, 0x200);
+
+            Assert.False(cache.CheckFast(0x100));
+            Assert.Equal("moved", cache.At(0x200));
         }
     }
 }

--- a/FEBuilderGBA.Core.Tests/ImageImportCorePortraitWriteTests.cs
+++ b/FEBuilderGBA.Core.Tests/ImageImportCorePortraitWriteTests.cs
@@ -684,8 +684,10 @@ namespace FEBuilderGBA.Core.Tests
 
             undo.Push(ud);
             undo.RunUndo();
-            Assert.Equal(U.Padding4(beforeLength), (uint)rom.Data.Length);
+            Assert.Equal(beforeLength, (uint)rom.Data.Length);
 
+            // Compatibility helper remains safe for existing callers, but exact
+            // Undo resizing now makes this a no-op.
             ImageImportCore.RestoreExactRomLengthAfterUndo(rom, beforeLength);
 
             Assert.Equal(beforeLength, (uint)rom.Data.Length);

--- a/FEBuilderGBA.Core.Tests/SongTableExpansionCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/SongTableExpansionCoreTests.cs
@@ -1,0 +1,328 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection("SharedState")]
+    public sealed class SongTableExpansionCoreTests : IDisposable
+    {
+        const uint TableBase = 0x3000;
+        const uint FreeBase = 0x100000;
+
+        readonly ROM _savedRom = CoreState.ROM;
+        readonly Undo _savedUndo = CoreState.Undo;
+        readonly IEtcCache _savedComment = CoreState.CommentCache;
+        readonly IEtcCache _savedLint = CoreState.LintCache;
+        readonly DecompProject _savedDecomp = CoreState.DecompProject;
+
+        public SongTableExpansionCoreTests()
+        {
+            CoreState.DecompProject = null;
+        }
+
+        public void Dispose()
+        {
+            CoreState.ROM = _savedRom;
+            CoreState.Undo = _savedUndo;
+            CoreState.CommentCache = _savedComment;
+            CoreState.LintCache = _savedLint;
+            CoreState.DecompProject = _savedDecomp;
+        }
+
+        [Fact]
+        public void Expand_AuditFailureAfterGrowth_RestoresRomCachesAndUndo()
+        {
+            ROM rom = MakeRom(3, addFreeSpace: false);
+            CoreState.ROM = rom;
+            var comment = new HeadlessEtcCache();
+            var lint = new HeadlessEtcCache();
+            CoreState.CommentCache = comment;
+            CoreState.LintCache = lint;
+            comment.Update(TableBase + 8, "comment-row");
+            comment.Update((uint)rom.Data.Length + 4, "comment-tail");
+            lint.Update(TableBase + 8, "lint-row");
+            lint.Update((uint)rom.Data.Length + 8, "lint-tail");
+            for (uint i = 0; i < 65; i++)
+                WriteU32(rom.Data, 0x200 + i * 4, U.toPointer(TableBase));
+
+            byte[] romBefore = (byte[])rom.Data.Clone();
+            var commentBefore = Capture(comment);
+            var lintBefore = Capture(lint);
+            var undo = NewUndo(rom, "failing expansion");
+
+            DataExpansionCore.ExpandResult result;
+            using (ROM.BeginUndoScope(undo))
+                result = SongTableExpansionCore.Expand(rom, 5);
+
+            Assert.False(result.Success);
+            Assert.Contains("implausible", result.Error);
+            Assert.Equal(romBefore, rom.Data);
+            Assert.Equal(commentBefore, Capture(comment));
+            Assert.Equal(lintBefore, Capture(lint));
+            Assert.Empty(undo.list);
+            Assert.Empty(undo.CachePatches);
+        }
+
+        [Fact]
+        public void Expand_UndoRedo_RestoresDestinationCollisions()
+        {
+            ROM rom = MakeRom(3);
+            CoreState.ROM = rom;
+            CoreState.Undo = new Undo();
+            var comment = new HeadlessEtcCache();
+            var lint = new HeadlessEtcCache();
+            CoreState.CommentCache = comment;
+            CoreState.LintCache = lint;
+            comment.Update(TableBase + 8, "comment-moved");
+            comment.Update(FreeBase + 8, "comment-destination");
+            lint.Update(TableBase + 8, "lint-moved");
+            lint.Update(FreeBase + 8, "lint-destination");
+
+            Undo.UndoData undo = CoreState.Undo.NewUndoData("expand");
+            DataExpansionCore.ExpandResult result;
+            using (ROM.BeginUndoScope(undo))
+                result = SongTableExpansionCore.Expand(rom, 5);
+            Assert.True(result.Success, result.Error);
+            CoreState.Undo.Push(undo);
+
+            Assert.Equal("comment-moved", comment.At(result.NewBaseAddress + 8));
+            Assert.Equal("lint-moved", lint.At(result.NewBaseAddress + 8));
+
+            CoreState.Undo.RunUndo();
+            Assert.Equal("comment-moved", comment.At(TableBase + 8));
+            Assert.Equal("comment-destination", comment.At(FreeBase + 8));
+            Assert.Equal("lint-moved", lint.At(TableBase + 8));
+            Assert.Equal("lint-destination", lint.At(FreeBase + 8));
+
+            Assert.True(CoreState.Undo.RunRedo());
+            Assert.False(comment.CheckFast(TableBase + 8));
+            Assert.Equal("comment-moved", comment.At(result.NewBaseAddress + 8));
+            Assert.False(lint.CheckFast(TableBase + 8));
+            Assert.Equal("lint-moved", lint.At(result.NewBaseAddress + 8));
+        }
+
+        [Fact]
+        public void Expand_WithLaterEdit_UndoAndRedoReconstructEveryState()
+        {
+            ROM rom = MakeRom(3);
+            CoreState.ROM = rom;
+            CoreState.Undo = new Undo();
+            var comment = new HeadlessEtcCache();
+            CoreState.CommentCache = comment;
+            CoreState.LintCache = new HeadlessEtcCache();
+            comment.Update(TableBase + 8, "moved");
+
+            Undo.UndoData expandUndo = CoreState.Undo.NewUndoData("expand");
+            DataExpansionCore.ExpandResult result;
+            using (ROM.BeginUndoScope(expandUndo))
+                result = SongTableExpansionCore.Expand(rom, 5);
+            Assert.True(result.Success, result.Error);
+            CoreState.Undo.Push(expandUndo);
+
+            const uint editAddr = 0x800;
+            Undo.UndoData editUndo = CoreState.Undo.NewUndoData("edit");
+            using (ROM.BeginUndoScope(editUndo))
+                rom.write_u8(editAddr, 0xAA);
+            CoreState.Undo.Push(editUndo);
+
+            CoreState.Undo.RunUndo();
+            Assert.Equal(0u, rom.u8(editAddr));
+            Assert.Equal("moved", comment.At(result.NewBaseAddress + 8));
+
+            CoreState.Undo.RunUndo();
+            Assert.Equal("moved", comment.At(TableBase + 8));
+
+            Assert.True(CoreState.Undo.RunRedo());
+            Assert.Equal("moved", comment.At(result.NewBaseAddress + 8));
+            Assert.Equal(0u, rom.u8(editAddr));
+
+            Assert.True(CoreState.Undo.RunRedo());
+            Assert.Equal(0xAAu, rom.u8(editAddr));
+            Assert.Equal("moved", comment.At(result.NewBaseAddress + 8));
+        }
+
+        [Fact]
+        public void Undo_TipHadNoCache_DoesNotMutateLaterInstalledCache()
+        {
+            ROM rom = MakeRom(3);
+            CoreState.ROM = rom;
+            CoreState.Undo = new Undo();
+            var original = new HeadlessEtcCache();
+            CoreState.CommentCache = original;
+            CoreState.LintCache = new HeadlessEtcCache();
+            original.Update(TableBase + 8, "original");
+
+            Undo.UndoData expandUndo = CoreState.Undo.NewUndoData("expand");
+            using (ROM.BeginUndoScope(expandUndo))
+            {
+                Assert.True(
+                    SongTableExpansionCore.Expand(rom, 5).Success);
+            }
+            CoreState.Undo.Push(expandUndo);
+
+            CoreState.CommentCache = null;
+            Undo.UndoData editUndo = CoreState.Undo.NewUndoData("edit");
+            using (ROM.BeginUndoScope(editUndo))
+                rom.write_u8(0x800, 0xAA);
+            CoreState.Undo.Push(editUndo);
+
+            CoreState.Undo.RunUndo();
+            var replacement = new HeadlessEtcCache();
+            replacement.Update(0x777, "replacement");
+            CoreState.CommentCache = replacement;
+
+            CoreState.Undo.RunUndo();
+
+            Assert.Equal("replacement", replacement.At(0x777));
+            Assert.False(replacement.CheckFast(TableBase + 8));
+        }
+
+        [Fact]
+        public void Undo_RestoresIntoReplacementLiveCacheInstance()
+        {
+            ROM rom = MakeRom(3);
+            CoreState.ROM = rom;
+            CoreState.Undo = new Undo();
+            var original = new HeadlessEtcCache();
+            CoreState.CommentCache = original;
+            CoreState.LintCache = new HeadlessEtcCache();
+            original.Update(TableBase + 8, "original-row");
+
+            Undo.UndoData expandUndo = CoreState.Undo.NewUndoData("expand");
+            using (ROM.BeginUndoScope(expandUndo))
+            {
+                Assert.True(
+                    SongTableExpansionCore.Expand(rom, 5).Success);
+            }
+            CoreState.Undo.Push(expandUndo);
+
+            var replacement = new HeadlessEtcCache();
+            replacement.Update(0x777, "replacement-only");
+            CoreState.CommentCache = replacement;
+
+            CoreState.Undo.RunUndo();
+
+            Assert.Equal("replacement-only", replacement.At(0x777));
+            Assert.Equal("original-row", replacement.At(TableBase + 8));
+        }
+
+        [Fact]
+        public void Expand_UnsupportedCache_RefusesBeforeRomMutation()
+        {
+            ROM rom = MakeRom(3);
+            CoreState.ROM = rom;
+            CoreState.CommentCache = new UnsupportedCache();
+            CoreState.LintCache = new HeadlessEtcCache();
+            byte[] before = (byte[])rom.Data.Clone();
+
+            DataExpansionCore.ExpandResult result =
+                SongTableExpansionCore.Expand(rom, 5);
+
+            Assert.False(result.Success);
+            Assert.Contains("transactional comment cache", result.Error);
+            Assert.Equal(before, rom.Data);
+        }
+
+        [Fact]
+        public void DefaultExpandTableTo_RepointsCacheWithoutUndoPatch()
+        {
+            ROM rom = MakeRom(3);
+            CoreState.ROM = rom;
+            var comment = new HeadlessEtcCache();
+            CoreState.CommentCache = comment;
+            CoreState.LintCache = new HeadlessEtcCache();
+            comment.Update(TableBase + 8, "forward-only");
+            var undo = NewUndo(rom, "default expand");
+
+            DataExpansionCore.ExpandResult result;
+            using (ROM.BeginUndoScope(undo))
+            {
+                result = DataExpansionCore.ExpandTableTo(
+                    rom,
+                    rom.RomInfo.sound_table_pointer,
+                    8,
+                    3,
+                    5);
+            }
+
+            Assert.True(result.Success, result.Error);
+            Assert.Equal(
+                "forward-only", comment.At(result.NewBaseAddress + 8));
+            Assert.Empty(undo.CachePatches);
+        }
+
+        static ROM MakeRom(
+            uint count,
+            int length = 0x1000000,
+            bool addFreeSpace = true)
+        {
+            var rom = new ROM();
+            rom.LoadLow("song-core-expand.gba", new byte[length], "BE8E01");
+            WriteU32(
+                rom.Data,
+                rom.RomInfo.sound_table_pointer,
+                U.toPointer(TableBase));
+            for (uint i = 0; i < count; i++)
+            {
+                uint row = TableBase + i * 8;
+                WriteU32(
+                    rom.Data,
+                    row,
+                    U.toPointer(0x4000 + i * 0x20));
+                WriteU32(rom.Data, row + 4, i);
+            }
+            WriteU32(rom.Data, TableBase + count * 8, 0xFFFFFFFF);
+
+            if (addFreeSpace)
+            {
+                for (uint i = 0; i < 0x2000; i++)
+                    rom.Data[FreeBase + i] = 0xFF;
+            }
+            return rom;
+        }
+
+        static Undo.UndoData NewUndo(ROM rom, string name)
+        {
+            return new Undo.UndoData
+            {
+                time = DateTime.Now,
+                name = name,
+                list = new List<Undo.UndoPostion>(),
+                filesize = (uint)rom.Data.Length,
+            };
+        }
+
+        static Dictionary<uint, string> Capture(IEtcCache cache)
+        {
+            Assert.True(cache.TryCaptureAll(out var snapshot));
+            return snapshot.Entries.ToDictionary(
+                pair => pair.Key, pair => pair.Value);
+        }
+
+        static void WriteU32(byte[] data, uint offset, uint value)
+        {
+            data[offset + 0] = (byte)(value & 0xFF);
+            data[offset + 1] = (byte)((value >> 8) & 0xFF);
+            data[offset + 2] = (byte)((value >> 16) & 0xFF);
+            data[offset + 3] = (byte)((value >> 24) & 0xFF);
+        }
+
+        sealed class UnsupportedCache : IEtcCache
+        {
+            public void RemoveOverRange(uint range) { }
+            public void RemoveRange(uint start, uint end) { }
+            public bool CheckFast(uint num) => false;
+            public string At(uint num, string def = "") => def;
+            public string S_At(uint num) => "";
+            public bool TryGetValue(uint num, out string outData)
+            {
+                outData = "";
+                return false;
+            }
+            public void Update(uint addr, string comment) { }
+            public void Remove(uint addr) { }
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/SongTableExpansionCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/SongTableExpansionCoreTests.cs
@@ -35,6 +35,9 @@ namespace FEBuilderGBA.Core.Tests
         public void Expand_AuditFailureAfterGrowth_RestoresRomCachesAndUndo()
         {
             ROM rom = MakeRom(3, addFreeSpace: false);
+            byte[] unaligned = new byte[rom.Data.Length + 1];
+            Array.Copy(rom.Data, unaligned, rom.Data.Length);
+            rom.SwapNewROMDataDirect(unaligned);
             CoreState.ROM = rom;
             var comment = new HeadlessEtcCache();
             var lint = new HeadlessEtcCache();
@@ -59,6 +62,8 @@ namespace FEBuilderGBA.Core.Tests
             Assert.False(result.Success);
             Assert.Contains("implausible", result.Error);
             Assert.Equal(romBefore, rom.Data);
+            Assert.Equal(romBefore.Length, rom.Data.Length);
+            Assert.False(rom.Modified);
             Assert.Equal(commentBefore, Capture(comment));
             Assert.Equal(lintBefore, Capture(lint));
             Assert.Empty(undo.list);
@@ -255,6 +260,26 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void Expand_MissingRangeRestore_RollsBackWithoutCommit()
+        {
+            ROM rom = MakeRom(3);
+            CoreState.ROM = rom;
+            CoreState.CommentCache = new FullOnlyCache();
+            CoreState.LintCache = new HeadlessEtcCache();
+            byte[] before = (byte[])rom.Data.Clone();
+            var undo = NewUndo(rom, "range restore unsupported");
+
+            DataExpansionCore.ExpandResult result;
+            using (ROM.BeginUndoScope(undo))
+                result = SongTableExpansionCore.Expand(rom, 5);
+
+            Assert.False(result.Success);
+            Assert.Equal(before, rom.Data);
+            Assert.Empty(undo.list);
+            Assert.Empty(undo.CachePatches);
+        }
+
+        [Fact]
         public void Undo_UnsupportedReplacementCache_DoesNotThrowAfterRomRestore()
         {
             ROM rom = MakeRom(3);
@@ -278,6 +303,52 @@ namespace FEBuilderGBA.Core.Tests
 
             Assert.Null(error);
             Assert.Equal(before, rom.Data);
+        }
+
+        [Fact]
+        public void Undo_FullOnlyReplacementCache_RemainsUnchanged()
+        {
+            ROM rom = MakeRom(3);
+            CoreState.ROM = rom;
+            CoreState.Undo = new Undo();
+            CoreState.CommentCache = new HeadlessEtcCache();
+            CoreState.LintCache = new HeadlessEtcCache();
+
+            Undo.UndoData undo = CoreState.Undo.NewUndoData("expand");
+            using (ROM.BeginUndoScope(undo))
+            {
+                Assert.True(
+                    SongTableExpansionCore.Expand(rom, 5).Success);
+            }
+            CoreState.Undo.Push(undo);
+
+            var replacement = new FullOnlyCache();
+            replacement.Update(0x777, "replacement");
+            CoreState.CommentCache = replacement;
+            CoreState.Undo.RunUndo();
+
+            Assert.Equal("replacement", replacement.At(0x777));
+        }
+
+        [Fact]
+        public void Expand_UsesExplicitRomWhenGlobalDiffers()
+        {
+            ROM target = MakeRom(3);
+            ROM other = MakeRom(1);
+            CoreState.ROM = other;
+            CoreState.CommentCache = new HeadlessEtcCache();
+            CoreState.LintCache = new HeadlessEtcCache();
+
+            DataExpansionCore.ExpandResult result =
+                SongTableExpansionCore.Expand(target, 5);
+
+            Assert.True(result.Success, result.Error);
+            Assert.Equal(
+                result.NewBaseAddress,
+                target.p32(target.RomInfo.sound_table_pointer));
+            Assert.Equal(
+                TableBase,
+                other.p32(other.RomInfo.sound_table_pointer));
         }
 
         [Fact]
@@ -413,6 +484,36 @@ namespace FEBuilderGBA.Core.Tests
             }
             public void Update(uint addr, string comment) { }
             public void Remove(uint addr) { }
+        }
+
+        sealed class FullOnlyCache : IEtcCache
+        {
+            readonly HeadlessEtcCache _inner = new();
+
+            public void RemoveOverRange(uint range) =>
+                _inner.RemoveOverRange(range);
+            public void RemoveRange(uint start, uint end) =>
+                _inner.RemoveRange(start, end);
+            public bool CheckFast(uint num) => _inner.CheckFast(num);
+            public string At(uint num, string def = "") =>
+                _inner.At(num, def);
+            public string S_At(uint num) => _inner.S_At(num);
+            public bool TryGetValue(uint num, out string outData) =>
+                _inner.TryGetValue(num, out outData);
+            public void Update(uint addr, string comment) =>
+                _inner.Update(addr, comment);
+            public void Remove(uint addr) => _inner.Remove(addr);
+            public void RepointEtcData(
+                uint oldAddr, uint oldSize, uint newAddr) =>
+                _inner.RepointEtcData(oldAddr, oldSize, newAddr);
+            public bool TryCaptureAll(out EtcCacheSnapshot snapshot) =>
+                _inner.TryCaptureAll(out snapshot);
+            public bool TryCaptureRanges(
+                IReadOnlyList<EtcCacheRange> ranges,
+                out EtcCacheSnapshot snapshot) =>
+                _inner.TryCaptureRanges(ranges, out snapshot);
+            public bool TryRestoreAll(EtcCacheSnapshot snapshot) =>
+                _inner.TryRestoreAll(snapshot);
         }
     }
 }

--- a/FEBuilderGBA.Core.Tests/SongTableExpansionCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/SongTableExpansionCoreTests.cs
@@ -146,13 +146,12 @@ namespace FEBuilderGBA.Core.Tests
         [Fact]
         public void Undo_TipHadNoCache_DoesNotMutateLaterInstalledCache()
         {
-            ROM rom = MakeRom(3);
+            ROM rom = MakeRom(3, addFreeSpace: false);
             CoreState.ROM = rom;
             CoreState.Undo = new Undo();
-            var original = new HeadlessEtcCache();
-            CoreState.CommentCache = original;
+            CoreState.CommentCache = null;
             CoreState.LintCache = new HeadlessEtcCache();
-            original.Update(TableBase + 8, "original");
+            uint originalLength = (uint)rom.Data.Length;
 
             Undo.UndoData expandUndo = CoreState.Undo.NewUndoData("expand");
             using (ROM.BeginUndoScope(expandUndo))
@@ -170,13 +169,43 @@ namespace FEBuilderGBA.Core.Tests
 
             CoreState.Undo.RunUndo();
             var replacement = new HeadlessEtcCache();
-            replacement.Update(0x777, "replacement");
+            uint replacementKey = originalLength + 4;
+            replacement.Update(replacementKey, "replacement");
             CoreState.CommentCache = replacement;
 
             CoreState.Undo.RunUndo();
 
-            Assert.Equal("replacement", replacement.At(0x777));
+            Assert.Equal("replacement", replacement.At(replacementKey));
             Assert.False(replacement.CheckFast(TableBase + 8));
+        }
+
+        [Fact]
+        public void Undo_GrownRom_RestoresDestinationCacheCapturedBeforeShrink()
+        {
+            ROM rom = MakeRom(3, addFreeSpace: false);
+            CoreState.ROM = rom;
+            CoreState.Undo = new Undo();
+            var comment = new HeadlessEtcCache();
+            CoreState.CommentCache = comment;
+            CoreState.LintCache = new HeadlessEtcCache();
+            uint originalLength = (uint)rom.Data.Length;
+            comment.Update(TableBase + 8, "moved");
+            comment.Update(originalLength + 8, "destination-before");
+
+            Undo.UndoData undo = CoreState.Undo.NewUndoData("expand");
+            DataExpansionCore.ExpandResult result;
+            using (ROM.BeginUndoScope(undo))
+                result = SongTableExpansionCore.Expand(rom, 5);
+            Assert.True(result.Success, result.Error);
+            CoreState.Undo.Push(undo);
+
+            Assert.Equal("moved", comment.At(result.NewBaseAddress + 8));
+            CoreState.Undo.RunUndo();
+
+            Assert.Equal(originalLength, (uint)rom.Data.Length);
+            Assert.Equal("moved", comment.At(TableBase + 8));
+            Assert.Equal(
+                "destination-before", comment.At(originalLength + 8));
         }
 
         [Fact]
@@ -223,6 +252,67 @@ namespace FEBuilderGBA.Core.Tests
             Assert.False(result.Success);
             Assert.Contains("transactional comment cache", result.Error);
             Assert.Equal(before, rom.Data);
+        }
+
+        [Fact]
+        public void Undo_UnsupportedReplacementCache_DoesNotThrowAfterRomRestore()
+        {
+            ROM rom = MakeRom(3);
+            CoreState.ROM = rom;
+            CoreState.Undo = new Undo();
+            CoreState.CommentCache = new HeadlessEtcCache();
+            CoreState.LintCache = new HeadlessEtcCache();
+            byte[] before = (byte[])rom.Data.Clone();
+
+            Undo.UndoData undo = CoreState.Undo.NewUndoData("expand");
+            using (ROM.BeginUndoScope(undo))
+            {
+                Assert.True(
+                    SongTableExpansionCore.Expand(rom, 5).Success);
+            }
+            CoreState.Undo.Push(undo);
+            CoreState.CommentCache = new UnsupportedCache();
+
+            Exception error = Record.Exception(
+                () => CoreState.Undo.RunUndo());
+
+            Assert.Null(error);
+            Assert.Equal(before, rom.Data);
+        }
+
+        [Fact]
+        public void Undo_AfterBranchTruncation_CapturesNewTip()
+        {
+            ROM rom = MakeRom(3);
+            CoreState.ROM = rom;
+            CoreState.Undo = new Undo();
+            var comment = new HeadlessEtcCache();
+            CoreState.CommentCache = comment;
+            CoreState.LintCache = new HeadlessEtcCache();
+            comment.Update(TableBase + 8, "original");
+
+            Undo.UndoData expandUndo = CoreState.Undo.NewUndoData("expand");
+            using (ROM.BeginUndoScope(expandUndo))
+            {
+                Assert.True(
+                    SongTableExpansionCore.Expand(rom, 5).Success);
+            }
+            CoreState.Undo.Push(expandUndo);
+            CoreState.Undo.RunUndo();
+            Assert.Equal("original", comment.At(TableBase + 8));
+
+            Undo.UndoData replacementEdit =
+                CoreState.Undo.NewUndoData("replacement edit");
+            using (ROM.BeginUndoScope(replacementEdit))
+                rom.write_u8(0x800, 0xBB);
+            CoreState.Undo.Push(replacementEdit);
+            Assert.Single(CoreState.Undo.UndoBuffer);
+
+            CoreState.Undo.RunUndo();
+
+            Assert.Equal(0u, rom.u8(0x800));
+            Assert.Equal("original", comment.At(TableBase + 8));
+            Assert.True(CoreState.Undo.CanRedo);
         }
 
         [Fact]

--- a/FEBuilderGBA.Core.Tests/SongTableExpansionCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/SongTableExpansionCoreTests.cs
@@ -188,6 +188,9 @@ namespace FEBuilderGBA.Core.Tests
         public void Undo_GrownRom_RestoresDestinationCacheCapturedBeforeShrink()
         {
             ROM rom = MakeRom(3, addFreeSpace: false);
+            byte[] unaligned = new byte[rom.Data.Length + 1];
+            Array.Copy(rom.Data, unaligned, rom.Data.Length);
+            rom.SwapNewROMDataDirect(unaligned);
             CoreState.ROM = rom;
             CoreState.Undo = new Undo();
             var comment = new HeadlessEtcCache();
@@ -203,6 +206,7 @@ namespace FEBuilderGBA.Core.Tests
                 result = SongTableExpansionCore.Expand(rom, 5);
             Assert.True(result.Success, result.Error);
             CoreState.Undo.Push(undo);
+            uint expandedLength = (uint)rom.Data.Length;
 
             Assert.Equal("moved", comment.At(result.NewBaseAddress + 8));
             CoreState.Undo.RunUndo();
@@ -211,6 +215,10 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Equal("moved", comment.At(TableBase + 8));
             Assert.Equal(
                 "destination-before", comment.At(originalLength + 8));
+
+            Assert.True(CoreState.Undo.RunRedo());
+            Assert.Equal(expandedLength, (uint)rom.Data.Length);
+            Assert.Equal("moved", comment.At(result.NewBaseAddress + 8));
         }
 
         [Fact]

--- a/FEBuilderGBA.Core/CoreState.cs
+++ b/FEBuilderGBA.Core/CoreState.cs
@@ -1,9 +1,110 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 
 namespace FEBuilderGBA
 {
+    public readonly struct EtcCacheRange
+    {
+        public const ulong AddressSpaceEnd = 1UL << 32;
+
+        public EtcCacheRange(uint start, ulong endExclusive)
+        {
+            if (endExclusive < start || endExclusive > AddressSpaceEnd)
+                throw new ArgumentOutOfRangeException(nameof(endExclusive));
+            Start = start;
+            EndExclusive = endExclusive;
+        }
+
+        public EtcCacheRange(uint start, uint size)
+            : this(start, (ulong)start + size)
+        {
+        }
+
+        public uint Start { get; }
+        public ulong EndExclusive { get; }
+        public bool Contains(uint address) =>
+            address >= Start && (ulong)address < EndExclusive;
+
+        public static EtcCacheRange All { get; } =
+            new EtcCacheRange(0, AddressSpaceEnd);
+    }
+
+    public sealed class EtcCacheSnapshot
+    {
+        readonly EtcCacheRange[] _ranges;
+        readonly Dictionary<uint, string> _entries;
+        readonly ReadOnlyCollection<EtcCacheRange> _readOnlyRanges;
+        readonly ReadOnlyDictionary<uint, string> _readOnlyEntries;
+
+        internal EtcCacheSnapshot(
+            IReadOnlyList<EtcCacheRange> ranges,
+            IReadOnlyDictionary<uint, string> entries)
+        {
+            _ranges = new EtcCacheRange[ranges.Count];
+            for (int i = 0; i < ranges.Count; i++)
+                _ranges[i] = ranges[i];
+            _entries = new Dictionary<uint, string>(entries);
+            _readOnlyRanges = Array.AsReadOnly(_ranges);
+            _readOnlyEntries =
+                new ReadOnlyDictionary<uint, string>(_entries);
+        }
+
+        public IReadOnlyList<EtcCacheRange> Ranges => _readOnlyRanges;
+        public IReadOnlyDictionary<uint, string> Entries => _readOnlyEntries;
+        internal bool CoversAll =>
+            _ranges.Length == 1
+            && _ranges[0].Start == 0
+            && _ranges[0].EndExclusive == EtcCacheRange.AddressSpaceEnd;
+
+        internal static EtcCacheSnapshot Capture(
+            IReadOnlyDictionary<uint, string> source,
+            IReadOnlyList<EtcCacheRange> ranges)
+        {
+            var entries = new Dictionary<uint, string>();
+            foreach (var pair in source)
+            {
+                if (Contains(ranges, pair.Key))
+                    entries[pair.Key] = pair.Value;
+            }
+            return new EtcCacheSnapshot(ranges, entries);
+        }
+
+        internal void RestoreRanges(Dictionary<uint, string> target)
+        {
+            var remove = new List<uint>();
+            foreach (uint key in target.Keys)
+            {
+                if (Contains(_ranges, key))
+                    remove.Add(key);
+            }
+            foreach (uint key in remove)
+                target.Remove(key);
+            foreach (var pair in _entries)
+                target[pair.Key] = pair.Value;
+        }
+
+        internal void RestoreAll(Dictionary<uint, string> target)
+        {
+            target.Clear();
+            foreach (var pair in _entries)
+                target[pair.Key] = pair.Value;
+        }
+
+        static bool Contains(
+            IReadOnlyList<EtcCacheRange> ranges,
+            uint address)
+        {
+            for (int i = 0; i < ranges.Count; i++)
+            {
+                if (ranges[i].Contains(address))
+                    return true;
+            }
+            return false;
+        }
+    }
+
     /// <summary>
     /// Interface for cache classes (EtcCache) needed by Core.
     /// Write methods used by Undo; read methods used by DisASMTrumb, etc.
@@ -30,6 +131,23 @@ namespace FEBuilderGBA
         /// continue to compile without breaking.
         /// </summary>
         void RepointEtcData(uint oldAddr, uint oldSize, uint newAddr) { }
+
+        bool TryCaptureAll(out EtcCacheSnapshot snapshot)
+        {
+            snapshot = null!;
+            return false;
+        }
+
+        bool TryCaptureRanges(
+            IReadOnlyList<EtcCacheRange> ranges,
+            out EtcCacheSnapshot snapshot)
+        {
+            snapshot = null!;
+            return false;
+        }
+
+        bool TryRestoreAll(EtcCacheSnapshot snapshot) => false;
+        bool TryRestoreRanges(EtcCacheSnapshot snapshot) => false;
     }
 
     /// <summary>

--- a/FEBuilderGBA.Core/DataExpansionCore.cs
+++ b/FEBuilderGBA.Core/DataExpansionCore.cs
@@ -73,6 +73,14 @@ namespace FEBuilderGBA
             /// parameter docs. Default <c>false</c> (a single
             /// <c>0xFFFFFFFF</c> dword).</summary>
             public bool FullZeroTerminatorRow { get; set; } = false;
+
+            /// <summary>
+            /// Whether comment/lint cache entries should be moved immediately
+            /// with the table. Defaults to <c>true</c> for compatibility.
+            /// Transaction orchestrators may defer this until their post-move
+            /// audits pass.
+            /// </summary>
+            public bool RepointEtcCaches { get; set; } = true;
         }
 
         /// <summary>
@@ -614,7 +622,7 @@ namespace FEBuilderGBA
             // MoveToFreeSapceForm.RepointEtcData behavior). KnownGap — ROM
             // undo does NOT reverse this; the caches stay pointing at the
             // new addresses after rollback.
-            if (oldTableSize > 0)
+            if (opts.RepointEtcCaches && oldTableSize > 0)
             {
                 CoreState.CommentCache?.RepointEtcData(oldBase, oldTableSize, newBase);
                 CoreState.LintCache?.RepointEtcData(oldBase, oldTableSize, newBase);

--- a/FEBuilderGBA.Core/EtcCache.cs
+++ b/FEBuilderGBA.Core/EtcCache.cs
@@ -9,6 +9,12 @@ namespace FEBuilderGBA
 {
     public class EtcCache : IEtcCache
     {
+        internal EtcCache()
+        {
+            Type = "";
+            Cache = new Dictionary<uint, string>();
+        }
+
         public EtcCache(string type)
         {
             this.Type = type;

--- a/FEBuilderGBA.Core/EtcCache.cs
+++ b/FEBuilderGBA.Core/EtcCache.cs
@@ -151,22 +151,56 @@ namespace FEBuilderGBA
 
         public void RepointEtcData(uint oldAddr, uint oldSize, uint newAddr)
         {
-            string fullfilename = U.ConfigEtcFilename(this.Type);
             Dictionary<uint, string> newDic = new Dictionary<uint, string>();
             foreach (var pair in this.Cache)
             {
-                if (pair.Key >= oldAddr && pair.Key < oldAddr + oldSize)
-                {
-                    uint addr = (pair.Key - oldAddr) + newAddr;
-                    newDic[(pair.Key - oldAddr) + newAddr] = pair.Value;
-                }
-                else
+                bool inWindow = oldSize != 0
+                    && (ulong)pair.Key >= oldAddr
+                    && (ulong)pair.Key < (ulong)oldAddr + oldSize;
+                if (!inWindow)
                 {
                     newDic[pair.Key] = pair.Value;
                 }
             }
+            foreach (var pair in this.Cache)
+            {
+                bool inWindow = oldSize != 0
+                    && (ulong)pair.Key >= oldAddr
+                    && (ulong)pair.Key < (ulong)oldAddr + oldSize;
+                if (inWindow)
+                    newDic[(pair.Key - oldAddr) + newAddr] = pair.Value;
+            }
 
             this.Cache = newDic;
+        }
+
+        public bool TryCaptureAll(out EtcCacheSnapshot snapshot)
+        {
+            snapshot = EtcCacheSnapshot.Capture(
+                Cache, new[] { EtcCacheRange.All });
+            return true;
+        }
+
+        public bool TryCaptureRanges(
+            IReadOnlyList<EtcCacheRange> ranges,
+            out EtcCacheSnapshot snapshot)
+        {
+            snapshot = EtcCacheSnapshot.Capture(Cache, ranges);
+            return true;
+        }
+
+        public bool TryRestoreAll(EtcCacheSnapshot snapshot)
+        {
+            if (snapshot == null || !snapshot.CoversAll) return false;
+            snapshot.RestoreAll(Cache);
+            return true;
+        }
+
+        public bool TryRestoreRanges(EtcCacheSnapshot snapshot)
+        {
+            if (snapshot == null) return false;
+            snapshot.RestoreRanges(Cache);
+            return true;
         }
         public void ShrinkEtcData(uint blank_start_addr, uint blank_size)
         {

--- a/FEBuilderGBA.Core/HeadlessEtcCache.cs
+++ b/FEBuilderGBA.Core/HeadlessEtcCache.cs
@@ -72,21 +72,54 @@ namespace FEBuilderGBA
                     ? pair.Key >= oldAddr
                     : pair.Key >= oldAddr && pair.Key < oldEnd;
                 if (inWindow)
-                {
-                    uint relocated = (pair.Key - oldAddr) + newAddr;
-                    newStore[relocated] = pair.Value;
-                }
+                    continue;
                 else
                 {
                     newStore[pair.Key] = pair.Value;
                 }
             }
-            // Swap the backing store contents. (Avoid the word "atomically" —
-            // this method is not thread-safe; the clear-then-repopulate window
-            // is observable to other threads. Copilot bot review on PR #635
-            // inline #3.)
+            foreach (var pair in _store)
+            {
+                bool inWindow = windowWraps
+                    ? pair.Key >= oldAddr
+                    : pair.Key >= oldAddr && pair.Key < oldEnd;
+                if (inWindow)
+                {
+                    uint relocated = (pair.Key - oldAddr) + newAddr;
+                    newStore[relocated] = pair.Value;
+                }
+            }
             _store.Clear();
             foreach (var p in newStore) _store[p.Key] = p.Value;
+        }
+
+        public bool TryCaptureAll(out EtcCacheSnapshot snapshot)
+        {
+            snapshot = EtcCacheSnapshot.Capture(
+                _store, new[] { EtcCacheRange.All });
+            return true;
+        }
+
+        public bool TryCaptureRanges(
+            IReadOnlyList<EtcCacheRange> ranges,
+            out EtcCacheSnapshot snapshot)
+        {
+            snapshot = EtcCacheSnapshot.Capture(_store, ranges);
+            return true;
+        }
+
+        public bool TryRestoreAll(EtcCacheSnapshot snapshot)
+        {
+            if (snapshot == null || !snapshot.CoversAll) return false;
+            snapshot.RestoreAll(_store);
+            return true;
+        }
+
+        public bool TryRestoreRanges(EtcCacheSnapshot snapshot)
+        {
+            if (snapshot == null) return false;
+            snapshot.RestoreRanges(_store);
+            return true;
         }
     }
 }

--- a/FEBuilderGBA.Core/Rom.cs
+++ b/FEBuilderGBA.Core/Rom.cs
@@ -890,7 +890,15 @@ namespace FEBuilderGBA
 
         internal bool write_resize_data_for_undo(uint resize)
         {
-            return write_resize_data(resize, trimCommentCache: false);
+            if (!write_resize_data(resize, trimCommentCache: false))
+                return false;
+            if ((uint)Data.Length == resize)
+                return true;
+
+            byte[] exactData = Data;
+            Array.Resize(ref exactData, checked((int)resize));
+            SwapNewROMDataDirect(exactData);
+            return true;
         }
 
         bool write_resize_data(uint resize, bool trimCommentCache)

--- a/FEBuilderGBA.Core/Rom.cs
+++ b/FEBuilderGBA.Core/Rom.cs
@@ -1212,6 +1212,10 @@ namespace FEBuilderGBA
         {
             this.Data = newROMData;
         }
+        internal void RestoreModifiedFlag(bool modified)
+        {
+            Modified = modified;
+        }
         public bool CompareByte(uint addr, byte[] bin)
         {
             if (addr + bin.Length >= this.Data.Length)

--- a/FEBuilderGBA.Core/Rom.cs
+++ b/FEBuilderGBA.Core/Rom.cs
@@ -885,6 +885,16 @@ namespace FEBuilderGBA
 
         public bool write_resize_data(uint resize)
         {
+            return write_resize_data(resize, trimCommentCache: true);
+        }
+
+        internal bool write_resize_data_for_undo(uint resize)
+        {
+            return write_resize_data(resize, trimCommentCache: false);
+        }
+
+        bool write_resize_data(uint resize, bool trimCommentCache)
+        {
             if (this.Data.Length == resize)
             {//サイズが同一なら何もしない
                 return true;
@@ -894,7 +904,7 @@ namespace FEBuilderGBA
                 CoreState.Services.ShowError(string.Format("32MB(0x02000000)より大きな領域を割り当てることはできません。\r\n要求サイズ:{0}", U.ToHexString(resize)));
                 return false;
             }
-            if (CoreState.CommentCache != null)
+            if (trimCommentCache && CoreState.CommentCache != null)
             {
                 CoreState.CommentCache.RemoveOverRange(resize);
             }

--- a/FEBuilderGBA.Core/SongTableExpansionCore.cs
+++ b/FEBuilderGBA.Core/SongTableExpansionCore.cs
@@ -1,0 +1,346 @@
+using System;
+using System.Collections.Generic;
+
+namespace FEBuilderGBA
+{
+    public static class SongTableExpansionCore
+    {
+        public const uint MaxSongCount = 32766;
+
+        const uint EntrySize = 8;
+        const int MaxPlausibleRepointSlots = 64;
+
+        public static bool ShouldShowExpansion(
+            ROM rom,
+            bool configuredShow)
+        {
+            if (configuredShow) return true;
+            if (rom?.RomInfo == null) return false;
+
+            uint ptr = rom.RomInfo.sound_table_pointer;
+            if (ptr == 0 || ptr + 3 >= (uint)rom.Data.Length)
+                return false;
+            return rom.u32(ptr) >= rom.RomInfo.extends_address;
+        }
+
+        public static DataExpansionCore.ExpandResult Expand(
+            ROM rom,
+            uint newCount)
+        {
+            if (CoreState.IsDecompMode)
+                return Failure("Song Table expansion is unavailable in decomp mode.");
+            if (rom?.RomInfo == null)
+                return Failure("ROM not loaded.");
+
+            uint pointerSlot = RebuildProducerCore.GetSoundTablePointer(rom);
+            if (pointerSlot == 0
+                || pointerSlot + 3 >= (uint)rom.Data.Length)
+            {
+                return Failure("This ROM has no valid Song Table pointer.");
+            }
+
+            uint oldBase = rom.p32(pointerSlot);
+            if (!U.isSafetyOffset(oldBase))
+                return Failure("The Song Table pointer is out of ROM bounds.");
+
+            uint currentCount = CountEntries(rom, oldBase);
+            if (currentCount == 0)
+                return Failure("Cannot expand an empty Song Table because row 0 is unavailable.");
+            if (newCount <= currentCount)
+            {
+                return Failure(
+                    $"New count ({newCount}) must be greater than current count ({currentCount}).");
+            }
+            if (newCount > MaxSongCount)
+            {
+                return Failure(
+                    $"New count ({newCount}) exceeds the maximum ({MaxSongCount}).");
+            }
+
+            if (!TryCaptureFullCache(
+                    CoreState.CommentCache,
+                    "comment",
+                    out CacheState commentBefore,
+                    out string cacheError))
+            {
+                return Failure(cacheError);
+            }
+            if (!TryCaptureFullCache(
+                    CoreState.LintCache,
+                    "lint",
+                    out CacheState lintBefore,
+                    out cacheError))
+            {
+                return Failure(cacheError);
+            }
+
+            byte[] romBefore = (byte[])rom.Data.Clone();
+            Undo.UndoData undo = ROM.GetAmbientUndoData();
+            int undoStart = undo?.list?.Count ?? 0;
+
+            try
+            {
+                DataExpansionCore.ExpandResult result =
+                    DataExpansionCore.ExpandTableTo(
+                        rom,
+                        pointerSlot,
+                        EntrySize,
+                        currentCount,
+                        newCount,
+                        new DataExpansionCore.ExpandOptions
+                        {
+                            Fill = DataExpansionCore.ExpandFill.First,
+                            Repoint =
+                                DataExpansionCore.ExpandRepoint.RawAndLdrAll,
+                            FullZeroTerminatorRow = false,
+                            RepointEtcCaches = false,
+                        });
+
+                if (!result.Success)
+                {
+                    RestoreFailure(
+                        rom, romBefore, commentBefore, lintBefore,
+                        undo, undoStart);
+                    return result;
+                }
+
+                IReadOnlyList<uint> slots =
+                    result.RepointedSlots ?? Array.Empty<uint>();
+                if (slots.Count == 0)
+                {
+                    RestoreFailure(
+                        rom, romBefore, commentBefore, lintBefore,
+                        undo, undoStart);
+                    return Failure(
+                        "Song Table expansion found no references to repoint.");
+                }
+
+                bool canonicalCovered = false;
+                foreach (uint slot in slots)
+                {
+                    if (slot == pointerSlot)
+                    {
+                        canonicalCovered = true;
+                        break;
+                    }
+                }
+                if (!canonicalCovered)
+                {
+                    RestoreFailure(
+                        rom, romBefore, commentBefore, lintBefore,
+                        undo, undoStart);
+                    return Failure(
+                        "Song Table expansion did not repoint the canonical pointer slot.");
+                }
+                if (slots.Count > MaxPlausibleRepointSlots)
+                {
+                    RestoreFailure(
+                        rom, romBefore, commentBefore, lintBefore,
+                        undo, undoStart);
+                    return Failure(
+                        $"Song Table expansion found an implausible {slots.Count} references.");
+                }
+
+                if (!RestoreFullCache(
+                        CoreState.CommentCache, commentBefore)
+                    || !RestoreFullCache(
+                        CoreState.LintCache, lintBefore))
+                {
+                    RestoreFailure(
+                        rom, romBefore, commentBefore, lintBefore,
+                        undo, undoStart);
+                    return Failure(
+                        "Song Table expansion could not restore the transactional caches.");
+                }
+
+                uint oldTableSize = currentCount * EntrySize;
+                var ranges = new[]
+                {
+                    new EtcCacheRange(oldBase, oldTableSize),
+                    new EtcCacheRange(result.NewBaseAddress, oldTableSize),
+                };
+
+                if (!TryCaptureRanges(
+                        CoreState.CommentCache,
+                        commentBefore,
+                        ranges,
+                        "comment",
+                        out EtcCacheSnapshot commentPatch,
+                        out cacheError)
+                    || !TryCaptureRanges(
+                        CoreState.LintCache,
+                        lintBefore,
+                        ranges,
+                        "lint",
+                        out EtcCacheSnapshot lintPatch,
+                        out cacheError))
+                {
+                    RestoreFailure(
+                        rom, romBefore, commentBefore, lintBefore,
+                        undo, undoStart);
+                    return Failure(cacheError);
+                }
+
+                CoreState.CommentCache?.RepointEtcData(
+                    oldBase, oldTableSize, result.NewBaseAddress);
+                CoreState.LintCache?.RepointEtcData(
+                    oldBase, oldTableSize, result.NewBaseAddress);
+
+                if (undo != null)
+                {
+                    if (commentPatch != null)
+                    {
+                        undo.AddCachePatch(
+                            Undo.EtcCacheSlot.Comment,
+                            commentPatch);
+                    }
+                    if (lintPatch != null)
+                    {
+                        undo.AddCachePatch(
+                            Undo.EtcCacheSlot.Lint,
+                            lintPatch);
+                    }
+                }
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                RestoreFailure(
+                    rom, romBefore, commentBefore, lintBefore,
+                    undo, undoStart);
+                Log.Error(
+                    "SongTableExpansionCore.Expand failed: " +
+                    ex.ToString());
+                return Failure("Song Table expansion failed: " + ex.Message);
+            }
+        }
+
+        static uint CountEntries(ROM rom, uint baseAddr)
+        {
+            uint count = 0;
+            while (count < MaxSongCount)
+            {
+                uint addr = baseAddr + count * EntrySize;
+                if (addr + EntrySize - 1 >= (uint)rom.Data.Length)
+                    break;
+                if (!U.isPointer(rom.u32(addr)))
+                    break;
+                count++;
+            }
+            return count;
+        }
+
+        static bool TryCaptureFullCache(
+            IEtcCache cache,
+            string name,
+            out CacheState state,
+            out string error)
+        {
+            if (cache == null)
+            {
+                state = new CacheState(false, null);
+                error = "";
+                return true;
+            }
+            if (!cache.TryCaptureAll(out EtcCacheSnapshot snapshot)
+                || !cache.TryRestoreAll(snapshot))
+            {
+                state = default;
+                error =
+                    $"Song Table expansion requires transactional {name} cache support.";
+                return false;
+            }
+
+            state = new CacheState(true, snapshot);
+            error = "";
+            return true;
+        }
+
+        static bool TryCaptureRanges(
+            IEtcCache cache,
+            CacheState before,
+            IReadOnlyList<EtcCacheRange> ranges,
+            string name,
+            out EtcCacheSnapshot snapshot,
+            out string error)
+        {
+            snapshot = null;
+            if (!before.HadCache)
+            {
+                error = "";
+                return true;
+            }
+            if (cache == null
+                || !cache.TryCaptureRanges(ranges, out snapshot))
+            {
+                error =
+                    $"Song Table expansion could not capture the live {name} cache.";
+                return false;
+            }
+
+            error = "";
+            return true;
+        }
+
+        static void RestoreFailure(
+            ROM rom,
+            byte[] romBefore,
+            CacheState commentBefore,
+            CacheState lintBefore,
+            Undo.UndoData undo,
+            int undoStart)
+        {
+            if (rom.Data.Length != romBefore.Length)
+                rom.write_resize_data((uint)romBefore.Length);
+            Array.Copy(romBefore, rom.Data, romBefore.Length);
+
+            RestoreFullCache(CoreState.CommentCache, commentBefore);
+            RestoreFullCache(CoreState.LintCache, lintBefore);
+
+            if (undo?.list != null && undo.list.Count > undoStart)
+                undo.list.RemoveRange(
+                    undoStart, undo.list.Count - undoStart);
+        }
+
+        static bool RestoreFullCache(
+            IEtcCache cache,
+            CacheState state)
+        {
+            if (!state.HadCache)
+                return true;
+            if (cache == null
+                || state.Snapshot == null
+                || !cache.TryRestoreAll(state.Snapshot))
+            {
+                Log.Error(
+                    "Song Table cache restore failed because the live cache is unavailable or unsupported.");
+                return false;
+            }
+            return true;
+        }
+
+        static DataExpansionCore.ExpandResult Failure(string error)
+        {
+            return new DataExpansionCore.ExpandResult
+            {
+                Success = false,
+                Error = error,
+            };
+        }
+
+        readonly struct CacheState
+        {
+            public CacheState(
+                bool hadCache,
+                EtcCacheSnapshot snapshot)
+            {
+                HadCache = hadCache;
+                Snapshot = snapshot;
+            }
+
+            public bool HadCache { get; }
+            public EtcCacheSnapshot Snapshot { get; }
+        }
+    }
+}

--- a/FEBuilderGBA.Core/SongTableExpansionCore.cs
+++ b/FEBuilderGBA.Core/SongTableExpansionCore.cs
@@ -40,7 +40,7 @@ namespace FEBuilderGBA
             }
 
             uint oldBase = rom.p32(pointerSlot);
-            if (!U.isSafetyOffset(oldBase))
+            if (!U.isSafetyOffset(oldBase, rom))
                 return Failure("The Song Table pointer is out of ROM bounds.");
 
             uint currentCount = CountEntries(rom, oldBase);
@@ -75,6 +75,7 @@ namespace FEBuilderGBA
             }
 
             byte[] romBefore = (byte[])rom.Data.Clone();
+            bool modifiedBefore = rom.Modified;
             Undo.UndoData undo = ROM.GetAmbientUndoData();
             int undoStart = undo?.list?.Count ?? 0;
 
@@ -100,7 +101,7 @@ namespace FEBuilderGBA
                 {
                     RestoreFailure(
                         rom, romBefore, commentBefore, lintBefore,
-                        undo, undoStart);
+                        undo, undoStart, modifiedBefore);
                     return result;
                 }
 
@@ -110,7 +111,7 @@ namespace FEBuilderGBA
                 {
                     RestoreFailure(
                         rom, romBefore, commentBefore, lintBefore,
-                        undo, undoStart);
+                        undo, undoStart, modifiedBefore);
                     return Failure(
                         "Song Table expansion found no references to repoint.");
                 }
@@ -128,7 +129,7 @@ namespace FEBuilderGBA
                 {
                     RestoreFailure(
                         rom, romBefore, commentBefore, lintBefore,
-                        undo, undoStart);
+                        undo, undoStart, modifiedBefore);
                     return Failure(
                         "Song Table expansion did not repoint the canonical pointer slot.");
                 }
@@ -136,7 +137,7 @@ namespace FEBuilderGBA
                 {
                     RestoreFailure(
                         rom, romBefore, commentBefore, lintBefore,
-                        undo, undoStart);
+                        undo, undoStart, modifiedBefore);
                     return Failure(
                         $"Song Table expansion found an implausible {slots.Count} references.");
                 }
@@ -148,7 +149,7 @@ namespace FEBuilderGBA
                 {
                     RestoreFailure(
                         rom, romBefore, commentBefore, lintBefore,
-                        undo, undoStart);
+                        undo, undoStart, modifiedBefore);
                     return Failure(
                         "Song Table expansion could not restore the transactional caches.");
                 }
@@ -177,7 +178,7 @@ namespace FEBuilderGBA
                 {
                     RestoreFailure(
                         rom, romBefore, commentBefore, lintBefore,
-                        undo, undoStart);
+                        undo, undoStart, modifiedBefore);
                     return Failure(cacheError);
                 }
 
@@ -208,7 +209,7 @@ namespace FEBuilderGBA
             {
                 RestoreFailure(
                     rom, romBefore, commentBefore, lintBefore,
-                    undo, undoStart);
+                    undo, undoStart, modifiedBefore);
                 Log.Error(
                     "SongTableExpansionCore.Expand failed: " +
                     ex.ToString());
@@ -272,7 +273,8 @@ namespace FEBuilderGBA
                 return true;
             }
             if (cache == null
-                || !cache.TryCaptureRanges(ranges, out snapshot))
+                || !cache.TryCaptureRanges(ranges, out snapshot)
+                || !cache.TryRestoreRanges(snapshot))
             {
                 error =
                     $"Song Table expansion could not capture the live {name} cache.";
@@ -289,11 +291,17 @@ namespace FEBuilderGBA
             CacheState commentBefore,
             CacheState lintBefore,
             Undo.UndoData undo,
-            int undoStart)
+            int undoStart,
+            bool modifiedBefore)
         {
             if (rom.Data.Length != romBefore.Length)
+            {
                 rom.write_resize_data((uint)romBefore.Length);
+                ImageImportCore.RestoreExactRomLengthAfterUndo(
+                    rom, (uint)romBefore.Length);
+            }
             Array.Copy(romBefore, rom.Data, romBefore.Length);
+            rom.RestoreModifiedFlag(modifiedBefore);
 
             RestoreFullCache(CoreState.CommentCache, commentBefore);
             RestoreFullCache(CoreState.LintCache, lintBefore);

--- a/FEBuilderGBA.Core/Undo.cs
+++ b/FEBuilderGBA.Core/Undo.cs
@@ -313,7 +313,8 @@ namespace FEBuilderGBA
                 //まずロールバックする前の状態に戻す.
                 if (this.RollBackCancelBackup.Length != rom.Data.Length)
                 {//長さが増える場合、ROMを増設する.
-                    rom.write_resize_data((uint)this.RollBackCancelBackup.Length);
+                    rom.write_resize_data_for_undo(
+                        (uint)this.RollBackCancelBackup.Length);
                 }
                 rom.write_range(0, this.RollBackCancelBackup);
             }
@@ -407,7 +408,7 @@ namespace FEBuilderGBA
         {
             if (rom.Data.Length < ud.filesize)
             {//ROMサイズが増やさないといけないなら増やす.
-                rom.write_resize_data(ud.filesize);
+                rom.write_resize_data_for_undo(ud.filesize);
             }
 
             for(int i = 0 ; i < ud.list.Count ; i++)
@@ -417,7 +418,7 @@ namespace FEBuilderGBA
 
             if (rom.Data.Length > ud.filesize)
             {//ROMサイズを減らさないといけないなら、ここで減らす.
-                rom.write_resize_data(ud.filesize);
+                rom.write_resize_data_for_undo(ud.filesize);
             }
         }
 

--- a/FEBuilderGBA.Core/Undo.cs
+++ b/FEBuilderGBA.Core/Undo.cs
@@ -7,6 +7,18 @@ namespace FEBuilderGBA
 {
     public class Undo
     {
+        internal enum EtcCacheSlot
+        {
+            Comment,
+            Lint,
+        }
+
+        internal sealed class EtcCacheUndoPatch
+        {
+            public EtcCacheSlot Slot { get; init; }
+            public EtcCacheSnapshot Snapshot { get; init; }
+        }
+
         public class UndoPostion
         {
             public uint addr { get; internal set; }
@@ -44,7 +56,18 @@ namespace FEBuilderGBA
             public List<UndoPostion> list { get; internal set; }
             public uint filesize { get; internal set; }
             public bool is_f5test { get; internal set; }
+            internal List<EtcCacheUndoPatch> CachePatches { get; } = new();
 
+            internal void AddCachePatch(
+                EtcCacheSlot slot,
+                EtcCacheSnapshot snapshot)
+            {
+                CachePatches.Add(new EtcCacheUndoPatch
+                {
+                    Slot = slot,
+                    Snapshot = snapshot,
+                });
+            }
         };
 
         /// <summary>
@@ -79,6 +102,14 @@ namespace FEBuilderGBA
             this.PostionWhenFileSaving = this.Postion;
         }
         byte[] RollBackCancelBackup; //ロールバックをキャンセルするためのバックアップ
+        CacheTipBackup RollBackCancelCommentCacheBackup;
+        CacheTipBackup RollBackCancelLintCacheBackup;
+
+        sealed class CacheTipBackup
+        {
+            public bool HadCache { get; init; }
+            public EtcCacheSnapshot Snapshot { get; init; }
+        }
 
         public Undo()
         {
@@ -145,6 +176,8 @@ namespace FEBuilderGBA
                 this.UndoBuffer.RemoveRange(this.Postion, this.UndoBuffer.Count - this.Postion);
                 //状況が変わるので、ロールバックバッファを破棄
                 this.RollBackCancelBackup = null;
+                this.RollBackCancelCommentCacheBackup = null;
+                this.RollBackCancelLintCacheBackup = null;
             }
             this.UndoBuffer.Add(ud);
             this.Postion = this.UndoBuffer.Count;
@@ -264,6 +297,10 @@ namespace FEBuilderGBA
             {
                 //ロールバックをキャンセルできるようにするために、現状のROMを記録しておく.
                 this.RollBackCancelBackup = (byte[])rom.Data.Clone();
+                this.RollBackCancelCommentCacheBackup =
+                    CaptureCacheTip(CoreState.CommentCache);
+                this.RollBackCancelLintCacheBackup =
+                    CaptureCacheTip(CoreState.LintCache);
             }
             else
             {
@@ -287,8 +324,84 @@ namespace FEBuilderGBA
                 Patch(this.UndoBuffer[i], rom);
             }
 
+            RestoreCaches(pos);
             this.Postion = pos;
             return true;
+        }
+
+        static CacheTipBackup CaptureCacheTip(IEtcCache cache)
+        {
+            if (cache == null)
+                return new CacheTipBackup { HadCache = false };
+
+            if (!cache.TryCaptureAll(out EtcCacheSnapshot snapshot))
+            {
+                Log.Error("Undo cache snapshot is unsupported; cache undo will be skipped.");
+                return new CacheTipBackup { HadCache = true };
+            }
+
+            return new CacheTipBackup
+            {
+                HadCache = true,
+                Snapshot = snapshot,
+            };
+        }
+
+        void RestoreCaches(int pos)
+        {
+            RestoreCache(
+                EtcCacheSlot.Comment,
+                RollBackCancelCommentCacheBackup,
+                pos);
+            RestoreCache(
+                EtcCacheSlot.Lint,
+                RollBackCancelLintCacheBackup,
+                pos);
+        }
+
+        void RestoreCache(
+            EtcCacheSlot slot,
+            CacheTipBackup backup,
+            int pos)
+        {
+            if (backup == null || !backup.HadCache)
+                return;
+
+            IEtcCache cache = GetLiveCache(slot);
+            if (cache == null || backup.Snapshot == null)
+            {
+                Log.Error("Undo cache restore skipped because the live cache is unavailable or unsupported.");
+                return;
+            }
+            if (!cache.TryRestoreAll(backup.Snapshot))
+            {
+                Log.Error("Undo cache restore is unsupported by the live cache.");
+                return;
+            }
+
+            for (int i = this.UndoBuffer.Count - 1; i >= pos; i--)
+            {
+                List<EtcCacheUndoPatch> patches =
+                    this.UndoBuffer[i].CachePatches;
+                for (int n = patches.Count - 1; n >= 0; n--)
+                {
+                    EtcCacheUndoPatch patch = patches[n];
+                    if (patch.Slot != slot)
+                        continue;
+                    if (!cache.TryRestoreRanges(patch.Snapshot))
+                    {
+                        Log.Error("Undo cache range restore is unsupported by the live cache.");
+                        return;
+                    }
+                }
+            }
+        }
+
+        static IEtcCache GetLiveCache(EtcCacheSlot slot)
+        {
+            return slot == EtcCacheSlot.Comment
+                ? CoreState.CommentCache
+                : CoreState.LintCache;
         }
         void Patch(UndoData ud,ROM rom)
         {

--- a/FEBuilderGBA.Core/Undo.cs
+++ b/FEBuilderGBA.Core/Undo.cs
@@ -374,26 +374,50 @@ namespace FEBuilderGBA
                 Log.Error("Undo cache restore skipped because the live cache is unavailable or unsupported.");
                 return;
             }
-            if (!cache.TryRestoreAll(backup.Snapshot))
+
+            var patches = new List<EtcCacheUndoPatch>();
+            for (int i = this.UndoBuffer.Count - 1; i >= pos; i--)
+            {
+                List<EtcCacheUndoPatch> recordPatches =
+                    this.UndoBuffer[i].CachePatches;
+                for (int n = recordPatches.Count - 1; n >= 0; n--)
+                {
+                    EtcCacheUndoPatch patch = recordPatches[n];
+                    if (patch.Slot == slot)
+                        patches.Add(patch);
+                }
+            }
+
+            if (!cache.TryCaptureAll(out EtcCacheSnapshot current)
+                || !cache.TryRestoreAll(current))
             {
                 Log.Error("Undo cache restore is unsupported by the live cache.");
                 return;
             }
 
-            for (int i = this.UndoBuffer.Count - 1; i >= pos; i--)
+            foreach (EtcCacheUndoPatch patch in patches)
             {
-                List<EtcCacheUndoPatch> patches =
-                    this.UndoBuffer[i].CachePatches;
-                for (int n = patches.Count - 1; n >= 0; n--)
+                if (!cache.TryCaptureRanges(
+                        patch.Snapshot.Ranges,
+                        out EtcCacheSnapshot rangeProbe)
+                    || !cache.TryRestoreRanges(rangeProbe))
                 {
-                    EtcCacheUndoPatch patch = patches[n];
-                    if (patch.Slot != slot)
-                        continue;
-                    if (!cache.TryRestoreRanges(patch.Snapshot))
-                    {
-                        Log.Error("Undo cache range restore is unsupported by the live cache.");
-                        return;
-                    }
+                    Log.Error("Undo cache range restore is unsupported by the live cache.");
+                    return;
+                }
+            }
+
+            if (!cache.TryRestoreAll(backup.Snapshot))
+            {
+                Log.Error("Undo cache restore is unsupported by the live cache.");
+                return;
+            }
+            foreach (EtcCacheUndoPatch patch in patches)
+            {
+                if (!cache.TryRestoreRanges(patch.Snapshot))
+                {
+                    Log.Error("Undo cache range restore failed after capability validation.");
+                    return;
                 }
             }
         }

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -14709,3 +14709,8 @@ Git が見つかりません。Git をインストールして再試行するか
 
 :Git: {0} ...
 Git: {0} ...
+:Enter the new entry count for the Song Table (current: {0}, max: {1}).
+ソングテーブルの新しいエントリ数を入力してください（現在: {0}、最大: {1}）。
+
+:Expanded Song Table to {0} entries.
+ソングテーブルを{0}エントリに拡張しました。

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -28539,3 +28539,8 @@ FEMapCreator 是由 bwdyeti 创建的独立实用工具；FEBuilderGBA 不捆绑
 
 :Git: {0} ...
 Git: {0} ...
+:Enter the new entry count for the Song Table (current: {0}, max: {1}).
+请输入歌曲表的新条目数（当前：{0}，最大：{1}）。
+
+:Expanded Song Table to {0} entries.
+已将歌曲表扩展到{0}个条目。


### PR DESCRIPTION
## Summary

- add the WinForms-parity **Data Expansion** action to the Avalonia Song Table editor, honoring the existing visibility preference and already-expanded table state
- grow the engine table safely with row-0 fill, all raw/LDR reference repointing, explicit termination, exact rollback, and transactional comment/lint cache Undo/Redo
- remove the former 1,024-row scan cap, preserve the selected song after relocation, refuse decomp-mode mutation, and localize the new ja/zh runtime text

Accepted plan: https://github.com/laqieer/FEBuilderGBA/issues/2095#issuecomment-5302744446

Closes #2095

## Test plan

- [x] focused Song Table/cache transaction tests (23 Core + 15 Avalonia passed)
- [x] full `FEBuilderGBA.Core.Tests` suite (7,554 passed, 19 skipped)
- [x] full `FEBuilderGBA.Avalonia.Tests` suite (9,852 passed, 10 skipped)
- [x] full `FEBuilderGBA.Tests` suite (2,357 passed)
- [x] code-literal localization coverage
- [x] real desktop application render with a populated synthetic FE8U Song Table and the localized expansion control visible

## GUI Test Report

The real desktop Skia host rendered the populated Song Table editor at 1100×650. The localized **Data Expansion** button is visible beneath the list and the selected row remains fully usable.

![Avalonia Song Table data expansion](https://github.com/user-attachments/assets/c9aa5332-d000-41d5-a786-228e2efaea94)

Copilot CLI: 1.0.79
Model: GPT-5.6 Sol (gpt-5.6-sol)