### PR TITLE
fix(avalonia): exit when main window closes

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/DesktopLifetimeShutdownModeTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/DesktopLifetimeShutdownModeTests.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+/// <summary>
+/// Regression guard for #2098: the desktop host must opt into
+/// ShutdownMode.OnMainWindowClose so closing the shell does not leave
+/// secondary editor windows orphaned under the default OnLastWindowClose mode.
+/// </summary>
+public class DesktopLifetimeShutdownModeTests
+{
+    static string RepoRoot()
+    {
+        string dir = AppContext.BaseDirectory;
+        while (dir != null && !File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+            dir = Path.GetDirectoryName(dir)!;
+        return dir ?? throw new InvalidOperationException("Cannot find solution root");
+    }
+
+    [Fact]
+    public void Program_StartsDesktopLifetime_WithMainWindowCloseShutdownMode()
+    {
+        string repo = RepoRoot();
+        string program = File.ReadAllText(Path.Combine(repo, "FEBuilderGBA.Avalonia", "Program.cs"));
+
+        Assert.Contains("StartWithClassicDesktopLifetime(args, ShutdownMode.OnMainWindowClose)", program);
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/DesktopLifetimeShutdownModeTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/DesktopLifetimeShutdownModeTests.cs
@@ -1,29 +1,154 @@
 using System;
-using System.IO;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Headless;
+using Avalonia.Threading;
+using FEBuilderGBA.Avalonia.Services;
 
 namespace FEBuilderGBA.Avalonia.Tests;
 
 /// <summary>
-/// Regression guard for #2098: the desktop host must opt into
-/// ShutdownMode.OnMainWindowClose so closing the shell does not leave
-/// secondary editor windows orphaned under the default OnLastWindowClose mode.
+/// Regression coverage for #2098: the desktop lifetime must opt into
+/// ShutdownMode.OnMainWindowClose so closing the shell tears down managed
+/// editor windows instead of leaving them orphaned under the default
+/// OnLastWindowClose behavior.
 /// </summary>
-public class DesktopLifetimeShutdownModeTests
+[Collection("WindowManagerSerial")]
+public sealed class DesktopLifetimeShutdownModeTests
 {
-    static string RepoRoot()
+    sealed class ClassicDesktopLifetimeApp : Application
     {
-        string dir = AppContext.BaseDirectory;
-        while (dir != null && !File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
-            dir = Path.GetDirectoryName(dir)!;
-        return dir ?? throw new InvalidOperationException("Cannot find solution root");
+        public ClassicDesktopLifetimeApp()
+        {
+            var lifetime = new ClassicDesktopStyleApplicationLifetime();
+            Program.ConfigureDesktopLifetime(lifetime);
+            ApplicationLifetime = lifetime;
+        }
+
+        public override void Initialize() { }
+    }
+
+    sealed class ClassicDesktopLifetimeEntryPoint
+    {
+        public static AppBuilder BuildAvaloniaApp()
+            => AppBuilder.Configure<ClassicDesktopLifetimeApp>()
+                .UseHeadless(new AvaloniaHeadlessPlatformOptions());
+    }
+
+    sealed class LifecycleEditorWindow : Window, IEditorView
+    {
+        public string ViewTitle => "Lifecycle";
+        public new bool IsLoaded => true;
+        public int ClosedCount { get; private set; }
+
+        public void NavigateTo(uint address) { }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            ClosedCount++;
+            base.OnClosed(e);
+        }
     }
 
     [Fact]
-    public void Program_StartsDesktopLifetime_WithMainWindowCloseShutdownMode()
+    public void ConfigureDesktopLifetime_sets_OnMainWindowClose()
     {
-        string repo = RepoRoot();
-        string program = File.ReadAllText(Path.Combine(repo, "FEBuilderGBA.Avalonia", "Program.cs"));
+        var lifetime = new ClassicDesktopStyleApplicationLifetime();
 
-        Assert.Contains("StartWithClassicDesktopLifetime(args, ShutdownMode.OnMainWindowClose)", program);
+        Program.ConfigureDesktopLifetime(lifetime);
+
+        Assert.Equal(ShutdownMode.OnMainWindowClose, lifetime.ShutdownMode);
+    }
+
+    static void WithClassicDesktopLifetime(Action<ClassicDesktopStyleApplicationLifetime, DesktopNavigationService> body)
+    {
+        using var session = HeadlessUnitTestSession.StartNew(
+            typeof(ClassicDesktopLifetimeEntryPoint),
+            AvaloniaTestIsolationLevel.PerTest);
+
+        session.Dispatch(() =>
+        {
+            var originalService = WindowManager.Instance.Service;
+            var originalMainWindow = WindowManager.Instance.MainWindow;
+            var service = new DesktopNavigationService();
+            WindowManager.Instance.SetService(service);
+
+            try
+            {
+                var lifetime = Assert.IsType<ClassicDesktopStyleApplicationLifetime>(
+                    Application.Current!.ApplicationLifetime);
+                body(lifetime, service);
+            }
+            finally
+            {
+                try
+                {
+                    WindowManager.Instance.CloseAll();
+                    Dispatcher.UIThread.RunJobs();
+                }
+                catch { }
+
+                if (WindowManager.Instance.MainWindow is { } mainWindow)
+                {
+                    try
+                    {
+                        mainWindow.Close();
+                        Dispatcher.UIThread.RunJobs();
+                    }
+                    catch { }
+                }
+
+                WindowManager.Instance.SetService(originalService);
+                WindowManager.Instance.MainWindow = originalMainWindow;
+            }
+        }, default);
+    }
+
+    [Fact]
+    public void Closing_main_window_shuts_down_desktop_lifetime_and_closes_managed_editor()
+    {
+        WithClassicDesktopLifetime((lifetime, service) =>
+        {
+            Assert.Equal(ShutdownMode.OnMainWindowClose, lifetime.ShutdownMode);
+
+            var mainWindow = new Window
+            {
+                Width = 240,
+                Height = 160,
+                Title = "Main",
+            };
+
+            lifetime.MainWindow = mainWindow;
+            WindowManager.Instance.MainWindow = mainWindow;
+
+            int exitCount = 0;
+            lifetime.Exit += (_, _) => exitCount++;
+
+            mainWindow.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var secondary = service.Open<LifecycleEditorWindow>();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(mainWindow.IsVisible);
+            Assert.True(secondary.IsVisible);
+            Assert.Same(secondary, service.FindOpen<LifecycleEditorWindow>());
+            Assert.Same(secondary, service.ActiveEditorWindow);
+            Assert.Contains(mainWindow, lifetime.Windows);
+            Assert.Contains(secondary, lifetime.Windows);
+
+            mainWindow.Close();
+            Dispatcher.UIThread.RunJobs();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(1, exitCount);
+            Assert.False(mainWindow.IsVisible);
+            Assert.False(secondary.IsVisible);
+            Assert.Equal(1, secondary.ClosedCount);
+            Assert.Empty(lifetime.Windows);
+            Assert.Null(service.FindOpen<LifecycleEditorWindow>());
+            Assert.Null(service.ActiveEditorWindow);
+        });
     }
 }

--- a/FEBuilderGBA.Avalonia/Program.cs
+++ b/FEBuilderGBA.Avalonia/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Media;
 
 namespace FEBuilderGBA.Avalonia
@@ -31,7 +32,7 @@ namespace FEBuilderGBA.Avalonia
                 return;
             }
 
-            BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+            BuildAvaloniaApp().StartWithClassicDesktopLifetime(args, ShutdownMode.OnMainWindowClose);
         }
 
         public static AppBuilder BuildAvaloniaApp()

--- a/FEBuilderGBA.Avalonia/Program.cs
+++ b/FEBuilderGBA.Avalonia/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Media;
 
 namespace FEBuilderGBA.Avalonia
@@ -32,7 +33,7 @@ namespace FEBuilderGBA.Avalonia
                 return;
             }
 
