### PR TITLE
fix(avalonia): use file picker for external tools

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/ExternalToolAppBundleTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ExternalToolAppBundleTests.cs
@@ -16,7 +16,8 @@ namespace FEBuilderGBA.Avalonia.Tests;
 public sealed class ExternalToolAppBundleTests : IDisposable
 {
     readonly string _root = Path.Combine(
-        Path.GetTempPath(),
+        AppContext.BaseDirectory,
+        "test-output",
         "avalonia_external_tool_" + Guid.NewGuid().ToString("N"));
     readonly Config? _savedConfig = CoreState.Config;
     readonly string? _savedBaseDirectory = CoreState.BaseDirectory;
@@ -33,7 +34,11 @@ public sealed class ExternalToolAppBundleTests : IDisposable
     {
         CoreState.Config = _savedConfig;
         CoreState.BaseDirectory = _savedBaseDirectory;
-        try { Directory.Delete(_root, recursive: true); }
+        try
+        {
+            if (Directory.Exists(_root))
+                Directory.Delete(_root, recursive: true);
+        }
         catch (IOException) { }
         catch (UnauthorizedAccessException) { }
     }
@@ -55,33 +60,55 @@ public sealed class ExternalToolAppBundleTests : IDisposable
         Assert.Equal(expected, diffPath);
     }
 
-    [Theory]
-    [InlineData(false, false, false)]
-    [InlineData(false, true, false)]
-    [InlineData(true, false, false)]
-    [InlineData(true, true, true)]
-    public void ExternalToolPickerMode_UsesFolderOnlyForMacApplicationBundles(
-        bool isMacOS,
-        bool allowMacApplicationBundle,
-        bool expectedFolder)
+    [Fact]
+    public void ExternalToolPicker_UsesFileSelectionForExecutablesAndAppBundles()
     {
-        var expected = expectedFolder
-            ? ExternalToolPickerMode.Folder
-            : ExternalToolPickerMode.File;
-        Assert.Equal(expected, FileDialogHelper.GetExternalToolPickerMode(
-            isMacOS, allowMacApplicationBundle));
+        var options = FileDialogHelper.CreateExternalToolOpenOptions("Select File");
+
+        Assert.Equal("Select File", options.Title);
+        Assert.False(options.AllowMultiple);
+        Assert.NotNull(options.FileTypeFilter);
+        Assert.Collection(options.FileTypeFilter!,
+            executables =>
+            {
+                Assert.Equal("Executables", executables.Name);
+                Assert.Equal(new[] { "*.exe", "*.app", "*" }, executables.Patterns);
+            },
+            allFiles =>
+            {
+                Assert.Equal("All Files", allFiles.Name);
+                Assert.Equal(new[] { "*" }, allFiles.Patterns);
+            });
     }
 
-    [Theory]
-    [InlineData("EmulatorTextBox", true)]
-    [InlineData("Emulator2TextBox", true)]
-    [InlineData("EventAssemblerTextBox", false)]
-    [InlineData("GitPathTextBox", false)]
-    public void OptionsView_RequestsBundleModeOnlyForEmulatorFields(
-        string targetName,
-        bool expected)
+    [AvaloniaFact]
+    public void OptionsView_BrowseTargets_KeepFileAndDirectoryRoutesConsistent()
     {
-        Assert.Equal(expected, OptionsView.AllowsMacApplicationBundlePicker(targetName));
+        var view = new OptionsView();
+        var host = new Window { Content = view };
+        host.Show();
+        try
+        {
+            Dispatcher.UIThread.RunJobs();
+
+            foreach (string target in OptionsView.FilePickerTargetNames)
+            {
+                Assert.True(OptionsView.IsFilePickerTarget(target));
+                Assert.False(OptionsView.IsDirectoryPickerTarget(target));
+                Assert.NotNull(view.FindControl<TextBox>(target));
+            }
+
+            foreach (string target in OptionsView.DirectoryPickerTargetNames)
+            {
+                Assert.True(OptionsView.IsDirectoryPickerTarget(target));
+                Assert.False(OptionsView.IsFilePickerTarget(target));
+                Assert.NotNull(view.FindControl<TextBox>(target));
+            }
+        }
+        finally
+        {
+            host.Close();
+        }
     }
 
     [Fact]

--- a/FEBuilderGBA.Avalonia.Tests/ExternalToolAppBundleTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ExternalToolAppBundleTests.cs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Xml.Linq;
 using global::Avalonia.Controls;
 using global::Avalonia.Headless.XUnit;
 using global::Avalonia.Threading;
