### PR TITLE
docs(workflow): select available review models dynamically

### DIFF
--- a/DEVELOPMENT-WORKFLOW.md
+++ b/DEVELOPMENT-WORKFLOW.md
@@ -53,12 +53,12 @@ Any conflict selects the higher tier. An untrusted or cross-repository PR is alw
 
 Reviewer selection uses the local runtime inventory:
 
-1. Inventory source is local runtime metadata only. Keep only explicitly selectable text/chat models that can run review agents; exclude picker aliases, non-review specializations, and the active developer provider.
-2. Resolve provider identity from runtime metadata and fail closed when it is missing, contradictory, ambiguous, or capacity is unavailable/unclear.
-3. Keep each model's raw advertised index. Order models within a provider by `(advertised_index, model_id lexical)`.
-4. Order providers for plan review as Google, then xAI, then the remaining providers by `(first model advertised_index, provider_id)`. Order providers for PR review as xAI, then Google, then the remaining providers by the same tie-break.
-5. Normal review selects one eligible provider. High review selects two distinct eligible providers. Never duplicate providers or model IDs; if enough distinct providers are unavailable, fail closed.
-6. Record the inventory source, model IDs, provider IDs, and reviewer IDs in the Review Board entry.
+1. Inventory source is local runtime metadata only. Keep only explicitly selectable text/chat models whose runtime fields show they can run review agents; exclude picker aliases, non-review specializations, and the active developer provider. If runtime fields cannot determine candidate eligibility or review-agent capacity, fail closed.
+2. Resolve the developer provider identity and every candidate provider identity from runtime metadata only; never infer a provider from model names. Fail closed if any such identity is missing, contradictory, or ambiguous.
+3. Each candidate model must expose exactly one raw `advertised_index` in runtime metadata. Fail closed if it is absent, non-unique, or contradictory. Within each provider, sort models ascending by `(advertised_index, model_id lexical)` and retain the first model.
+4. Assign provider role bias by review stage: plan review `Google=0`, `xAI=1`, others `2`; PR review `xAI=0`, `Google=1`, others `2`. Sort providers ascending by `(role bias, first-model advertised_index, provider_id lexical)`.
+5. Normal review takes the first eligible provider. High review takes the first two distinct eligible providers. Never duplicate providers or model IDs; if too few distinct providers remain, fail closed.
+6. Record the inventory source, provider IDs, retained model IDs, and reviewer IDs in the Review Board entry.
 
 Each reviewer fetches the issue/plan/PR/diff from identifiers inside its own isolated invocation. Prompts contain only issue/PR numbers, accepted-plan URL, and current head SHA. Reports contain verdict, findings, and citations; normally under 4 KiB and never over 8 KiB.
 

--- a/DEVELOPMENT-WORKFLOW.md
+++ b/DEVELOPMENT-WORKFLOW.md
@@ -54,11 +54,11 @@ Any conflict selects the higher tier. An untrusted or cross-repository PR is alw
 Reviewer selection uses the local runtime inventory:
 
 1. Inventory source is local runtime metadata only. Keep only explicitly selectable text/chat models whose runtime fields show they can run review agents; exclude picker aliases, non-review specializations, and the active developer provider. If runtime fields cannot determine candidate eligibility or review-agent capacity, fail closed.
-2. Resolve the developer provider identity and every candidate provider identity from runtime metadata only; never infer a provider from model names. Fail closed if any such identity is missing, contradictory, or ambiguous.
-3. Each candidate model must expose exactly one raw `advertised_index` in runtime metadata. Fail closed if it is absent, non-unique, or contradictory. Within each provider, sort models ascending by `(advertised_index, model_id lexical)` and retain the first model.
+2. Resolve the developer provider identity and every candidate provider identity from runtime metadata only; never infer a provider from model names. Define `advertised_index` as the candidate's zero-based position in the raw runtime-advertised inventory order. Fail closed if any provider identity is missing, contradictory, or ambiguous, or if that raw order is unavailable or contradictory.
+3. Within each provider, sort models ascending by `(advertised_index, model_id lexical)` and retain the first model. If any eligible model ID appears under multiple providers or has a contradictory provider mapping, fail closed before provider selection.
 4. Assign provider role bias by review stage: plan review `Google=0`, `xAI=1`, others `2`; PR review `xAI=0`, `Google=1`, others `2`. Sort providers ascending by `(role bias, first-model advertised_index, provider_id lexical)`.
 5. Normal review takes the first eligible provider. High review takes the first two distinct eligible providers. Never duplicate providers or model IDs; if too few distinct providers remain, fail closed.