-            BuildAvaloniaApp().StartWithClassicDesktopLifetime(args, ShutdownMode.OnMainWindowClose);
+            BuildAvaloniaApp().StartWithClassicDesktopLifetime(args, ConfigureDesktopLifetime);
         }
 
         public static AppBuilder BuildAvaloniaApp()
@@ -91,6 +92,11 @@ namespace FEBuilderGBA.Avalonia
                     new FontFallback { FontFamily = new FontFamily("WenQuanYi Micro Hei") },
                 },
             };
+        }
+
+        internal static void ConfigureDesktopLifetime(IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            desktop.ShutdownMode = ShutdownMode.OnMainWindowClose;
         }
     }
 }


### PR DESCRIPTION
## Summary

- configure the Avalonia classic desktop lifetime to shut down when `MainWindow` closes
- prevent secondary editor windows from remaining orphaned after the home window exits
- add a regression test that locks the startup shutdown mode to `OnMainWindowClose`

Accepted plan: https://github.com/laqieer/FEBuilderGBA/issues/2098#issuecomment-5313916651

Closes #2098

## Test plan

- [x] `dotnet test FEBuilderGBA.Avalonia.Tests\FEBuilderGBA.Avalonia.Tests.csproj -c Release --nologo` (9,854 passed; 10 ROM-dependent tests skipped)
- [x] `dotnet build FEBuilderGBA.Avalonia\FEBuilderGBA.Avalonia.csproj -c Release --nologo` (0 warnings/errors)
- [x] `python scripts\classify_review_risk.py FEBuilderGBA.Avalonia.Tests\DesktopLifetimeShutdownModeTests.cs FEBuilderGBA.Avalonia\Program.cs` (`normal`)
- [x] `git diff --check`

## GUI Test Report

- Launched the real Avalonia desktop application on Windows without a ROM.
- Confirmed programmatic `MainWindow` close exits the process cleanly with no remaining `FEBuilderGBA.Avalonia` process.
- Captured the live home window plus a repository-supported no-ROM `PatchManagerView` render as secondary-window evidence.
- A dirty-ROM cancellation check was not possible without using a ROM; the existing cancellable `MainWindow_Closing` path is unchanged and the full Avalonia test suite passes.

![Avalonia main window and secondary view](https://github.com/user-attachments/assets/ec47d197-ddfa-4046-bdc3-c62011137bb5)

Copilot CLI: 1.0.80
Model: GPT-5.6 Sol (gpt-5.6-sol)