@@ -82,28 +85,23 @@ public sealed class ExternalToolAppBundleTests : IDisposable
     }
 
     [AvaloniaFact]
-    public void OptionsView_BrowseTargets_KeepFileAndDirectoryRoutesConsistent()
+    public void OptionsView_BrowseButtons_RouteTagsThroughAxamlWiring()
     {
+        var actualRoutes = LoadOptionsViewBrowseRoutes();
+        var expectedRoutes = ExpectedOptionsViewBrowseRoutes()
+            .OrderBy(route => route.Tag, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(expectedRoutes, actualRoutes);
+
         var view = new OptionsView();
         var host = new Window { Content = view };
         host.Show();
         try
         {
             Dispatcher.UIThread.RunJobs();
-
-            foreach (string target in OptionsView.FilePickerTargetNames)
-            {
-                Assert.True(OptionsView.IsFilePickerTarget(target));
-                Assert.False(OptionsView.IsDirectoryPickerTarget(target));
-                Assert.NotNull(view.FindControl<TextBox>(target));
-            }
-
-            foreach (string target in OptionsView.DirectoryPickerTargetNames)
-            {
-                Assert.True(OptionsView.IsDirectoryPickerTarget(target));
-                Assert.False(OptionsView.IsFilePickerTarget(target));
-                Assert.NotNull(view.FindControl<TextBox>(target));
-            }
+            foreach ((string targetName, _) in actualRoutes)
+                Assert.NotNull(view.FindControl<TextBox>(targetName));
         }
         finally
         {
@@ -168,5 +166,76 @@ public sealed class ExternalToolAppBundleTests : IDisposable
         Directory.CreateDirectory(macOS);
         File.WriteAllText(Path.Combine(macOS, "mGBA"), "not executed");
         return bundle;
+    }
+
+    static (string Tag, string Click)[] LoadOptionsViewBrowseRoutes()
+    {
+        string axaml = ReadRepoFile(Path.Combine("FEBuilderGBA.Avalonia", "Views", "OptionsView.axaml"));
+        XDocument document = XDocument.Parse(axaml);
+        XNamespace ns = document.Root!.Name.Namespace;
+        var routes = new List<(string Tag, string Click)>();
+
+        foreach (XElement button in document.Descendants(ns + "Button"))
+        {
+            if (!string.Equals((string?)button.Attribute("Content"), "Browse...", StringComparison.Ordinal))
+                continue;
+
+            string automationId = (string?)button.Attribute("AutomationProperties.AutomationId") ?? "<unnamed>";
+            string? tag = (string?)button.Attribute("Tag");
+            Assert.False(string.IsNullOrWhiteSpace(tag), $"{automationId} is missing Tag.");
+            string? click = (string?)button.Attribute("Click");
+            Assert.False(string.IsNullOrWhiteSpace(click), $"{automationId} is missing Click.");
+            routes.Add((tag!, click!));
+        }
+
+        return routes
+            .OrderBy(route => route.Tag, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    static IEnumerable<(string Tag, string Click)> ExpectedOptionsViewBrowseRoutes()
+    {
+        yield return ("BinaryEditorTextBox", "BrowseFile_Click");
+        yield return ("DevkitproEabiTextBox", "BrowseFile_Click");
+        yield return ("Emulator2TextBox", "BrowseFile_Click");
+        yield return ("EmulatorTextBox", "BrowseFile_Click");
+        yield return ("EventAssemblerTextBox", "BrowseFile_Click");
+        yield return ("FEMapCreatorAssetsRootTextBox", "BrowseFolder_Click");
+        yield return ("FEMapCreatorPathTextBox", "BrowseFile_Click");
+        yield return ("FeclibTextBox", "BrowseFile_Click");
+        yield return ("GitPathTextBox", "BrowseFile_Click");
+        yield return ("GbaMusRiperTextBox", "BrowseFile_Click");
+        yield return ("GoldroadAsmTextBox", "BrowseFile_Click");
+        yield return ("Mid2agbTextBox", "BrowseFile_Click");
+        yield return ("Midfix4agbTextBox", "BrowseFile_Click");
+        yield return ("Program1TextBox", "BrowseFile_Click");
+        yield return ("Program2TextBox", "BrowseFile_Click");
+        yield return ("Program3TextBox", "BrowseFile_Click");
+        yield return ("Python3TextBox", "BrowseFile_Click");
+        yield return ("RetdecTextBox", "BrowseFile_Click");
+        yield return ("SappyTextBox", "BrowseFile_Click");
+        yield return ("SoxTextBox", "BrowseFile_Click");
+        yield return ("SrccodeDirectoryTextBox", "BrowseFolder_Click");
+        yield return ("SrccodeTexteditorTextBox", "BrowseFile_Click");
+    }
+
+    static string ReadRepoFile(string relativePath)
+    {
+        string root = FindRepoRoot();
+        string path = Path.Combine(root, relativePath);
+        Assert.True(File.Exists(path), $"{relativePath} not found at {path}");
+        return File.ReadAllText(path);
+    }
+
+    static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "FEBuilderGBA.sln")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+        throw new InvalidOperationException("Could not locate repo root (FEBuilderGBA.sln).");
     }
 }

--- a/FEBuilderGBA.Avalonia/Dialogs/FileDialogHelper.cs
+++ b/FEBuilderGBA.Avalonia/Dialogs/FileDialogHelper.cs
@@ -9,12 +9,6 @@ using FEBuilderGBA;
 
 namespace FEBuilderGBA.Avalonia.Dialogs
 {
-    internal enum ExternalToolPickerMode
-    {
-        File,
-        Folder,
-    }
-
     /// <summary>
     /// Helper for file open/save dialogs using Avalonia 11 StorageProvider API.
     /// All user-visible strings are wrapped with R._() for i18n.
@@ -246,20 +240,27 @@ namespace FEBuilderGBA.Avalonia.Dialogs
             return provider;
         }
 
-        internal static ExternalToolPickerMode GetExternalToolPickerMode(
-            bool isMacOS,
-            bool allowMacApplicationBundle)
-            => isMacOS && allowMacApplicationBundle
-                ? ExternalToolPickerMode.Folder
-                : ExternalToolPickerMode.File;
+        internal static FilePickerOpenOptions CreateExternalToolOpenOptions(string title)
+            => new()
+            {
+                Title = R._(title),
+                AllowMultiple = false,
+                FileTypeFilter = new[]
+                {
+                    new FilePickerFileType(R._("Executables"))
+                    {
+                        Patterns = ExecutablePatterns,
+                    },
+                    MakeAllFileType(),
+                },
+            };
 
-        static string? ResolveExternalToolLocalPath<T>(IReadOnlyList<T> items)
-            where T : IStorageItem
+        static string? ResolveExternalToolLocalPath(IReadOnlyList<IStorageFile>? files)
         {
-            if (items.Count == 0)
+            if (files == null || files.Count == 0)
                 return null;
 
-            string? path = items[0].TryGetLocalPath();
+            string? path = files[0].TryGetLocalPath();
             if (string.IsNullOrEmpty(path))
             {
                 CoreState.Services?.ShowInfo(R._("This setting configures an external tool path and requires desktop file-system access; it is not available on this device."));
@@ -540,42 +541,17 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         }
 
         /// <summary>
-        /// Pick a local external-tool path. macOS callers may explicitly request
-        /// a folder picker for an application bundle; every other case uses the
-        /// ordinary executable file picker.
+        /// Pick a local external-tool path with the shared executable file picker.
+        /// macOS application bundles remain selectable through the <c>*.app</c>
+        /// filter, while non-desktop targets still reject picks with no local path.
         /// </summary>
-        public static async Task<string?> OpenExternalTool(
-            TopLevel? owner,
-            string title,
-            bool allowMacApplicationBundle = false)
+        public static async Task<string?> OpenExternalTool(TopLevel? owner, string title)
         {
             var provider = GetStorageProvider(owner, nameof(OpenExternalTool));
             if (provider == null)
                 return null;
 
-            string localizedTitle = R._(title);
-            if (GetExternalToolPickerMode(
-                OperatingSystem.IsMacOS(),
-                allowMacApplicationBundle) == ExternalToolPickerMode.Folder)
-            {
-                var folders = await provider.OpenFolderPickerAsync(new FolderPickerOpenOptions
-                {
-                    Title = localizedTitle,
-                    AllowMultiple = false,
-                });
-                return ResolveExternalToolLocalPath(folders);
-            }
-
-            var executableFiles = new FilePickerFileType(R._("Executables"))
-            {
-                Patterns = ExecutablePatterns,
-            };
-            var files = await provider.OpenFilePickerAsync(new FilePickerOpenOptions
-            {
-                Title = localizedTitle,
-                AllowMultiple = false,
-                FileTypeFilter = new[] { executableFiles, MakeAllFileType() },
-            });
+            var files = await provider.OpenFilePickerAsync(CreateExternalToolOpenOptions(title));
             return ResolveExternalToolLocalPath(files);
         }
 

--- a/FEBuilderGBA.Avalonia/Views/OptionsView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OptionsView.axaml.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using global::Avalonia;
 using System.Threading.Tasks;
 using global::Avalonia.Controls;
@@ -31,43 +30,6 @@ namespace FEBuilderGBA.Avalonia.Views
         /// Never used by production code.
         /// </summary>
         internal OptionsViewModel ViewModelForTests => _vm;
-
-        static readonly string[] FilePickerTargets = new[]
-        {
-            "GitPathTextBox",
-            "EmulatorTextBox",
-            "Emulator2TextBox",
-            "BinaryEditorTextBox",
-            "Program1TextBox",
-            "Program2TextBox",
-            "Program3TextBox",
-            "SappyTextBox",
-            "Mid2agbTextBox",
-            "GbaMusRiperTextBox",
-            "SoxTextBox",
-            "Midfix4agbTextBox",
-            "EventAssemblerTextBox",
-            "DevkitproEabiTextBox",
-            "GoldroadAsmTextBox",
-            "RetdecTextBox",
-            "Python3TextBox",
-            "FeclibTextBox",
-            "SrccodeTexteditorTextBox",
-            "FEMapCreatorPathTextBox",
-        };
-
-        static readonly string[] DirectoryPickerTargets = new[]
-        {
-            "SrccodeDirectoryTextBox",
-            "FEMapCreatorAssetsRootTextBox",
-        };
-
-        internal static IReadOnlyList<string> FilePickerTargetNames => FilePickerTargets;
-        internal static IReadOnlyList<string> DirectoryPickerTargetNames => DirectoryPickerTargets;
-        internal static bool IsFilePickerTarget(string targetName)
-            => Array.IndexOf(FilePickerTargets, targetName) >= 0;
-        internal static bool IsDirectoryPickerTarget(string targetName)
-            => Array.IndexOf(DirectoryPickerTargets, targetName) >= 0;
 
         public OptionsView()
         {
@@ -276,7 +238,7 @@ namespace FEBuilderGBA.Avalonia.Views
             if (sender is not Button btn || btn.Tag is not string targetName)
                 return;
             var target = this.FindControl<TextBox>(targetName);
-            if (target == null || !IsFilePickerTarget(targetName)) return;
+            if (target == null) return;
 
             string? path = await FileDialogHelper.OpenExternalTool(
                 TopLevel.GetTopLevel(this),
@@ -291,7 +253,7 @@ namespace FEBuilderGBA.Avalonia.Views
             if (sender is not Button btn || btn.Tag is not string targetName)
                 return;
             var target = this.FindControl<TextBox>(targetName);
-            if (target == null || !IsDirectoryPickerTarget(targetName)) return;
+            if (target == null) return;
 
             var storage = TopLevel.GetTopLevel(this)?.StorageProvider;
             if (storage == null) return;

--- a/FEBuilderGBA.Avalonia/Views/OptionsView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OptionsView.axaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using global::Avalonia;
 using System.Threading.Tasks;
 using global::Avalonia.Controls;
@@ -31,8 +32,42 @@ namespace FEBuilderGBA.Avalonia.Views
         /// </summary>
         internal OptionsViewModel ViewModelForTests => _vm;
 
-        internal static bool AllowsMacApplicationBundlePicker(string targetName)
-            => targetName is "EmulatorTextBox" or "Emulator2TextBox";
+        static readonly string[] FilePickerTargets = new[]
+        {
+            "GitPathTextBox",
+            "EmulatorTextBox",
+            "Emulator2TextBox",
+            "BinaryEditorTextBox",
+            "Program1TextBox",
+            "Program2TextBox",
+            "Program3TextBox",
+            "SappyTextBox",
+            "Mid2agbTextBox",
+            "GbaMusRiperTextBox",
+            "SoxTextBox",
+            "Midfix4agbTextBox",
+            "EventAssemblerTextBox",
+            "DevkitproEabiTextBox",
+            "GoldroadAsmTextBox",
+            "RetdecTextBox",
+            "Python3TextBox",
+            "FeclibTextBox",
+            "SrccodeTexteditorTextBox",
+            "FEMapCreatorPathTextBox",
+        };
+
+        static readonly string[] DirectoryPickerTargets = new[]
+        {
+            "SrccodeDirectoryTextBox",
+            "FEMapCreatorAssetsRootTextBox",
+        };
+
+        internal static IReadOnlyList<string> FilePickerTargetNames => FilePickerTargets;
+        internal static IReadOnlyList<string> DirectoryPickerTargetNames => DirectoryPickerTargets;
+        internal static bool IsFilePickerTarget(string targetName)
+            => Array.IndexOf(FilePickerTargets, targetName) >= 0;
+        internal static bool IsDirectoryPickerTarget(string targetName)
+            => Array.IndexOf(DirectoryPickerTargets, targetName) >= 0;
 
         public OptionsView()
         {
@@ -241,12 +276,11 @@ namespace FEBuilderGBA.Avalonia.Views
             if (sender is not Button btn || btn.Tag is not string targetName)
                 return;
             var target = this.FindControl<TextBox>(targetName);
-            if (target == null) return;
+            if (target == null || !IsFilePickerTarget(targetName)) return;
 
             string? path = await FileDialogHelper.OpenExternalTool(
                 TopLevel.GetTopLevel(this),
-                "Select File",
-                AllowsMacApplicationBundlePicker(targetName));
+                "Select File");
             if (path != null)
                 target.Text = path;
             RefreshFEMapCreatorStatus();
@@ -257,7 +291,7 @@ namespace FEBuilderGBA.Avalonia.Views
             if (sender is not Button btn || btn.Tag is not string targetName)
                 return;
             var target = this.FindControl<TextBox>(targetName);
-            if (target == null) return;
+            if (target == null || !IsDirectoryPickerTarget(targetName)) return;
 
             var storage = TopLevel.GetTopLevel(this)?.StorageProvider;
             if (storage == null) return;

--- a/FEBuilderGBA.Avalonia/Views/ToolInitWizardView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ToolInitWizardView.axaml.cs
@@ -200,9 +200,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
         async void OnRefEmulator_Click(object? sender, RoutedEventArgs e)
         {
-            string? picked = await PickExeFileAsync(
-                "Select Emulator",
-                allowMacApplicationBundle: true);
+            string? picked = await PickExeFileAsync("Select Emulator");
             if (picked != null)
                 _vm.PendingEmulatorPath = picked;
         }
@@ -876,17 +874,10 @@ namespace FEBuilderGBA.Avalonia.Views
         // Helpers.
         // ===================================================================
 
-        /// <summary>
-        /// Centralized external-tool picker. The emulator step opts into the
-        /// macOS application-bundle folder picker; all other steps keep file
-        /// selection.
-        /// </summary>
-        System.Threading.Tasks.Task<string?> PickExeFileAsync(
-            string title,
-            bool allowMacApplicationBundle = false)
+        /// <summary>Centralized external-tool picker using the shared executable file dialog.</summary>
+        System.Threading.Tasks.Task<string?> PickExeFileAsync(string title)
             => FileDialogHelper.OpenExternalTool(
                 TopLevel.GetTopLevel(this),
-                title,
-                allowMacApplicationBundle);
+                title);
     }
 }


### PR DESCRIPTION
## Summary

- use a file-open picker for every Avalonia External Tools executable path
- allow macOS `.app` bundles and normal executable files through the shared executable filter
- preserve true directory browse fields, manual path entry, Android/non-local handling, and external launching
- add focused picker/filter/field-consistency tests

Accepted plan: https://github.com/laqieer/FEBuilderGBA/issues/2106#issuecomment-5327763613

Closes #2106

## Review risk

Normal — Avalonia desktop picker routing only.

## Test plan

- [x] `dotnet test ... --filter FullyQualifiedName~ExternalToolAppBundleTests` (6 passed)
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests\FEBuilderGBA.Avalonia.Tests.csproj -c Release` (9,848 passed; 10 ROM-dependent skips)
- [x] `dotnet build FEBuilderGBA.Avalonia\FEBuilderGBA.Avalonia.csproj -c Release` (0 warnings/errors)
- [x] `git diff --check`

## GUI Test Report

- Launched the real Options → External Tools view on Windows.
- Representative Browse interaction opened a file-selection dialog with filename/type controls and executable filters including `*.exe`, `*.app`, and `*`; no external binary was selected or run.
- Native macOS `.app` selection is additionally covered by picker logic tests and macOS CI.

![Options external tools picker validation](https://github.com/user-attachments/assets/12243da6-d9b1-467e-898f-c8abddceb554)

Copilot CLI: 1.0.80
Model: GPT-5.6 Sol (gpt-5.6-sol)
