### PR TITLE
test(core): stabilize EA process markers

### DIFF
--- a/FEBuilderGBA.Core.Tests/EventAssemblerCompileCoreProductionRunnerTests.cs
+++ b/FEBuilderGBA.Core.Tests/EventAssemblerCompileCoreProductionRunnerTests.cs
@@ -20,6 +20,7 @@ namespace FEBuilderGBA.Core.Tests
             "warning: C_Code.lyn.event:11:1: Writing before initializing offset. You may be breaking the ROM!";
         const string ColorzCoreSuccessMarker =
             "No errors. Please continue being awesome.";
+        const int ParentExitColdStartTimeoutMs = 10_000;
 
         static ROM CreateTestRom(int size = 512)
         {
@@ -70,7 +71,7 @@ namespace FEBuilderGBA.Core.Tests
 
                 EventAssemblerCompileCore.ResolveExeOverride = () => fakeExe;
                 EventAssemblerCompileCore.RunProcessOverride = null!;
-                EventAssemblerCompileCore.RunProcessTimeoutMs = 500;
+                EventAssemblerCompileCore.RunProcessTimeoutMs = ParentExitColdStartTimeoutMs;
 
                 var stopwatch = Stopwatch.StartNew();
                 EventAssemblerProcessStubSupport.LaunchRecord launch;
@@ -102,18 +103,18 @@ namespace FEBuilderGBA.Core.Tests
                     Assert.Equal(0xAA, rom.Data[0x100]);
                     Assert.NotEmpty(undo.list);
                     Assert.False(
-                        SpinWait.SpinUntil(() => File.Exists(markerPath), TimeSpan.FromSeconds(3)),
+                        EventAssemblerProcessStubSupport.TryReadChildMarker(
+                            markerPath,
+                            TimeSpan.FromSeconds(3),
+                            out _),
                         "Windows job containment should kill the helper descendant before it self-terminates.");
-                    Assert.False(
-                        File.Exists(markerPath),
-                        "The job-contained descendant wrote its self-termination marker.");
                 }
                 else
                 {
-                    bool descendantSelfTerminated = SpinWait.SpinUntil(
-                        () => File.Exists(markerPath),
+                    string childMarker = EventAssemblerProcessStubSupport.ReadChildMarker(
+                        markerPath,
                         TimeSpan.FromSeconds(
-                            EventAssemblerProcessStubSupport.ParentExitChildSelfTerminateSeconds));
+                            EventAssemblerProcessStubSupport.ParentExitChildSelfTerminateSeconds + 2));
 
                     Assert.False(result.Success);
                     Assert.Equal(before, rom.Data);
@@ -124,12 +125,9 @@ namespace FEBuilderGBA.Core.Tests
                     Assert.Contains(
                         ProcessRunnerScenarioSupport.CaptureIncompleteErrorMessage,
                         result.ErrorMessage);
-                    Assert.True(
-                        descendantSelfTerminated,
-                        "The POSIX helper descendant did not self-terminate after the bounded capture failure.");
                     Assert.Equal(
                         "parent-exit helper descendant self-terminated",
-                        File.ReadAllText(markerPath));
+                        childMarker);
                 }
             }
             finally
@@ -255,9 +253,10 @@ namespace FEBuilderGBA.Core.Tests
                 }
                 stopwatch.Stop();
 
-                bool childSurvived = SpinWait.SpinUntil(
-                    () => File.Exists(markerPath),
-                    TimeSpan.FromSeconds(3));
+                bool childSurvived = EventAssemblerProcessStubSupport.TryReadChildMarker(
+                    markerPath,
+                    TimeSpan.FromSeconds(3),
+                    out _);
 
                 Assert.False(result.Success);
                 Assert.Equal(EventAssemblerProcessStubSupport.TimeoutParentMode, launch.Mode);
@@ -267,7 +266,6 @@ namespace FEBuilderGBA.Core.Tests
                 Assert.Contains("Error: Event Assembler timed out after 120 seconds.", result.Output);
                 Assert.Contains("Error: Event Assembler timed out after 120 seconds.", result.ErrorMessage);
                 Assert.False(childSurvived, "The timeout child outlived the process-tree kill.");