-6. Record the inventory source, provider IDs, retained model IDs, and reviewer IDs in the Review Board entry.
+6. Record the inventory source and only the selected provider IDs, model IDs, and reviewer IDs in the Review Board entry.
 
 Each reviewer fetches the issue/plan/PR/diff from identifiers inside its own isolated invocation. Prompts contain only issue/PR numbers, accepted-plan URL, and current head SHA. Reports contain verdict, findings, and citations; normally under 4 KiB and never over 8 KiB.
 
@@ -67,7 +67,7 @@ Post the consolidated signoff with:
 ```text
 Review Tier: low|normal|high
 Classifier Result: <tier and reason>
-Review Board: <inventory source; provider ids; model ids; reviewer ids, omitted for low>
+Review Board: <inventory source; selected provider ids; selected model ids; reviewer ids, omitted for low>
 Copilot CLI: <version>
 Model: <display-name> (<model-id>)
 ```

--- a/DEVELOPMENT-WORKFLOW.md
+++ b/DEVELOPMENT-WORKFLOW.md
@@ -51,13 +51,14 @@ Any conflict selects the higher tier. An untrusted or cross-repository PR is alw
 | Normal | One reviewer from a different provider | One reviewer from a different provider |
 | High | Two reviewers from distinct providers | Two reviewers from distinct providers; add `security-review` when security-relevant |
 
-Reviewer provider preference:
+Reviewer selection uses the local runtime inventory:
 
-1. Exclude the active developer model's provider.
-2. Prefer xAI (`grok-4.5`) for PR review and Google (`gemini-3.6-flash`) for plan review.
-3. For high risk, use both available different providers; use OpenAI (`gpt-5.6-sol`, fallback `gpt-5.5`) when the developer is not OpenAI or another provider is unavailable.
-4. Google fallback is `gemini-3.1-pro-preview`.
-5. Never duplicate model IDs. If the required number of distinct providers is unavailable, fail closed.
+1. Inventory source is local runtime metadata only. Keep only explicitly selectable text/chat models that can run review agents; exclude picker aliases, non-review specializations, and the active developer provider.
+2. Resolve provider identity from runtime metadata and fail closed when it is missing, contradictory, ambiguous, or capacity is unavailable/unclear.
+3. Keep each model's raw advertised index. Order models within a provider by `(advertised_index, model_id lexical)`.
+4. Order providers for plan review as Google, then xAI, then the remaining providers by `(first model advertised_index, provider_id)`. Order providers for PR review as xAI, then Google, then the remaining providers by the same tie-break.
+5. Normal review selects one eligible provider. High review selects two distinct eligible providers. Never duplicate providers or model IDs; if enough distinct providers are unavailable, fail closed.
+6. Record the inventory source, model IDs, provider IDs, and reviewer IDs in the Review Board entry.
 
 Each reviewer fetches the issue/plan/PR/diff from identifiers inside its own isolated invocation. Prompts contain only issue/PR numbers, accepted-plan URL, and current head SHA. Reports contain verdict, findings, and citations; normally under 4 KiB and never over 8 KiB.
 
@@ -66,7 +67,7 @@ Post the consolidated signoff with:
 ```text
 Review Tier: low|normal|high
 Classifier Result: <tier and reason>
-Review Board: <model ids, omitted for low>
+Review Board: <inventory source; provider ids; model ids; reviewer ids, omitted for low>
 Copilot CLI: <version>
 Model: <display-name> (<model-id>)
 ```


### PR DESCRIPTION
## Summary

- replace version-pinned reviewer model IDs with deterministic selection from the local runtime inventory
- preserve provider-distinct Normal/High gates, role preferences, isolation, signoff, and fail-closed behavior
- record the runtime inventory source plus selected provider/model/reviewer IDs for auditability

Accepted plan: https://github.com/laqieer/FEBuilderGBA/issues/2099#issuecomment-5313921912

Closes #2099

## Review risk

High — `DEVELOPMENT-WORKFLOW.md` is an exact high-risk path.

## Test plan

- [x] `python scripts\classify-review-risk.test.py` (25 passed)
- [x] `python scripts\classify_review_risk.py DEVELOPMENT-WORKFLOW.md` (`high`)
- [x] `git diff --check`

Copilot CLI: 1.0.80
Model: GPT-5.6 Sol (gpt-5.6-sol)