-                Assert.False(File.Exists(markerPath), "The timeout child wrote its cleanup marker after the runner returned.");
                 Assert.Equal(before, rom.Data);
                 Assert.Empty(undo.list);
                 Assert.True(

--- a/FEBuilderGBA.Core.Tests/EventAssemblerProcessStubSupport.cs
+++ b/FEBuilderGBA.Core.Tests/EventAssemblerProcessStubSupport.cs
@@ -8,6 +8,7 @@ internal static class EventAssemblerProcessStubSupport
 {
     const int LaunchRecordReadRetryCount = 20;
     const int LaunchRecordReadRetryDelayMs = 50;
+    const int ChildMarkerReadRetryDelayMs = 50;
 
     internal const string ModeEnvVar = "FEBUILDERGBA_EA_PROCESS_STUB_MODE";
     internal const string LaunchRecordEnvVar = "FEBUILDERGBA_EA_PROCESS_STUB_RECORD";
@@ -29,16 +30,14 @@ internal static class EventAssemblerProcessStubSupport
 
     internal static LaunchRecord ReadLaunchRecord(string path)
     {
-        Assert.True(File.Exists(path), "Production runner helper record was not written: " + path);
-
         Exception? lastError = null;
         for (int attempt = 0; attempt < LaunchRecordReadRetryCount; attempt++)
         {
             try
             {
-                string json = File.ReadAllText(path);
-                if (string.IsNullOrWhiteSpace(json))
-                    throw new InvalidDataException("Process stub launch record was empty.");
+                string json = ReadRequiredNonEmptyText(
+                    path,
+                    "Process stub launch record was empty.");
 
                 return JsonSerializer.Deserialize<LaunchRecord>(json)
                     ?? throw new InvalidDataException("Could not deserialize process stub launch record.");
@@ -56,6 +55,21 @@ internal static class EventAssemblerProcessStubSupport
         throw new InvalidOperationException(
             "Could not read a complete process stub launch record: " + path,
             lastError);
+    }
+
+    internal static string ReadChildMarker(string path, TimeSpan timeout)
+    {
+        if (TryReadChildMarker(path, timeout, out string? marker, out Exception? lastError))
+            return marker!;
+
+        throw new InvalidOperationException(
+            "Could not read a complete process stub child marker: " + path,
+            lastError);
+    }
+
+    internal static bool TryReadChildMarker(string path, TimeSpan timeout, out string? marker)
+    {
+        return TryReadChildMarker(path, timeout, out marker, out _);
     }
 
     internal static string FindExecutable()
@@ -110,10 +124,88 @@ internal static class EventAssemblerProcessStubSupport
         return directory ?? throw new InvalidOperationException("Could not locate FEBuilderGBA.sln.");
     }
 
+    static bool TryReadChildMarker(
+        string path,
+        TimeSpan timeout,
+        out string? marker,
+        out Exception? lastError)
+    {
+        return TryReadNonEmptyText(
+            path,
+            GetRetryCount(timeout, ChildMarkerReadRetryDelayMs),
+            ChildMarkerReadRetryDelayMs,
+            "Process stub child marker was empty.",
+            out marker,
+            out lastError);
+    }
+
+    static bool TryReadNonEmptyText(
+        string path,
+        int retryCount,
+        int retryDelayMs,
+        string emptyMessage,
+        out string? text,
+        out Exception? lastError)
+    {
+        if (retryCount <= 0)
+            throw new ArgumentOutOfRangeException(nameof(retryCount));
+        if (retryDelayMs < 0)
+            throw new ArgumentOutOfRangeException(nameof(retryDelayMs));
+
+        text = null;
+        lastError = null;
+
+        for (int attempt = 0; attempt < retryCount; attempt++)
+        {
+            try
+            {
+                text = ReadRequiredNonEmptyText(path, emptyMessage);
+                return true;
+            }
+            catch (Exception ex) when (IsTransientMarkerReadFailure(ex))
+            {
+                lastError = ex;
+                if (attempt + 1 == retryCount)
+                    break;
+
+                Thread.Sleep(retryDelayMs);
+            }
+        }
+
+        return false;
+    }
+
+    static string ReadRequiredNonEmptyText(string path, string emptyMessage)
+    {
+        string text = File.ReadAllText(path);
+        if (string.IsNullOrWhiteSpace(text))
+            throw new InvalidDataException(emptyMessage);
+
+        return text;
+    }
+
+    static int GetRetryCount(TimeSpan timeout, int retryDelayMs)
+    {
+        if (timeout <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(timeout));
+        if (retryDelayMs <= 0)
+            throw new ArgumentOutOfRangeException(nameof(retryDelayMs));
+
+        return Math.Max(
+            1,
+            1 + (int)Math.Ceiling(timeout.TotalMilliseconds / retryDelayMs));
+    }
+
     static bool IsTransientLaunchRecordReadFailure(Exception ex)
     {
         return ex is IOException
             || ex is JsonException
+            || ex is InvalidDataException;
+    }
+
+    static bool IsTransientMarkerReadFailure(Exception ex)
+    {
+        return ex is IOException
             || ex is InvalidDataException;
     }
 

--- a/FEBuilderGBA.Core.Tests/EventAssemblerProcessStubSupport.cs
+++ b/FEBuilderGBA.Core.Tests/EventAssemblerProcessStubSupport.cs
@@ -6,6 +6,9 @@ namespace FEBuilderGBA.Core.Tests;
 
 internal static class EventAssemblerProcessStubSupport
 {
+    internal const int AtomicPublishRetryCount = 3;
+    internal const int AtomicPublishRetryDelayMs = 50;
+
     const int LaunchRecordReadRetryCount = 20;
     const int LaunchRecordReadRetryDelayMs = 50;
     const int ChildMarkerReadRetryDelayMs = 50;
@@ -101,6 +104,69 @@ internal static class EventAssemblerProcessStubSupport
         throw new FileNotFoundException("Runnable ColorzCore test stub was not built.");
     }
 
+    internal static void WriteAtomicText(string path, string content)
+    {
+        WriteAtomicText(path, content, MoveFileOverwrite, Thread.Sleep);
+    }
+
+    internal static void WriteAtomicText(
+        string path,
+        string content,
+        Action<string, string> moveOverwrite,
+        Action<int> delay)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        ArgumentNullException.ThrowIfNull(content);
+        ArgumentNullException.ThrowIfNull(moveOverwrite);
+        ArgumentNullException.ThrowIfNull(delay);
+
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        string tempPath = path + ".tmp";
+        File.WriteAllText(tempPath, content);
+        PublishStagedAtomicText(
+            path,
+            content,
+            moveOverwrite,
+            delay);
+    }
+
+    internal static void PublishStagedAtomicText(string path, string expectedContent)
+    {
+        PublishStagedAtomicText(path, expectedContent, MoveFileOverwrite, Thread.Sleep);
+    }
+
+    internal static void PublishStagedAtomicText(
+        string path,
+        string expectedContent,
+        Action<string, string> moveOverwrite,
+        Action<int> delay)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        ArgumentNullException.ThrowIfNull(expectedContent);
+        ArgumentNullException.ThrowIfNull(moveOverwrite);
+        ArgumentNullException.ThrowIfNull(delay);
+
+        string tempPath = path + ".tmp";
+        for (int attempt = 0; attempt < AtomicPublishRetryCount; attempt++)
+        {
+            try
+            {
+                moveOverwrite(tempPath, path);
+                return;
+            }
+            catch (Exception ex) when (IsTransientAtomicPublishFailure(ex))
+            {
+                if (HasExpectedAtomicPublishContent(path, expectedContent))
+                    return;
+
+                if (!File.Exists(tempPath) || attempt + 1 == AtomicPublishRetryCount)
+                    throw;
+
+                delay(AtomicPublishRetryDelayMs);
+            }
+        }
+    }
+
     internal static void AssertSamePath(string expected, string actual)
     {
         string normalizedExpected = Path.GetFullPath(expected);
@@ -177,11 +243,38 @@ internal static class EventAssemblerProcessStubSupport
 
     static string ReadRequiredNonEmptyText(string path, string emptyMessage)
     {
-        string text = File.ReadAllText(path);
+        using var stream = new FileStream(
+            path,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.ReadWrite | FileShare.Delete);
+        using var reader = new StreamReader(stream);
+        string text = reader.ReadToEnd();
         if (string.IsNullOrWhiteSpace(text))
             throw new InvalidDataException(emptyMessage);
 
         return text;
+    }
+
+    static bool HasExpectedAtomicPublishContent(string path, string expectedContent)
+    {
+        try
+        {
+            using var stream = new FileStream(
+                path,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.ReadWrite | FileShare.Delete);
+            using var reader = new StreamReader(stream);
+            return string.Equals(
+                reader.ReadToEnd(),
+                expectedContent,
+                StringComparison.Ordinal);
+        }
+        catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+        {
+            return false;
+        }
     }
 
     static int GetRetryCount(TimeSpan timeout, int retryDelayMs)
@@ -207,6 +300,17 @@ internal static class EventAssemblerProcessStubSupport
     {
         return ex is IOException
             || ex is InvalidDataException;
+    }
+
+    static bool IsTransientAtomicPublishFailure(Exception ex)
+    {
+        return ex is IOException
+            || ex is UnauthorizedAccessException;
+    }
+
+    static void MoveFileOverwrite(string sourcePath, string destinationPath)
+    {
+        File.Move(sourcePath, destinationPath, overwrite: true);
     }
 
     internal sealed class LaunchRecord

--- a/FEBuilderGBA.Core.Tests/EventAssemblerProcessStubSupportTests.cs
+++ b/FEBuilderGBA.Core.Tests/EventAssemblerProcessStubSupportTests.cs
@@ -8,17 +8,158 @@ namespace FEBuilderGBA.Core.Tests
 {
     public class EventAssemblerProcessStubSupportTests
     {
+        const string ParentExitChildMarker = "parent-exit helper descendant self-terminated";
+
         [Fact]
-        public void ReadLaunchRecord_RetriesTransientInvalidJsonUntilComplete()
+        public void ReadLaunchRecord_RetriesMissingFinalFileUntilAtomicPublish()
+        {
+            string root = CreateRoot();
+            string path = Path.Combine(root, "launch-record.json");
+            string tempPath = path + ".tmp";
+            EventAssemblerProcessStubSupport.LaunchRecord expected = CreateExpectedLaunchRecord(root);
+            File.WriteAllText(tempPath, JsonSerializer.Serialize(expected));
+
+            try
+            {
+                Exception? writerError = null;
+                var writer = new Thread(() =>
+                {
+                    try
+                    {
+                        Thread.Sleep(100);
+                        File.Move(tempPath, path, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        writerError = ex;
+                    }
+                });
+                writer.Start();
+
+                EventAssemblerProcessStubSupport.LaunchRecord actual =
+                    EventAssemblerProcessStubSupport.ReadLaunchRecord(path);
+                Assert.True(writer.Join(TimeSpan.FromSeconds(5)), "Launch-record writer thread did not finish.");
+                Assert.Null(writerError);
+
+                AssertLaunchRecord(expected, actual);
+            }
+            finally
+            {
+                try { Directory.Delete(root, true); } catch { }
+            }
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("{\"Mode\":\"timeout-parent\"")]
+        public void ReadLaunchRecord_RetriesEmptyOrPartialJsonUntilComplete(string initialJson)
+        {
+            string root = CreateRoot();
+            string path = Path.Combine(root, "launch-record.json");
+            string tempPath = path + ".tmp";
+            EventAssemblerProcessStubSupport.LaunchRecord expected = CreateExpectedLaunchRecord(root);
+            File.WriteAllText(path, initialJson);
+
+            try
+            {
+                Exception? writerError = null;
+                var writer = new Thread(() =>
+                {
+                    try
+                    {
+                        Thread.Sleep(100);
+                        File.WriteAllText(tempPath, JsonSerializer.Serialize(expected));
+                        File.Move(tempPath, path, true);
+                    }
+                    catch (Exception ex)
+                    {
+                        writerError = ex;
+                    }
+                });
+                writer.Start();
+
+                EventAssemblerProcessStubSupport.LaunchRecord actual =
+                    EventAssemblerProcessStubSupport.ReadLaunchRecord(path);
+                Assert.True(writer.Join(TimeSpan.FromSeconds(5)), "Launch-record writer thread did not finish.");
+                Assert.Null(writerError);
+
+                AssertLaunchRecord(expected, actual);
+            }
+            finally
+            {
+                try { Directory.Delete(root, true); } catch { }
+            }
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("{ not valid json")]
+        public void ReadLaunchRecord_PersistentMissingOrCorruptFails(string? persistentJson)
+        {
+            string root = CreateRoot();
+            string path = Path.Combine(root, "launch-record.json");
+            if (persistentJson != null)
+                File.WriteAllText(path, persistentJson);
+
+            try
+            {
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+                    () => EventAssemblerProcessStubSupport.ReadLaunchRecord(path));
+
+                Assert.Contains(path, ex.Message);
+                Assert.NotNull(ex.InnerException);
+                if (persistentJson == null)
+                    Assert.IsType<FileNotFoundException>(ex.InnerException);
+                else
+                    Assert.IsType<JsonException>(ex.InnerException);
+            }
+            finally
+            {
+                try { Directory.Delete(root, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void ChildMarkerReader_WaitsForAtomicFinalPublishAndNonEmptyContent()
+        {
+            string root = CreateRoot();
+            string path = Path.Combine(root, "child-survived.txt");
+            string tempPath = path + ".tmp";
+            File.WriteAllText(tempPath, ParentExitChildMarker);
+
+            try
+            {
+                Assert.False(
+                    EventAssemblerProcessStubSupport.TryReadChildMarker(
+                        path,
+                        TimeSpan.FromMilliseconds(200),
+                        out string? markerBeforePublish));
+                Assert.Null(markerBeforePublish);
+
+                File.Move(tempPath, path, true);
+
+                string marker = EventAssemblerProcessStubSupport.ReadChildMarker(
+                    path,
+                    TimeSpan.FromSeconds(1));
+
+                Assert.Equal(ParentExitChildMarker, marker);
+            }
+            finally
+            {
+                try { Directory.Delete(root, true); } catch { }
+            }
+        }
+
+        static string CreateRoot()
         {
             string root = Path.Combine(Path.GetTempPath(), "ea-launch-record-" + Path.GetRandomFileName());
             Directory.CreateDirectory(root);
-            string path = Path.Combine(root, "launch-record.json");
-            string tempPath = path + ".tmp";
-            File.WriteAllText(path, "");
-            File.WriteAllText(tempPath, "pending");
+            return root;
+        }
 
-            var expected = new EventAssemblerProcessStubSupport.LaunchRecord
+        static EventAssemblerProcessStubSupport.LaunchRecord CreateExpectedLaunchRecord(string root)
+        {
+            return new EventAssemblerProcessStubSupport.LaunchRecord
             {
                 Mode = EventAssemblerProcessStubSupport.TimeoutParentMode,
                 ProcessId = 123,
@@ -29,55 +170,20 @@ namespace FEBuilderGBA.Core.Tests
                 OutputRomPath = Path.Combine(root, "output.gba"),
                 Arguments = new[] { "A", "FE8", "-input:wrapper.event" },
             };
-
-            try
-            {
-                var writer = new Thread(() =>
-                {
-                    Thread.Sleep(100);
-                    File.WriteAllText(path, JsonSerializer.Serialize(expected));
-                    File.Delete(tempPath);
-                });
-                writer.Start();
-
-                EventAssemblerProcessStubSupport.LaunchRecord actual =
-                    EventAssemblerProcessStubSupport.ReadLaunchRecord(path);
-                Assert.True(writer.Join(TimeSpan.FromSeconds(5)), "Launch-record writer thread did not finish.");
-
-                Assert.Equal(expected.Mode, actual.Mode);
-                Assert.Equal(expected.ProcessId, actual.ProcessId);
-                Assert.Equal(expected.ChildProcessId, actual.ChildProcessId);
-                EventAssemblerProcessStubSupport.AssertSamePath(expected.ProcessPath, actual.ProcessPath);
-                EventAssemblerProcessStubSupport.AssertSamePath(expected.WorkingDirectory, actual.WorkingDirectory);
-                EventAssemblerProcessStubSupport.AssertSamePath(expected.WrapperPath, actual.WrapperPath);
-                EventAssemblerProcessStubSupport.AssertSamePath(expected.OutputRomPath, actual.OutputRomPath);
-                Assert.Equal(expected.Arguments, actual.Arguments);
-            }
-            finally
-            {
-                try { Directory.Delete(root, true); } catch { }
-            }
         }
 
-        [Fact]
-        public void ReadLaunchRecord_PersistentInvalidJsonThrows()
+        static void AssertLaunchRecord(
+            EventAssemblerProcessStubSupport.LaunchRecord expected,
+            EventAssemblerProcessStubSupport.LaunchRecord actual)
         {
-            string root = Path.Combine(Path.GetTempPath(), "ea-launch-record-" + Path.GetRandomFileName());
-            Directory.CreateDirectory(root);
-            string path = Path.Combine(root, "launch-record.json");
-            File.WriteAllText(path, "{ not valid json");
-
-            try
-            {
-                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
-                    () => EventAssemblerProcessStubSupport.ReadLaunchRecord(path));
-
-                Assert.NotNull(ex.InnerException);
-            }
-            finally
-            {
-                try { Directory.Delete(root, true); } catch { }
-            }
+            Assert.Equal(expected.Mode, actual.Mode);
+            Assert.Equal(expected.ProcessId, actual.ProcessId);
+            Assert.Equal(expected.ChildProcessId, actual.ChildProcessId);
+            EventAssemblerProcessStubSupport.AssertSamePath(expected.ProcessPath, actual.ProcessPath);
+            EventAssemblerProcessStubSupport.AssertSamePath(expected.WorkingDirectory, actual.WorkingDirectory);
+            EventAssemblerProcessStubSupport.AssertSamePath(expected.WrapperPath, actual.WrapperPath);
+            EventAssemblerProcessStubSupport.AssertSamePath(expected.OutputRomPath, actual.OutputRomPath);
+            Assert.Equal(expected.Arguments, actual.Arguments);
         }
     }
 }

--- a/FEBuilderGBA.Core.Tests/EventAssemblerProcessStubSupportTests.cs
+++ b/FEBuilderGBA.Core.Tests/EventAssemblerProcessStubSupportTests.cs
@@ -13,40 +13,7 @@ namespace FEBuilderGBA.Core.Tests
         [Fact]
         public void ReadLaunchRecord_RetriesMissingFinalFileUntilAtomicPublish()
         {
-            string root = CreateRoot();
-            string path = Path.Combine(root, "launch-record.json");
-            string tempPath = path + ".tmp";
-            EventAssemblerProcessStubSupport.LaunchRecord expected = CreateExpectedLaunchRecord(root);
-            File.WriteAllText(tempPath, JsonSerializer.Serialize(expected));
-
-            try
-            {
-                Exception? writerError = null;
-                var writer = new Thread(() =>
-                {
-                    try
-                    {
-                        Thread.Sleep(100);
-                        File.Move(tempPath, path, true);
-                    }
-                    catch (Exception ex)
-                    {
-                        writerError = ex;
-                    }
-                });
-                writer.Start();
-
-                EventAssemblerProcessStubSupport.LaunchRecord actual =
-                    EventAssemblerProcessStubSupport.ReadLaunchRecord(path);
-                Assert.True(writer.Join(TimeSpan.FromSeconds(5)), "Launch-record writer thread did not finish.");
-                Assert.Null(writerError);
-
-                AssertLaunchRecord(expected, actual);
-            }
-            finally
-            {
-                try { Directory.Delete(root, true); } catch { }
-            }
+            AssertLaunchRecordReadWaitsForAtomicPublish(initialFinalJson: null);
         }
 
         [Theory]
@@ -54,41 +21,7 @@ namespace FEBuilderGBA.Core.Tests
         [InlineData("{\"Mode\":\"timeout-parent\"")]
         public void ReadLaunchRecord_RetriesEmptyOrPartialJsonUntilComplete(string initialJson)
         {
-            string root = CreateRoot();
-            string path = Path.Combine(root, "launch-record.json");
-            string tempPath = path + ".tmp";
-            EventAssemblerProcessStubSupport.LaunchRecord expected = CreateExpectedLaunchRecord(root);
-            File.WriteAllText(path, initialJson);
-
-            try
-            {
-                Exception? writerError = null;
-                var writer = new Thread(() =>
-                {
-                    try
-                    {
-                        Thread.Sleep(100);
-                        File.WriteAllText(tempPath, JsonSerializer.Serialize(expected));
-                        File.Move(tempPath, path, true);
-                    }
-                    catch (Exception ex)
-                    {
-                        writerError = ex;
-                    }
-                });
-                writer.Start();
-
-                EventAssemblerProcessStubSupport.LaunchRecord actual =
-                    EventAssemblerProcessStubSupport.ReadLaunchRecord(path);
-                Assert.True(writer.Join(TimeSpan.FromSeconds(5)), "Launch-record writer thread did not finish.");
-                Assert.Null(writerError);
-
-                AssertLaunchRecord(expected, actual);
-            }
-            finally
-            {
-                try { Directory.Delete(root, true); } catch { }
-            }
+            AssertLaunchRecordReadWaitsForAtomicPublish(initialJson);
         }
 
         [Theory]
@@ -125,27 +58,288 @@ namespace FEBuilderGBA.Core.Tests
             string root = CreateRoot();
             string path = Path.Combine(root, "child-survived.txt");
             string tempPath = path + ".tmp";
-            File.WriteAllText(tempPath, ParentExitChildMarker);
+            Exception? publisherError = null;
+            string? marker = null;
+            Exception? readerError = null;
+
+            using var publishReady = new ManualResetEventSlim(false);
+            using var allowPublish = new ManualResetEventSlim(false);
+            using var readerStarted = new ManualResetEventSlim(false);
+
+            var publisher = new Thread(() =>
+            {
+                try
+                {
+                    File.WriteAllText(tempPath, ParentExitChildMarker);
+                    publishReady.Set();
+                    if (!allowPublish.Wait(TimeSpan.FromSeconds(5)))
+                        throw new TimeoutException("Child-marker publisher timed out before the final atomic publish.");
+
+                    EventAssemblerProcessStubSupport.PublishStagedAtomicText(
+                        path,
+                        ParentExitChildMarker);
+                }
+                catch (Exception ex)
+                {
+                    publisherError = ex;
+                }
+            });
+
+            Thread? reader = null;
 
             try
             {
+                publisher.Start();
+                Assert.True(
+                    publishReady.Wait(TimeSpan.FromSeconds(5)),
+                    "Child-marker publisher did not stage the atomic publish.");
+                Assert.True(File.Exists(tempPath), "The child-marker publisher did not stage the temporary file.");
+                Assert.False(File.Exists(path), "The child-marker final path should remain unpublished while staging.");
+
+                reader = new Thread(() =>
+                {
+                    try
+                    {
+                        readerStarted.Set();
+                        marker = EventAssemblerProcessStubSupport.ReadChildMarker(
+                            path,
+                            TimeSpan.FromSeconds(1));
+                    }
+                    catch (Exception ex)
+                    {
+                        readerError = ex;
+                    }
+                });
+                reader.Start();
+
+                Assert.True(readerStarted.Wait(TimeSpan.FromSeconds(5)), "Child-marker reader did not start.");
                 Assert.False(
-                    EventAssemblerProcessStubSupport.TryReadChildMarker(
-                        path,
-                        TimeSpan.FromMilliseconds(200),
-                        out string? markerBeforePublish));
-                Assert.Null(markerBeforePublish);
+                    reader.Join(TimeSpan.FromMilliseconds(200)),
+                    "Reader should keep retrying while the child-marker publish is still in progress.");
 
-                File.Move(tempPath, path, true);
-
-                string marker = EventAssemblerProcessStubSupport.ReadChildMarker(
-                    path,
-                    TimeSpan.FromSeconds(1));
+                allowPublish.Set();
+                Assert.True(publisher.Join(TimeSpan.FromSeconds(5)), "Child-marker publisher thread did not finish.");
+                Assert.Null(publisherError);
+                Assert.True(reader.Join(TimeSpan.FromSeconds(5)), "Child-marker reader thread did not finish.");
+                Assert.Null(readerError);
 
                 Assert.Equal(ParentExitChildMarker, marker);
             }
             finally
             {
+                allowPublish.Set();
+                if (publisher.IsAlive)
+                    publisher.Join(TimeSpan.FromSeconds(5));
+                if (reader?.IsAlive == true)
+                    reader.Join(TimeSpan.FromSeconds(5));
+                try { Directory.Delete(root, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void AtomicPublisher_RetriesTransientMoveFailuresWhileTempExists()
+        {
+            string root = CreateRoot();
+            string path = Path.Combine(root, "launch-record.json");
+            EventAssemblerProcessStubSupport.LaunchRecord expected = CreateExpectedLaunchRecord(root);
+            string expectedJson = JsonSerializer.Serialize(expected);
+            File.WriteAllText(path + ".tmp", expectedJson);
+            int moveCalls = 0;
+            int delayCalls = 0;
+
+            try
+            {
+                EventAssemblerProcessStubSupport.PublishStagedAtomicText(
+                    path,
+                    expectedJson,
+                    (sourcePath, destinationPath) =>
+                    {
+                        moveCalls++;
+                        if (moveCalls < EventAssemblerProcessStubSupport.AtomicPublishRetryCount)
+                            throw new IOException("sharing violation");
+
+                        File.Move(sourcePath, destinationPath, overwrite: true);
+                    },
+                    _ => delayCalls++);
+
+                Assert.Equal(EventAssemblerProcessStubSupport.AtomicPublishRetryCount, moveCalls);
+                Assert.Equal(EventAssemblerProcessStubSupport.AtomicPublishRetryCount - 1, delayCalls);
+                Assert.False(File.Exists(path + ".tmp"));
+                AssertLaunchRecord(expected, EventAssemblerProcessStubSupport.ReadLaunchRecord(path));
+            }
+            finally
+            {
+                try { Directory.Delete(root, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void AtomicPublisher_AcceptsCompletedThenThrewMoveWhenFinalContentMatches()
+        {
+            string root = CreateRoot();
+            string path = Path.Combine(root, "launch-record.json");
+            EventAssemblerProcessStubSupport.LaunchRecord expected = CreateExpectedLaunchRecord(root);
+            string expectedJson = JsonSerializer.Serialize(expected);
+            File.WriteAllText(path + ".tmp", expectedJson);
+            int moveCalls = 0;
+            int delayCalls = 0;
+
+            try
+            {
+                EventAssemblerProcessStubSupport.PublishStagedAtomicText(
+                    path,
+                    expectedJson,
+                    (sourcePath, destinationPath) =>
+                    {
+                        moveCalls++;
+                        File.Move(sourcePath, destinationPath, overwrite: true);
+                        throw new IOException("simulated completed-then-threw");
+                    },
+                    _ => delayCalls++);
+
+                Assert.Equal(1, moveCalls);
+                Assert.Equal(0, delayCalls);
+                Assert.False(File.Exists(path + ".tmp"));
+                AssertLaunchRecord(expected, EventAssemblerProcessStubSupport.ReadLaunchRecord(path));
+            }
+            finally
+            {
+                try { Directory.Delete(root, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void AtomicPublisher_PersistentUnauthorizedAccessThrows()
+        {
+            string root = CreateRoot();
+            string path = Path.Combine(root, "launch-record.json");
+            string expectedJson = JsonSerializer.Serialize(CreateExpectedLaunchRecord(root));
+            File.WriteAllText(path + ".tmp", expectedJson);
+            int moveCalls = 0;
+            int delayCalls = 0;
+
+            try
+            {
+                UnauthorizedAccessException ex = Assert.Throws<UnauthorizedAccessException>(
+                    () => EventAssemblerProcessStubSupport.PublishStagedAtomicText(
+                        path,
+                        expectedJson,
+                        (sourcePath, destinationPath) =>
+                        {
+                            moveCalls++;
+                            throw new UnauthorizedAccessException(
+                                $"sharing violation {moveCalls}: {sourcePath} -> {destinationPath}");
+                        },
+                        _ => delayCalls++));
+
+                Assert.Contains("sharing violation", ex.Message);
+                Assert.Equal(EventAssemblerProcessStubSupport.AtomicPublishRetryCount, moveCalls);
+                Assert.Equal(EventAssemblerProcessStubSupport.AtomicPublishRetryCount - 1, delayCalls);
+                Assert.True(File.Exists(path + ".tmp"));
+                Assert.False(File.Exists(path));
+            }
+            finally
+            {
+                try { Directory.Delete(root, true); } catch { }
+            }
+        }
+
+        static void AssertLaunchRecordReadWaitsForAtomicPublish(string? initialFinalJson)
+        {
+            string root = CreateRoot();
+            string path = Path.Combine(root, "launch-record.json");
+            string tempPath = path + ".tmp";
+            EventAssemblerProcessStubSupport.LaunchRecord expected = CreateExpectedLaunchRecord(root);
+            string expectedJson = JsonSerializer.Serialize(expected);
+            EventAssemblerProcessStubSupport.LaunchRecord? actual = null;
+            Exception? publisherError = null;
+            Exception? readerError = null;
+
+            using var publishReady = new ManualResetEventSlim(false);
+            using var allowPublish = new ManualResetEventSlim(false);
+            using var readerStarted = new ManualResetEventSlim(false);
+
+            if (initialFinalJson != null)
+                File.WriteAllText(path, initialFinalJson);
+
+            var publisher = new Thread(() =>
+            {
+                try
+                {
+                    File.WriteAllText(tempPath, expectedJson);
+                    publishReady.Set();
+                    if (!allowPublish.Wait(TimeSpan.FromSeconds(5)))
+                        throw new TimeoutException("Launch-record publisher timed out before the final atomic publish.");
+
+                    EventAssemblerProcessStubSupport.PublishStagedAtomicText(
+                        path,
+                        expectedJson);
+                }
+                catch (Exception ex)
+                {
+                    publisherError = ex;
+                }
+            });
+
+            Thread? reader = null;
+
+            try
+            {
+                publisher.Start();
+                Assert.True(
+                    publishReady.Wait(TimeSpan.FromSeconds(5)),
+                    "Launch-record publisher did not stage the atomic publish.");
+                Assert.True(File.Exists(tempPath), "The launch-record publisher did not stage the temporary file.");
+                if (initialFinalJson == null)
+                {
+                    Assert.False(File.Exists(path), "The launch-record final path should remain unpublished while staging.");
+                }
+                else
+                {
+                    Assert.True(File.Exists(path), "The launch-record final path should contain the pre-existing incomplete file.");
+                    Assert.Equal(initialFinalJson, File.ReadAllText(path));
+                }
+
+                reader = new Thread(() =>
+                {
+                    try
+                    {
+                        readerStarted.Set();
+                        actual = EventAssemblerProcessStubSupport.ReadLaunchRecord(path);
+                    }
+                    catch (Exception ex)
+                    {
+                        readerError = ex;
+                    }
+                });
+                reader.Start();
+
+                Assert.True(readerStarted.Wait(TimeSpan.FromSeconds(5)), "Launch-record reader did not start.");
+                bool completedEarly = reader.Join(TimeSpan.FromMilliseconds(200));
+                Assert.False(
+                    completedEarly,
+                    readerError == null
+                        ? "Reader should keep retrying while the launch-record publish is still in progress."
+                        : "Reader should keep retrying while the launch-record publish is still in progress."
+                            + Environment.NewLine
+                            + readerError);
+
+                allowPublish.Set();
+                Assert.True(publisher.Join(TimeSpan.FromSeconds(5)), "Launch-record publisher thread did not finish.");
+                Assert.Null(publisherError);
+                Assert.True(reader.Join(TimeSpan.FromSeconds(5)), "Launch-record reader thread did not finish.");
+                Assert.Null(readerError);
+                Assert.NotNull(actual);
+
+                AssertLaunchRecord(expected, actual!);
+            }
+            finally
+            {
+                allowPublish.Set();
+                if (publisher.IsAlive)
+                    publisher.Join(TimeSpan.FromSeconds(5));
+                if (reader?.IsAlive == true)
+                    reader.Join(TimeSpan.FromSeconds(5));
                 try { Directory.Delete(root, true); } catch { }
             }
         }

--- a/FEBuilderGBA.Core.Tests/EventAssemblerProcessStubSupportTests.cs
+++ b/FEBuilderGBA.Core.Tests/EventAssemblerProcessStubSupportTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Text.Json;
 using System.Threading;
@@ -53,7 +54,7 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
-        public void ChildMarkerReader_WaitsForAtomicFinalPublishAndNonEmptyContent()
+        public void ChildMarkerReader_WaitsForAtomicReplacementOfEmptyFinalMarker()
         {
             string root = CreateRoot();
             string path = Path.Combine(root, "child-survived.txt");
@@ -66,6 +67,8 @@ namespace FEBuilderGBA.Core.Tests
             using var allowPublish = new ManualResetEventSlim(false);
             using var readerStarted = new ManualResetEventSlim(false);
 
+            File.WriteAllText(path, "");
+
             var publisher = new Thread(() =>
             {
                 try
@@ -75,9 +78,7 @@ namespace FEBuilderGBA.Core.Tests
                     if (!allowPublish.Wait(TimeSpan.FromSeconds(5)))
                         throw new TimeoutException("Child-marker publisher timed out before the final atomic publish.");
 
-                    EventAssemblerProcessStubSupport.PublishStagedAtomicText(
-                        path,
-                        ParentExitChildMarker);
+                    ReplaceStagedAtomicText(path, TimeSpan.FromSeconds(5));
                 }
                 catch (Exception ex)
                 {
@@ -94,7 +95,11 @@ namespace FEBuilderGBA.Core.Tests
                     publishReady.Wait(TimeSpan.FromSeconds(5)),
                     "Child-marker publisher did not stage the atomic publish.");
                 Assert.True(File.Exists(tempPath), "The child-marker publisher did not stage the temporary file.");
-                Assert.False(File.Exists(path), "The child-marker final path should remain unpublished while staging.");
+                Assert.Equal(ParentExitChildMarker, File.ReadAllText(tempPath));
+                Assert.True(
+                    File.Exists(path),
+                    "The child-marker final path should keep the seeded empty marker while staging the replacement.");
+                Assert.Equal(string.Empty, File.ReadAllText(path));
 
                 reader = new Thread(() =>
                 {
@@ -113,14 +118,31 @@ namespace FEBuilderGBA.Core.Tests
                 reader.Start();
 
                 Assert.True(readerStarted.Wait(TimeSpan.FromSeconds(5)), "Child-marker reader did not start.");
+                bool completedEarly = reader.Join(TimeSpan.FromMilliseconds(200));
                 Assert.False(
-                    reader.Join(TimeSpan.FromMilliseconds(200)),
-                    "Reader should keep retrying while the child-marker publish is still in progress.");
+                    completedEarly,
+                    readerError == null
+                        ? "Reader should keep retrying while the child-marker final marker is still empty before atomic replacement."
+                        : "Reader should keep retrying while the child-marker final marker is still empty before atomic replacement."
+                            + Environment.NewLine
+                            + readerError);
 
                 allowPublish.Set();
-                Assert.True(publisher.Join(TimeSpan.FromSeconds(5)), "Child-marker publisher thread did not finish.");
+                Assert.True(
+                    publisher.Join(TimeSpan.FromSeconds(5)),
+                    publisherError == null
+                        ? "Child-marker publisher thread did not finish."
+                        : "Child-marker publisher thread did not finish."
+                            + Environment.NewLine
+                            + publisherError);
                 Assert.Null(publisherError);
-                Assert.True(reader.Join(TimeSpan.FromSeconds(5)), "Child-marker reader thread did not finish.");
+                Assert.True(
+                    reader.Join(TimeSpan.FromSeconds(5)),
+                    readerError == null
+                        ? "Child-marker reader thread did not finish."
+                        : "Child-marker reader thread did not finish."
+                            + Environment.NewLine
+                            + readerError);
                 Assert.Null(readerError);
 
                 Assert.Equal(ParentExitChildMarker, marker);
@@ -132,6 +154,28 @@ namespace FEBuilderGBA.Core.Tests
                     publisher.Join(TimeSpan.FromSeconds(5));
                 if (reader?.IsAlive == true)
                     reader.Join(TimeSpan.FromSeconds(5));
+                try { Directory.Delete(root, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void ReadChildMarker_PersistentMissingFails()
+        {
+            string root = CreateRoot();
+            string path = Path.Combine(root, "child-survived.txt");
+
+            try
+            {
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+                    () => EventAssemblerProcessStubSupport.ReadChildMarker(
+                        path,
+                        TimeSpan.FromMilliseconds(200)));
+
+                Assert.Contains(path, ex.Message);
+                Assert.IsType<FileNotFoundException>(ex.InnerException);
+            }
+            finally
+            {
                 try { Directory.Delete(root, true); } catch { }
             }
         }
@@ -271,9 +315,7 @@ namespace FEBuilderGBA.Core.Tests
                     if (!allowPublish.Wait(TimeSpan.FromSeconds(5)))
                         throw new TimeoutException("Launch-record publisher timed out before the final atomic publish.");
 
-                    EventAssemblerProcessStubSupport.PublishStagedAtomicText(
-                        path,
-                        expectedJson);
+                    ReplaceStagedAtomicText(path, TimeSpan.FromSeconds(5));
                 }
                 catch (Exception ex)
                 {
@@ -341,6 +383,28 @@ namespace FEBuilderGBA.Core.Tests
                 if (reader?.IsAlive == true)
                     reader.Join(TimeSpan.FromSeconds(5));
                 try { Directory.Delete(root, true); } catch { }
+            }
+        }
+
+        static void ReplaceStagedAtomicText(string path, TimeSpan timeout)
+        {
+            string tempPath = path + ".tmp";
+            var stopwatch = Stopwatch.StartNew();
+
+            while (true)
+            {
+                try
+                {
+                    File.Move(tempPath, path, overwrite: true);
+                    return;
+                }
+                catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+                {
+                    if (stopwatch.Elapsed >= timeout || !File.Exists(tempPath))
+                        throw;
+
+                    Thread.Sleep(20);
+                }
             }
         }
 

--- a/FEBuilderGBA.Core.Tests/Helpers/EventAssemblerProcessStub/Program.cs
+++ b/FEBuilderGBA.Core.Tests/Helpers/EventAssemblerProcessStub/Program.cs
@@ -14,6 +14,8 @@ internal static class Program
     const string ParentExitDescendantHoldsPipesMode = "parent-exit-descendant-holds-pipes";
     const string TimeoutParentMode = "timeout-parent";
     const int ParentExitChildSelfTerminateSeconds = 12;
+    const int AtomicPublishRetryCount = 3;
+    const int AtomicPublishRetryDelayMs = 50;
     const string ParentExitChildCommand = "__parent-exit-child";
     const string TimeoutChildCommand = "__timeout-child";
     const string WritingBeforeInitializingOffsetWarning =
@@ -189,7 +191,51 @@ internal static class Program
         Directory.CreateDirectory(Path.GetDirectoryName(path)!);
         string tempPath = path + ".tmp";
         File.WriteAllText(tempPath, content);
-        File.Move(tempPath, path, true);
+        for (int attempt = 0; attempt < AtomicPublishRetryCount; attempt++)
+        {
+            try
+            {
+                File.Move(tempPath, path, overwrite: true);
+                return;
+            }
+            catch (Exception ex) when (IsTransientAtomicPublishFailure(ex))
+            {
+                if (HasExpectedAtomicPublishContent(path, content))
+                    return;
+
+                if (!File.Exists(tempPath) || attempt + 1 == AtomicPublishRetryCount)
+                    throw;
+
+                Thread.Sleep(AtomicPublishRetryDelayMs);
+            }
+        }
+    }
+
+    static bool HasExpectedAtomicPublishContent(string path, string expectedContent)
+    {
+        try
+        {
+            using var stream = new FileStream(
+                path,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.ReadWrite | FileShare.Delete);
+            using var reader = new StreamReader(stream);
+            return string.Equals(
+                reader.ReadToEnd(),
+                expectedContent,
+                StringComparison.Ordinal);
+        }
+        catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    static bool IsTransientAtomicPublishFailure(Exception ex)
+    {
+        return ex is IOException
+            || ex is UnauthorizedAccessException;
     }
 
     sealed class LaunchRecord

--- a/FEBuilderGBA.Core.Tests/Helpers/EventAssemblerProcessStub/Program.cs
+++ b/FEBuilderGBA.Core.Tests/Helpers/EventAssemblerProcessStub/Program.cs
@@ -142,7 +142,7 @@ internal static class Program
             throw new InvalidOperationException("Parent-exit child expects a marker path.");
 
         Thread.Sleep(TimeSpan.FromSeconds(ParentExitChildSelfTerminateSeconds));
-        File.WriteAllText(args[1], "parent-exit helper descendant self-terminated");
+        WriteAtomicText(args[1], "parent-exit helper descendant self-terminated");
         return 0;
     }
 
@@ -152,7 +152,7 @@ internal static class Program
             throw new InvalidOperationException("Timeout child expects a marker path.");
 
         Thread.Sleep(TimeSpan.FromMilliseconds(2500));
-        File.WriteAllText(args[1], "child survived timeout kill");
+        WriteAtomicText(args[1], "child survived timeout kill");
         return 0;
     }
 
@@ -181,9 +181,14 @@ internal static class Program
 
     static void WriteLaunchRecord(string path, LaunchRecord launch)
     {
+        WriteAtomicText(path, JsonSerializer.Serialize(launch));
+    }
+
+    static void WriteAtomicText(string path, string content)
+    {
         Directory.CreateDirectory(Path.GetDirectoryName(path)!);
         string tempPath = path + ".tmp";
-        File.WriteAllText(tempPath, JsonSerializer.Serialize(launch));
+        File.WriteAllText(tempPath, content);
         File.Move(tempPath, path, true);
     }
 


### PR DESCRIPTION
## Summary

- atomically publish Event Assembler process-helper launch and child marker files
- bounded-retry missing, empty, partial, and transient marker reads while keeping persistent failure explicit
- give the parent-exit scenario enough cold-start time without changing the separate 500 ms timeout/tree-kill test
- add regression coverage for transient and persistent marker states

Accepted plan: https://github.com/laqieer/FEBuilderGBA/issues/2112#issuecomment-5337286317

Closes #2112

## Review risk

Normal — test protocol and timing only; production Event Assembler/ROM code is unchanged.

## Test plan

- [x] production-runner/support tests (9 passed)
- [x] parent-exit scenario repeated 10 times
- [x] `dotnet test FEBuilderGBA.Core.Tests\FEBuilderGBA.Core.Tests.csproj -c Release -warnaserror` (7,578 passed; 19 platform/tool skips)
- [x] Core and CLI Release builds
- [x] `git diff --check`

Copilot CLI: 1.0.80
Model: GPT-5.6 Sol (gpt-5.6-sol)

