### PR TITLE
feat(avalonia): cover FE6 triangle attack quotes

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/EventBattleTalkFE6TriangleViewTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EventBattleTalkFE6TriangleViewTests.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using global::Avalonia;
+using global::Avalonia.Controls;
+using global::Avalonia.Headless.XUnit;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Controls;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    [Collection("SharedState")]
+    public class EventBattleTalkFE6TriangleViewTests
+    {
+        const int SyntheticFe6RomSize = 0x800000;
+        const uint TriangleBase = 0x666528u;
+        const string TriangleCharacterLabelKey = "Character (Unit):";
+        const string MainHelpText = "Main battle-dialogue rows are 12-byte attacker/defender/text/flag records triggered when those two units fight.";
+        const string SecondaryHelpText = "FE6's boss-conversation table stores 16-byte generic boss lines: one triggering unit, a chapter/map id, text, flag, and an event pointer.";
+        const string TriangleHelpText = "FE6's triangle-attack quotes use a direct 6-row 16-byte table: character, chapter/map id, text, and event/flag byte only. There is no event pointer.";
+
+        static void WithSyntheticFE6(Action<ROM> body)
+        {
+            var prevRom = CoreState.ROM;
+            var prevServices = CoreState.Services;
+            var prevUndo = CoreState.Undo;
+            try
+            {
+                var rom = new ROM();
+                Assert.True(rom.LoadLow("synthetic-fe6-view.gba", new byte[SyntheticFe6RomSize], "AFEJ01"));
+                for (uint i = 0; i < 6; i++)
+                {
+                    uint addr = TriangleBase + i * 16;
+                    rom.Data[addr + 0] = (byte)(0x10 + i);
+                    rom.Data[addr + 1] = (byte)i;
+                    rom.write_u16(addr + 4, 0x500 + i);
+                    rom.Data[addr + 8] = (byte)(0x40 + i);
+                }
+                CoreState.ROM = rom;
+                CoreState.Services = new HeadlessAppServices();
+                CoreState.Undo = new Undo();
+                NameResolver.ClearCache();
+                body(rom);
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                CoreState.Services = prevServices;
+                CoreState.Undo = prevUndo;
+                NameResolver.ClearCache();
+            }
+        }
+
+        [AvaloniaFact]
+        public void TriangleSelector_LoadsSixRowsAndAppliesFieldVisibility()
+        {
+            WithSyntheticFE6(_ =>
+            {
+                var view = new EventBattleTalkFE6View();
+                Invoke(view, "LoadList");
+
+                var combo = view.FindControl<ComboBox>("TableFilter");
+                Assert.NotNull(combo);
+                Assert.Equal(3, combo!.ItemCount);
+                var third = Assert.IsType<ComboBoxItem>(combo.Items[2]);
+                var thirdText = Assert.IsType<TextBlock>(third.Content);
+                Assert.Equal("Triangle attack (16-byte)", thirdText.Text);
+
+                combo.SelectedIndex = 2;
+                view.Measure(new Size(1200, 760));
+                view.Arrange(new Rect(0, 0, 1200, 760));
+
+                var entryList = view.FindControl<AddressListControl>("EntryList");
+                Assert.NotNull(entryList);
+                Assert.Equal(6, entryList!.ItemCount);
+
+                Assert.Equal("Character:", view.FindControl<TextBlock>("AttackerLabel")!.Text);
+                Assert.Contains("Chapter", view.FindControl<TextBlock>("DefenderLabel")!.Text ?? "");
+                Assert.Equal("Event/Flag Byte:", view.FindControl<TextBlock>("AchievementFlagLabel")!.Text);
+                Assert.Equal(TriangleHelpText, view.FindControl<TextBlock>("HelpTextLabel")!.Text);
+                Assert.False(view.FindControl<TextBlock>("DefenderNameLabel")!.IsVisible);
+                Assert.False(view.FindControl<TextBlock>("EventPointerLabel")!.IsVisible);
+                Assert.False(view.FindControl<NumericUpDown>("EventPointerBox")!.IsVisible);
+                Assert.False(view.FindControl<TextBlock>("Unknown02Label")!.IsVisible);
+                Assert.False(view.FindControl<NumericUpDown>("Unknown02Box")!.IsVisible);
+                Assert.Equal(255, view.FindControl<NumericUpDown>("AchievementFlagBox")!.Maximum);
+            });
+        }
+
+        [AvaloniaFact]
+        public void HelpText_SwitchesPerTable()
+        {
+            WithSyntheticFE6(_ =>
+            {
+                var view = new EventBattleTalkFE6View();
+                Invoke(view, "LoadList");
+
+                var combo = view.FindControl<ComboBox>("TableFilter");
+                var help = view.FindControl<TextBlock>("HelpTextLabel");
+                Assert.NotNull(combo);
+                Assert.NotNull(help);
+
+                Assert.Equal(MainHelpText, help!.Text);
+
+                combo!.SelectedIndex = 1;
+                Assert.Equal(SecondaryHelpText, help.Text);
+
+                combo.SelectedIndex = 2;
+                Assert.Equal(TriangleHelpText, help.Text);
+            });
+        }
+
+        [AvaloniaFact]
+        public void TriangleLocalization_UsesUnitSenseLabel_AndHelpTextTranslations()
+        {
+            string repoRoot = FindRepoRoot();
+            string enPath = Path.Combine(repoRoot, "config", "translate", "en.txt");
+            string jaPath = Path.Combine(repoRoot, "config", "translate", "ja.txt");
+            string zhPath = Path.Combine(repoRoot, "config", "translate", "zh.txt");
+
+            foreach (string path in new[] { enPath, jaPath, zhPath })
+            {
+                Assert.True(File.Exists(path), $"Missing translation file: {path}");
+                var keys = ReadTranslationKeys(path);
+                Assert.Contains(TriangleCharacterLabelKey, keys);
+                Assert.Contains(MainHelpText, keys);
+                Assert.Contains(SecondaryHelpText, keys);
+                Assert.Contains(TriangleHelpText, keys);
+            }
+
+            AssertTranslation(jaPath, TriangleCharacterLabelKey, "ユニット:");
+            AssertTranslation(jaPath, "Character:", "文字:");
+            AssertTranslation(jaPath, TriangleHelpText, "FE6のトライアングルアタック台詞は、直接配置された6行固定の16バイトテーブルです。内容は [ユニット / 章・マップID / テキスト / イベント/フラグバイト] のみで、イベントポインタはありません。");
+            AssertTranslatedTriangleView(
+                jaPath,
+                expectedLabel: "ユニット:",
+                unexpectedGlyphLabel: "文字:",
+                expectedHelp: "FE6のトライアングルアタック台詞は、直接配置された6行固定の16バイトテーブルです。内容は [ユニット / 章・マップID / テキスト / イベント/フラグバイト] のみで、イベントポインタはありません。");
+
+            AssertTranslation(zhPath, TriangleCharacterLabelKey, "单位:");
+            AssertTranslation(zhPath, "Character:", "字符:");
+            AssertTranslation(zhPath, TriangleHelpText, "FE6的三角攻击台词使用直接写死的6行16字节表，内容只有 [单位 / 章节/地图ID / 文本 / 事件/标志字节]，没有事件指针。");
+            AssertTranslatedTriangleView(
+                zhPath,
+                expectedLabel: "单位:",
+                unexpectedGlyphLabel: "字符:",
+                expectedHelp: "FE6的三角攻击台词使用直接写死的6行16字节表，内容只有 [单位 / 章节/地图ID / 文本 / 事件/标志字节]，没有事件指针。");
+        }
+
+        [AvaloniaFact]
+        public void NavigateTo_TriangleAddress_SelectsThirdTableAndRow()
+        {
+            WithSyntheticFE6(_ =>
+            {
+                var view = new EventBattleTalkFE6View();
+                Invoke(view, "LoadList");
+                uint target = TriangleBase + 4 * 16;
+
+                view.NavigateTo(target);
+
+                var combo = view.FindControl<ComboBox>("TableFilter");
+                Assert.NotNull(combo);
+                Assert.Equal(2, combo!.SelectedIndex);
+                var vm = Assert.IsType<EventBattleTalkFE6ViewModel>(view.DataViewModel);
+                Assert.True(vm.IsTriangleAttackTable);
+                Assert.Equal(target, vm.CurrentAddr);
+            });
+        }
+
+        static void Invoke(EventBattleTalkFE6View view, string method)
+        {
+            var m = typeof(EventBattleTalkFE6View).GetMethod(method,
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+                null, Type.EmptyTypes, null);
+            Assert.NotNull(m);
+            m!.Invoke(view, Array.Empty<object?>());
+        }
+
+        static string FindRepoRoot()
+        {
+            string start = AppDomain.CurrentDomain.BaseDirectory;
+            for (var dir = new DirectoryInfo(start); dir != null; dir = dir.Parent)
+            {
+                if (File.Exists(Path.Combine(dir.FullName, "FEBuilderGBA.sln")))
+                    return dir.FullName;
+            }
+            throw new InvalidOperationException($"Could not locate FEBuilderGBA.sln starting from {start}");
+        }
+
+        static HashSet<string> ReadTranslationKeys(string path)
+        {
+            var keys = new HashSet<string>(StringComparer.Ordinal);
+            foreach (string line in File.ReadLines(path))
+            {
+                if (line.StartsWith(":", StringComparison.Ordinal))
+                    keys.Add(line.Substring(1));
+            }
+            return keys;
+        }
+
+        static void AssertTranslation(string path, string key, string expected)
+        {
+            try
+            {
+                MyTranslateResource.Clear();
+                MyTranslateResource.LoadResource(path);
+                Assert.Equal(expected, R._(key));
+            }
+            finally
+            {
+                MyTranslateResource.Clear();
+            }
+        }
+
+        static void AssertTranslatedTriangleView(string path, string expectedLabel, string unexpectedGlyphLabel, string expectedHelp)
+        {
+            try
+            {
+                MyTranslateResource.Clear();
+                MyTranslateResource.LoadResource(path);
+
+                WithSyntheticFE6(_ =>
+                {
+                    var view = new EventBattleTalkFE6View();
+                    Invoke(view, "LoadList");
+                    view.FindControl<ComboBox>("TableFilter")!.SelectedIndex = 2;
+
+                    Assert.Equal(expectedLabel, view.FindControl<TextBlock>("AttackerLabel")!.Text);
+                    Assert.NotEqual(unexpectedGlyphLabel, view.FindControl<TextBlock>("AttackerLabel")!.Text);
+                    Assert.Equal(expectedHelp, view.FindControl<TextBlock>("HelpTextLabel")!.Text);
+                });
+            }
+            finally
+            {
+                MyTranslateResource.Clear();
+            }
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/EventBattleTalkFE6ViewModelTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/EventBattleTalkFE6ViewModelTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using FEBuilderGBA;
 using FEBuilderGBA.Avalonia.ViewModels;
@@ -273,6 +274,208 @@ public class EventBattleTalkFE6ViewModelTests
                 vm.Unknown0A = ua; vm.Unknown0B = ub;
                 vm.Write();
             }
+        });
+    }
+
+
+    // =====================================================================
+    // Issue #2114 — FE6 triangle-attack direct quote table.
+    // =====================================================================
+
+    const int SyntheticFe6RomSize = 0x800000;
+    const uint TriangleBase = 0x666528u;
+    const uint MainBase = 0x700000u;
+    const uint SecondaryBase = 0x710000u;
+
+    static void WithSyntheticFE6(Action<ROM> body)
+    {
+        var prevRom = CoreState.ROM;
+        try
+        {
+            var rom = new ROM();
+            Assert.True(rom.LoadLow("synthetic-fe6.gba", new byte[SyntheticFe6RomSize], "AFEJ01"));
+            CoreState.ROM = rom;
+            NameResolver.ClearCache();
+            body(rom);
+        }
+        finally
+        {
+            CoreState.ROM = prevRom;
+            NameResolver.ClearCache();
+        }
+    }
+
+    static void SeedMainAndSecondary(ROM rom)
+    {
+        rom.write_p32(rom.RomInfo.event_ballte_talk_pointer, MainBase);
+        rom.write_u16(MainBase + 0, 0x0201);
+        rom.write_u16(MainBase + 12, 0x0403);
+        rom.write_u16(MainBase + 24, 0x0000);
+
+        rom.write_p32(rom.RomInfo.event_ballte_talk2_pointer, SecondaryBase);
+        rom.write_u16(SecondaryBase + 0, 0x0605);
+        rom.write_u32(SecondaryBase + 12, 0x08123456);
+        rom.write_u16(SecondaryBase + 16, 0x0807);
+        rom.write_u16(SecondaryBase + 32, 0x0000);
+    }
+
+    [Fact]
+    public void TriangleAttack_BlockSizeAndBase_AreDirectFixedFE6Only()
+    {
+        WithSyntheticFE6(rom =>
+        {
+            var vm = new EventBattleTalkFE6ViewModel();
+            Assert.Equal(0x666528u, rom.RomInfo.event_triangle_attack_quote_address);
+            Assert.Equal(TriangleBase, EventBattleTalkFE6ViewModel.ResolveBaseAddr(
+                rom, EventBattleTalkFE6ViewModel.BattleTalkTable.TriangleAttack));
+
+            vm.Table = EventBattleTalkFE6ViewModel.BattleTalkTable.TriangleAttack;
+            Assert.True(vm.IsTriangleAttackTable);
+            Assert.False(vm.IsSecondaryTable);
+            Assert.Equal(16u, vm.BlockSize);
+        });
+    }
+
+    [Fact]
+    public void LoadList_TriangleAttack_ReturnsExactlySixDirectRows_NoPointerOrTerminatorScan()
+    {
+        WithSyntheticFE6(rom =>
+        {
+            // Looks like a pointer if misread with p32(), and also begins with
+            // u16==0 so a terminator scan would stop immediately.
+            rom.write_u32(TriangleBase, 0x08720000);
+            rom.write_u16(TriangleBase + 16, 0xFFFF);
+            rom.Data[0x720000] = 0x22;
+
+            var vm = new EventBattleTalkFE6ViewModel();
+            List<AddrResult> list = vm.LoadList(EventBattleTalkFE6ViewModel.BattleTalkTable.TriangleAttack);
+
+            Assert.True(vm.IsTriangleAttackTable);
+            Assert.Equal(6, list.Count);
+            Assert.Equal(6, vm.GetListCount());
+            for (int i = 0; i < list.Count; i++)
+                Assert.Equal(TriangleBase + (uint)(i * 16), list[i].addr);
+        });
+    }
+
+    [Fact]
+    public void LoadEntry_TriangleAttack_ReadsOnlyDirectWritableFields()
+    {
+        WithSyntheticFE6(rom =>
+        {
+            uint addr = TriangleBase + 2 * 16;
+            rom.Data[addr + 0] = 0x12;
+            rom.Data[addr + 1] = 0x07;
+            rom.Data[addr + 2] = 0xA2;
+            rom.Data[addr + 3] = 0xA3;
+            rom.write_u16(addr + 4, 0x3456);
+            rom.Data[addr + 6] = 0xA6;
+            rom.Data[addr + 7] = 0xA7;
+            rom.Data[addr + 8] = 0x5A;
+            rom.write_u32(addr + 12, 0xDEADBEEF);
+
+            var vm = new EventBattleTalkFE6ViewModel();
+            vm.LoadList(EventBattleTalkFE6ViewModel.BattleTalkTable.TriangleAttack);
+            vm.LoadEntry(addr);
+
+            Assert.True(vm.IsLoaded);
+            Assert.Equal(addr, vm.CurrentAddr);
+            Assert.Equal(0x12u, vm.AttackerUnit);
+            Assert.Equal(0x07u, vm.DefenderUnit);
+            Assert.Equal(0x3456u, vm.Text);
+            Assert.Equal(0x5Au, vm.AchievementFlag);
+            Assert.Equal(0u, vm.EventPointer);
+            Assert.Contains("EventFlagByte", vm.GetDataReport().Keys);
+            Assert.Contains("u8@0x08_EventFlagByte", vm.GetRawRomReport().Keys);
+            Assert.DoesNotContain("u32@0x0C_EventPointer", vm.GetRawRomReport().Keys);
+        });
+    }
+
+    [Fact]
+    public void Write_TriangleAttack_PreservesReservedTailAndNeighborBytes()
+    {
+        WithSyntheticFE6(rom =>
+        {
+            uint addr = TriangleBase + 3 * 16;
+            for (uint i = 0; i < 7 * 16; i++)
+                rom.Data[TriangleBase + i] = (byte)(0x80 + (i & 0x3F));
+            byte[] before = (byte[])rom.Data.Clone();
+
+            var vm = new EventBattleTalkFE6ViewModel();
+            vm.LoadList(EventBattleTalkFE6ViewModel.BattleTalkTable.TriangleAttack);
+            vm.LoadEntry(addr);
+            vm.AttackerUnit = 0x21;
+            vm.DefenderUnit = 0x09;
+            vm.Unknown02 = 0xEE;
+            vm.Unknown03 = 0xEE;
+            vm.Text = 0x4567;
+            vm.Unknown06 = 0xEE;
+            vm.Unknown07 = 0xEE;
+            vm.AchievementFlag = 0xAB;
+            vm.Unknown0A = 0xEE;
+            vm.Unknown0B = 0xEE;
+            vm.EventPointer = 0xDEADBEEF;
+            vm.Write();
+
+            Assert.Equal(0x21, rom.Data[addr + 0]);
+            Assert.Equal(0x09, rom.Data[addr + 1]);
+            Assert.Equal(0x4567u, rom.u16(addr + 4));
+            Assert.Equal(0xAB, rom.Data[addr + 8]);
+
+            foreach (uint off in new uint[] { 2, 3, 6, 7, 9, 10, 11, 12, 13, 14, 15 })
+                Assert.Equal(before[addr + off], rom.Data[addr + off]);
+            for (uint i = 0; i < 7 * 16; i++)
+            {
+                uint absolute = TriangleBase + i;
+                if (absolute == addr + 0 || absolute == addr + 1 || absolute == addr + 4 ||
+                    absolute == addr + 5 || absolute == addr + 8)
+                    continue;
+                Assert.Equal(before[absolute], rom.Data[absolute]);
+            }
+        });
+    }
+
+    [Fact]
+    public void TriangleAttack_ShortRomFailsClosed()
+    {
+        WithSyntheticFE6(rom =>
+        {
+            rom.SwapNewROMDataDirect(new byte[(int)(TriangleBase + 5 * 16 + 15)]);
+            var vm = new EventBattleTalkFE6ViewModel();
+
+            Assert.Equal(0u, EventBattleTalkFE6ViewModel.ResolveBaseAddr(
+                rom, EventBattleTalkFE6ViewModel.BattleTalkTable.TriangleAttack));
+            Assert.Empty(vm.LoadList(EventBattleTalkFE6ViewModel.BattleTalkTable.TriangleAttack));
+            vm.LoadEntry(TriangleBase);
+            Assert.False(vm.IsLoaded);
+        });
+    }
+
+    [Fact]
+    public void Synthetic_MainAndSecondary_RegressionsRemainPointerAndTerminatorBased()
+    {
+        WithSyntheticFE6(rom =>
+        {
+            SeedMainAndSecondary(rom);
+            var vm = new EventBattleTalkFE6ViewModel();
+
+            var main = vm.LoadList(EventBattleTalkFE6ViewModel.BattleTalkTable.Main);
+            Assert.Equal(2, main.Count);
+            Assert.Equal(12u, main[1].addr - main[0].addr);
+            uint mainNeighborBefore = rom.u32(MainBase + 12);
+            vm.LoadEntry(MainBase);
+            vm.EventPointer = 0xDEADBEEF;
+            vm.AchievementFlag = 0x1234;
+            vm.Write();
+            Assert.Equal(mainNeighborBefore, rom.u32(MainBase + 12));
+
+            var secondary = vm.LoadList(EventBattleTalkFE6ViewModel.BattleTalkTable.Secondary);
+            Assert.Equal(2, secondary.Count);
+            Assert.Equal(16u, secondary[1].addr - secondary[0].addr);
+            vm.LoadEntry(SecondaryBase);
+            vm.EventPointer = 0x08ABCDEF;
+            vm.Write();
+            Assert.Equal(0x08ABCDEFu, rom.u32(SecondaryBase + 12));
         });
     }
 

--- a/FEBuilderGBA.Avalonia.Tests/NightmareModuleCoverageTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/NightmareModuleCoverageTests.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using FEBuilderGBA.Avalonia.Services;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    public class NightmareModuleCoverageTests
+    {
+        const string ExpectedRepository = "laqieer/Fire-Emblem-Nightmare-Modules";
+        const string ExpectedCommit = "e854861a7c16dadd3f2ea26be4b8c3d71c0e9c10";
+        const string ExpectedPathHash = "a8019f8688da5766c740e4620a662914670fc21a002a0803c28f90cfe0661c6a";
+
+        static JsonDocument LoadManifest()
+        {
+            string path = Path.Combine(FindRepoRoot(), "FEBuilderGBA.Avalonia.Tests", "TestData", "nightmare-module-coverage.json");
+            return JsonDocument.Parse(File.ReadAllText(path, Encoding.UTF8));
+        }
+
+        [Fact]
+        public void Manifest_HasExpectedPinnedCountsAndHash()
+        {
+            using var doc = LoadManifest();
+            var root = doc.RootElement;
+            Assert.Equal(ExpectedRepository, root.GetProperty("sourceRepository").GetString());
+            Assert.Equal(ExpectedCommit, root.GetProperty("sourceCommit").GetString());
+            Assert.Equal(755, root.GetProperty("totalCount").GetInt32());
+
+            var counts = root.GetProperty("rootCounts");
+            Assert.Equal(102, counts.GetProperty("FE6 Nightmare Modules").GetInt32());
+            Assert.Equal(373, counts.GetProperty("FE7 Nightmare Modules").GetInt32());
+            Assert.Equal(280, counts.GetProperty("FE8 Nightmare modules").GetInt32());
+
+            string[] paths = Entries(root).Select(e => e.GetProperty("path").GetString()!).ToArray();
+            string joined = string.Join("\n", paths) + "\n";
+            string hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(joined))).ToLowerInvariant();
+            Assert.Equal(ExpectedPathHash, hash);
+            Assert.Equal(hash, root.GetProperty("pathListSha256").GetString());
+        }
+
+        [Fact]
+        public void Entries_AreSortedUniqueNmmPathsUnderExactlyPinnedRoots()
+        {
+            using var doc = LoadManifest();
+            string[] allowedRoots = { "FE6 Nightmare Modules", "FE7 Nightmare Modules", "FE8 Nightmare modules" };
+            string[] paths = Entries(doc.RootElement).Select(e => e.GetProperty("path").GetString()!).ToArray();
+
+            Assert.Equal(paths.OrderBy(p => p, StringComparer.Ordinal).ToArray(), paths);
+            Assert.Equal(paths.Length, paths.Distinct(StringComparer.Ordinal).Count());
+            Assert.All(paths, p =>
+            {
+                Assert.EndsWith(".nmm", p, StringComparison.OrdinalIgnoreCase);
+                string root = p.Split('/')[0];
+                Assert.Contains(root, allowedRoots);
+            });
+        }
+
+        [Fact]
+        public void Entries_MapExactlyOnceToDocumentedFamilyAndDisposition()
+        {
+            using var doc = LoadManifest();
+            var root = doc.RootElement;
+            var families = root.GetProperty("familyDefinitions").EnumerateObject().Select(p => p.Name).ToHashSet(StringComparer.Ordinal);
+            var dispositions = root.GetProperty("dispositionDefinitions").EnumerateObject().Select(p => p.Name).ToHashSet(StringComparer.Ordinal);
+
+            foreach (var entry in Entries(root))
+            {
+                string path = entry.GetProperty("path").GetString()!;
+                string family = entry.GetProperty("family").GetString()!;
+                string disposition = entry.GetProperty("disposition").GetString()!;
+                Assert.True(families.Contains(family), $"{path}: undocumented family {family}");
+                Assert.True(dispositions.Contains(disposition), $"{path}: undocumented disposition {disposition}");
+                Assert.False(string.IsNullOrWhiteSpace(entry.GetProperty("target").GetString()) && disposition != "explicit-exclusion",
+                    $"{path}: non-exclusion entries must name a target");
+                Assert.NotEqual("missing", disposition);
+            }
+        }
+
+        [Fact]
+        public void SummaryCounts_MatchEntries()
+        {
+            using var doc = LoadManifest();
+            var root = doc.RootElement;
+            AssertSummary(root, "familyCounts", e => e.GetProperty("family").GetString()!);
+            AssertSummary(root, "dispositionCounts", e => e.GetProperty("disposition").GetString()!);
+        }
+
+        [Fact]
+        public void TriangleMappings_AreExplicitAndCatalogTargetIsLive()
+        {
+            using var doc = LoadManifest();
+            var root = doc.RootElement;
+            var entries = Entries(root).ToDictionary(e => e.GetProperty("path").GetString()!, e => e, StringComparer.Ordinal);
+
+            var fe6 = entries["FE6 Nightmare Modules/Quote editor/Triangle attack quote editor.nmm"];
+            Assert.Equal("integrated-surface", fe6.GetProperty("disposition").GetString());
+            Assert.Equal("EventBattleTalkFE6", fe6.GetProperty("target").GetString());
+
+            var explicitMap = root.GetProperty("explicitMappings");
+            Assert.Equal("0x666528", explicitMap.GetProperty("FE6 Nightmare Modules/Quote editor/Triangle attack quote editor.nmm").GetProperty("directBase").GetString());
+            Assert.Equal(6, explicitMap.GetProperty("FE6 Nightmare Modules/Quote editor/Triangle attack quote editor.nmm").GetProperty("count").GetInt32());
+            Assert.Equal(16, explicitMap.GetProperty("FE6 Nightmare Modules/Quote editor/Triangle attack quote editor.nmm").GetProperty("stride").GetInt32());
+
+            foreach (string path in new[]
+            {
+                "FE7 Nightmare Modules/Quote Editors/Triangle Attack Convo Editor.nmm",
+                "FE7 Nightmare Modules/Character Editors/Quote Editors/Triangle Attack Convo Editor.nmm",
+            })
+            {
+                Assert.Equal("existing-avalonia-surface", entries[path].GetProperty("disposition").GetString());
+                Assert.Equal("EventBattleTalkFE7", entries[path].GetProperty("target").GetString());
+                Assert.Equal("0xC9F130", explicitMap.GetProperty(path).GetProperty("directBase").GetString());
+            }
+
+            Assert.Contains(EditorCatalog.AllEntries, e => e.Key == "EventBattleTalkFE6");
+            Assert.Contains(root.GetProperty("liveCatalogTargets").EnumerateArray(), e => e.GetString() == "EventBattleTalkFE6");
+        }
+
+        static JsonElement[] Entries(JsonElement root) => root.GetProperty("entries").EnumerateArray().ToArray();
+
+        static void AssertSummary(JsonElement root, string summaryProperty, Func<JsonElement, string> keySelector)
+        {
+            var expected = Entries(root)
+                .GroupBy(keySelector, StringComparer.Ordinal)
+                .ToDictionary(g => g.Key, g => g.Count(), StringComparer.Ordinal);
+            var actual = root.GetProperty(summaryProperty).EnumerateObject()
+                .ToDictionary(p => p.Name, p => p.Value.GetInt32(), StringComparer.Ordinal);
+            Assert.Equal(expected, actual);
+        }
+
+        static string FindRepoRoot()
+        {
+            string start = AppDomain.CurrentDomain.BaseDirectory;
+            for (var dir = new DirectoryInfo(start); dir != null; dir = dir.Parent)
+            {
+                if (File.Exists(Path.Combine(dir.FullName, "FEBuilderGBA.sln")))
+                    return dir.FullName;
+            }
+            throw new InvalidOperationException($"Could not locate FEBuilderGBA.sln starting from {start}");
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/TestData/nightmare-module-coverage.json
+++ b/FEBuilderGBA.Avalonia.Tests/TestData/nightmare-module-coverage.json
@@ -1,0 +1,6170 @@
+{
+  "schemaVersion": 1,
+  "sourceRepository": "laqieer/Fire-Emblem-Nightmare-Modules",
+  "sourceCommit": "e854861a7c16dadd3f2ea26be4b8c3d71c0e9c10",
+  "sourceTreeApi": "GitHub git tree metadata only; module file contents were not executed, cloned, built, or applied.",
+  "pathListSha256": "a8019f8688da5766c740e4620a662914670fc21a002a0803c28f90cfe0661c6a",
+  "hashAlgorithm": "SHA-256 over the sorted path list joined with LF and a trailing LF",
+  "totalCount": 755,
+  "rootCounts": {
+    "FE6 Nightmare Modules": 102,
+    "FE7 Nightmare Modules": 373,
+    "FE8 Nightmare modules": 280
+  },
+  "familyCounts": {
+    "animation": 15,
+    "audio": 6,
+    "battle-screen": 22,
+    "beta": 6,
+    "chapter-unit": 309,
+    "character-class": 50,
+    "event": 55,
+    "graphics": 8,
+    "hardcode-tuning": 22,
+    "item": 23,
+    "map": 22,
+    "menu": 4,
+    "promotion": 3,
+    "quote": 20,
+    "shop": 174,
+    "support": 16
+  },
+  "dispositionCounts": {
+    "existing-avalonia-surface": 726,
+    "explicit-exclusion": 6,
+    "integrated-surface": 1,
+    "patch-manager": 22
+  },
+  "dispositionDefinitions": {
+    "existing-avalonia-surface": "Covered by an existing FEBuilderGBA Avalonia/catalog editor or cross-platform scanner surface.",
+    "integrated-surface": "Covered by the issue #2114 FEBuilderGBA implementation work.",
+    "patch-manager": "Covered by Patch Manager or hard-code tuning surfaces rather than a row-table editor.",
+    "explicit-exclusion": "Intentionally excluded from FEBuilderGBA live coverage (prototype/duplicate/randomizer-only Nightmare module).",
+    "missing": "No FEBuilderGBA surface identified. This manifest should contain zero missing paths after issue #2114."
+  },
+  "familyDefinitions": {
+    "animation": "Battle animation/module animation tables.",
+    "arena": "Arena class or arena weapon tables.",
+    "audio": "Song table and sound room tables.",
+    "battle-screen": "Battle screen, battle palette, and related UI graphics.",
+    "beta": "Prototype or duplicate beta modules.",
+    "chapter-unit": "Chapter unit placement, recruitment, reinforcement, and chest/shop event data.",
+    "character-class": "Character, class, and combined character/class data.",
+    "event": "Event pointer, condition, script, or event data tables.",
+    "graphics": "Portrait, background, CG, map sprite, and other graphics tables.",
+    "hardcode-tuning": "Hard-coded tuning/randomizer-oriented tables.",
+    "item": "Item and spell association data.",
+    "map": "Chapter data, map settings, map terrain, map graphics, and map-related tables.",
+    "menu": "Menu command/menu data tables.",
+    "promotion": "Promotion and class-change data.",
+    "quote": "Battle, death, support, and triangle-attack quote tables.",
+    "shop": "Shop inventory and shop event tables.",
+    "summon": "Summon unit tables.",
+    "support": "Support unit and support conversation data."
+  },
+  "explicitMappings": {
+    "FE6 Nightmare Modules/Quote editor/Triangle attack quote editor.nmm": {
+      "target": "EventBattleTalkFE6",
+      "disposition": "integrated-surface",
+      "directBase": "0x666528",
+      "count": 6,
+      "stride": 16,
+      "writableFields": [
+        "B0 Character",
+        "B1 Chapter",
+        "W4 Text ID",
+        "B8 Event/flag byte"
+      ]
+    },
+    "FE7 Nightmare Modules/Quote Editors/Triangle Attack Convo Editor.nmm": {
+      "target": "EventBattleTalkFE7",
+      "disposition": "existing-avalonia-surface",
+      "directBase": "0xC9F130",
+      "count": 4,
+      "stride": 12
+    },
+    "FE7 Nightmare Modules/Character Editors/Quote Editors/Triangle Attack Convo Editor.nmm": {
+      "target": "EventBattleTalkFE7",
+      "disposition": "existing-avalonia-surface",
+      "directBase": "0xC9F130",
+      "count": 4,
+      "stride": 12
+    }
+  },
+  "liveCatalogTargets": [
+    "EventBattleTalkFE6"
+  ],
+  "entries": [
+    {
+      "path": "FE6 Nightmare Modules/Animations/Custom Battle Animation Editor.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "animation",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle animation editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Animations/FE6 Battle Palette Reference.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "animation",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle animation editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 1.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 10A.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 10B.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 11A.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 11B.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 12.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 12x.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 13.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 14.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 14x.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 15.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 16.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 16x.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 17A.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 17B.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 18A.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 18B.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 19A.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 19B.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 2.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 20A.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 20Ax.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 20B.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 20Bx.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 21.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 21x.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 22.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 23.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 24.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 3.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 4.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 5.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 6.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 7.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 8.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 8x.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Chapter 9.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Final Chapter.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Trial Map 1.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Trial Map 2.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Trial Map 3.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Trial Map 4.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Trial Map 5.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Trial Map Characters.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Army Editor/Tutorial.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Battle screen editor/battle screen editor1.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "battle-screen",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle screen / palette editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Battle screen editor/battle screen editor2.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "battle-screen",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle screen / palette editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Battle screen editor/battle screen editor3.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "battle-screen",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle screen / palette editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Battle screen editor/battle screen editor4.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "battle-screen",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle screen / palette editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Battle screen editor/battle screen editor5.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "battle-screen",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle screen / palette editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Chapter Data Editor/Chapter Data Editor.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "map",
+      "disposition": "existing-avalonia-surface",
+      "target": "MapSetting / MapEditor / MapChange"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Chapter Data Editor/FE6 Event References.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Char and Class editor/FE6 Character Editor.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Char and Class editor/FE6 Class Editor.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Item editor/Item Editor.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "item",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemEditor / item specialized editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Portrait Editors/FE6 Portrait Editor.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "graphics",
+      "disposition": "existing-avalonia-surface",
+      "target": "Graphics editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Promotion Editors/FE6 Promotion Item Editor.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "item",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemEditor / item specialized editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Promotion Editors/FE6 Promotion Pointer Editor.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "promotion",
+      "disposition": "existing-avalonia-surface",
+      "target": "Promotion / CC branch editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Quote editor/Boss battle quote editor.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "quote",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventBattleTalkFE6 / EventHaikuFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Quote editor/Death quote editor.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "quote",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventBattleTalkFE6 / EventHaikuFE6"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Quote editor/Triangle attack quote editor.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "quote",
+      "disposition": "integrated-surface",
+      "target": "EventBattleTalkFE6",
+      "note": "FE6 direct triangle-attack quotes: 6 x 16 at 0x666528"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Random editors/Crit bonus editor.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "hardcode-tuning",
+      "disposition": "patch-manager",
+      "target": "Patch Manager / hard-code editors",
+      "note": "Hard-coded tuning or randomizer-oriented tables are covered by patch/hard-code surfaces, not a Nightmare loader"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Random editors/Level cap editor.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "hardcode-tuning",
+      "disposition": "patch-manager",
+      "target": "Patch Manager / hard-code editors",
+      "note": "Hard-coded tuning or randomizer-oriented tables are covered by patch/hard-code surfaces, not a Nightmare loader"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Random editors/Promotion level editor.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "hardcode-tuning",
+      "disposition": "patch-manager",
+      "target": "Patch Manager / hard-code editors",
+      "note": "Hard-coded tuning or randomizer-oriented tables are covered by patch/hard-code surfaces, not a Nightmare loader"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 10B Armory.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 10B Shop Events.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 11A Shop Events.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 11B Shop Events.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 13 Shop Events.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 14 Shop Events.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 15 Shop Events.NMM",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 16 Shop Events.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 17A Shop Events.NMM",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 17B Shop Events.NMM",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 18B Shop Events.NMM",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 19A Shop Events.NMM",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 19B Shop Events.NMM",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 2 Armory.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 2 Shop Events.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 2 Vendor.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 20A Shop Events.NMM",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 21 Shop Events.NMM",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 23 Shop Events.NMM",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 4 Armory.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 4 Shop Events.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 4 Vendor.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 5 Shop Events.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 5 Vendor.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 7 Left Armory.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 7 Right Armory.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 7 Shop Events.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 7 Vendor.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 9 Armory.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 9 Shop Events.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Chapter 9 Vendor.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Shop Editors/Custom Shop Editor.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Sound Room Editor/FE6 Sound Room Editor.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "audio",
+      "disposition": "existing-avalonia-surface",
+      "target": "SongTable / SoundRoom"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Spell Association Editor/FE6 Spell Association Editor.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "item",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemEditor / item specialized editors"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Support editors/Support Editor.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "support",
+      "disposition": "existing-avalonia-surface",
+      "target": "SupportTalk / SupportUnit"
+    },
+    {
+      "path": "FE6 Nightmare Modules/Support editors/Support bonus editor.nmm",
+      "root": "FE6 Nightmare Modules",
+      "game": "FE6",
+      "family": "support",
+      "disposition": "existing-avalonia-surface",
+      "target": "SupportTalk / SupportUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation Editors/Animation Pointer Table Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "animation",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle animation editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation Editors/Animation Reference.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "animation",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle animation editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation Editors/Battle Animation Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "animation",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle animation editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation Editors/Character-Specific Animation editors/Assassin Legault.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation Editors/Character-Specific Animation editors/Bishop Lucius.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation Editors/Character-Specific Animation editors/Custom Battle Sprite Pointer Table Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation Editors/Character-Specific Animation editors/Hawkeye.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation Editors/Character-Specific Animation editors/Hero Raven.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation Editors/Character-Specific Animation editors/Isadora.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation Editors/Character-Specific Animation editors/Linus 1.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation Editors/Character-Specific Animation editors/Linus 2.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation Editors/Character-Specific Animation editors/Linus 3.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation Editors/Character-Specific Animation editors/Lloyd 1.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation Editors/Character-Specific Animation editors/Lloyd 2.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation Editors/Character-Specific Animation editors/Lloyd 3.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation Editors/Character-Specific Animation editors/Monk Lucius.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation Editors/Character-Specific Animation editors/Myrmidon Guy.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation Editors/Character-Specific Animation editors/Nino Sage.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation Editors/Character-Specific Animation editors/Swordmaster Guy.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation Editors/Character-Specific Animation editors/Thief Legault.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation Editors/Copy of Custom Battle Animation Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "animation",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle animation editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation Editors/Custom Battle Animation Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "animation",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle animation editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation Editors/Custom Item Animation List.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "item",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemEditor / item specialized editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation/Animation Pointer Table Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "animation",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle animation editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation/Animation Reference.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "animation",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle animation editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation/Battle Animation Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "animation",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle animation editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation/Character-Specific Animation editors/Assassin Legault.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation/Character-Specific Animation editors/Bishop Lucius.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation/Character-Specific Animation editors/Custom Battle Sprite Pointer Table Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation/Character-Specific Animation editors/Hawkeye.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation/Character-Specific Animation editors/Hero Raven.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation/Character-Specific Animation editors/Isadora.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation/Character-Specific Animation editors/Linus 1.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation/Character-Specific Animation editors/Linus 2.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation/Character-Specific Animation editors/Linus 3.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation/Character-Specific Animation editors/Lloyd 1.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation/Character-Specific Animation editors/Lloyd 2.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation/Character-Specific Animation editors/Lloyd 3.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation/Character-Specific Animation editors/Monk Lucius.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation/Character-Specific Animation editors/Myrmidon Guy.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation/Character-Specific Animation editors/Nino Sage.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation/Character-Specific Animation editors/Swordmaster Guy.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation/Character-Specific Animation editors/Thief Legault.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation/Copy of Custom Battle Animation Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "animation",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle animation editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation/Custom Battle Animation Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "animation",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle animation editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation/Custom Item Animation List.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "item",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemEditor / item specialized editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Animation/FE7 Battle Palette Reference.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "animation",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle animation editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Arena Class Editor/Arena Class Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Background Editors/Battle BG Array Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "graphics",
+      "disposition": "existing-avalonia-surface",
+      "target": "Graphics editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Background Editors/Convo BG Array Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "quote",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventBattleTalkFE7 / EventHaikuFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Battle Screen Editor/Battle screen editor1.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "battle-screen",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle screen / palette editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Battle Screen Editor/Battle screen editor2.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "battle-screen",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle screen / palette editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Battle Screen Editor/Battle screen editor3.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "battle-screen",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle screen / palette editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Battle Screen Editor/Battle screen editor4.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "battle-screen",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle screen / palette editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Battle Screen Editor/Battle screen editor5.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "battle-screen",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle screen / palette editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Beta Modules/Character Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "beta",
+      "disposition": "explicit-exclusion",
+      "target": "",
+      "note": "Prototype/duplicate beta Nightmare modules are not authoritative FEBuilderGBA coverage targets"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Beta Modules/Class Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "beta",
+      "disposition": "explicit-exclusion",
+      "target": "",
+      "note": "Prototype/duplicate beta Nightmare modules are not authoritative FEBuilderGBA coverage targets"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Beta Modules/Item editor/Item Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "beta",
+      "disposition": "explicit-exclusion",
+      "target": "",
+      "note": "Prototype/duplicate beta Nightmare modules are not authoritative FEBuilderGBA coverage targets"
+    },
+    {
+      "path": "FE7 Nightmare Modules/CG Editor/CG Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "graphics",
+      "disposition": "existing-avalonia-surface",
+      "target": "Graphics editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Data Editor/ChapterDataEditor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "map",
+      "disposition": "existing-avalonia-surface",
+      "target": "MapSetting / MapEditor / MapChange"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Data Editor/Escape Tile Pointer Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "map",
+      "disposition": "existing-avalonia-surface",
+      "target": "MapSetting / MapEditor / MapChange"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Blank CUE.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 1.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 10.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 11E.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 11H.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 12.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 13.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 13x.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 14.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 15.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 16.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 17.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 17x.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 18.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 19.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 19x.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 19xx.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 2.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 20.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 21.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 22.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 23.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 23x.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 24 Linus.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 24 Lloyd.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 25 Cutscene.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 25.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 26.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 27 Jerme.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 27 Kenneth.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 28.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 28x.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 29.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 3.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 30 Eliwood.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 30 Hector.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 31.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 31x.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 32.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 32x.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 4.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 5.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 6.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 7.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 7x.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 8.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter 9.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter Final Boss.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Chapter Final.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Prologue.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Chapter Unit Editor/Unknown18.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Character Editors/Battle Palette Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Character Editors/Character Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Character Editors/Custom Support Pointer Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "support",
+      "disposition": "existing-avalonia-surface",
+      "target": "SupportTalk / SupportUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Character Editors/Endings Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Character Editors/Quote Editors/Death quote editor part 1.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "quote",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventBattleTalkFE7 / EventHaikuFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Character Editors/Quote Editors/Death quote editor part 2.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "quote",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventBattleTalkFE7 / EventHaikuFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Character Editors/Quote Editors/Specified Battle Convo Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "quote",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventBattleTalkFE7 / EventHaikuFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Character Editors/Quote Editors/Triangle Attack Convo Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "quote",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventBattleTalkFE7",
+      "note": "FE7 triangle-attack quotes: existing quote surface, 4 x 12 at 0xC9F130"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Character Editors/Quote Editors/Unspecified Battle Convo Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "quote",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventBattleTalkFE7 / EventHaikuFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Character Editors/Support Bonus Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "support",
+      "disposition": "existing-avalonia-surface",
+      "target": "SupportTalk / SupportUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Character Editors/Support Compatibility Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "support",
+      "disposition": "existing-avalonia-surface",
+      "target": "SupportTalk / SupportUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Character Editors/Support Convo Availability Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "quote",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventBattleTalkFE7 / EventHaikuFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Character Editors/Support Pointer Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "support",
+      "disposition": "existing-avalonia-surface",
+      "target": "SupportTalk / SupportUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Class & Character Editors/Character Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Class & Character Editors/Class Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Class & Character editor/Character Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Class & Character editor/Class Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Class Editors/Arena Class Editor/Arena Class Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Class Editors/Class Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Class Editors/Misc Map Sprite Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "map",
+      "disposition": "existing-avalonia-surface",
+      "target": "MapSetting / MapEditor / MapChange"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Class Editors/Movement Cost Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Class Editors/Standing Map Sprite Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "map",
+      "disposition": "existing-avalonia-surface",
+      "target": "MapSetting / MapEditor / MapChange"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/AI Recruitment Editor/AI Recruitment [P1].nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/AI Recruitment Editor/AI Recruitment [P2].nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/CG Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/FE7 Event References.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/FE7 World Map Event References.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Lyn Ending Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 1.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 10.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 11.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 11H.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 12.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 13.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 13x.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 14.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 15-16.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 15H.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 16-17.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 16x-17x.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 17-18.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 18-19.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 18x-19x.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 19-20.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 19xx.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 2.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 20-21.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 21-22.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 22-23.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 22x-23x.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 23-24 Linus.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 23-24 Lloyd.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 24-26.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 25-27 J.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 25-27 K.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 25H.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 26-28.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 26x-28x.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 27-29.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 28E.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 29-31.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 29-31x.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 3.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 30-32.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 30H.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 32x.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 4.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 5.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 6.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 7.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 7x.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 8.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Chapter 9.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Final Chapter (2).nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Final Chapter.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Pointer Tables/Prologue Pointer Table.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Event Modules/Tutorial Event Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Graphic Editors/Background Editors/Battle BG Array Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "graphics",
+      "disposition": "existing-avalonia-surface",
+      "target": "Graphics editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Graphic Editors/Background Editors/Convo BG Array Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "quote",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventBattleTalkFE7 / EventHaikuFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Graphic Editors/Battle Screen Editor/Battle screen editor1.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "battle-screen",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle screen / palette editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Graphic Editors/Battle Screen Editor/Battle screen editor2.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "battle-screen",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle screen / palette editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Graphic Editors/Battle Screen Editor/Battle screen editor3.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "battle-screen",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle screen / palette editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Graphic Editors/Battle Screen Editor/Battle screen editor4.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "battle-screen",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle screen / palette editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Graphic Editors/Battle Screen Editor/Battle screen editor5.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "battle-screen",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle screen / palette editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Graphic Editors/CG Editor/CG Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "graphics",
+      "disposition": "existing-avalonia-surface",
+      "target": "Graphics editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Graphic Editors/Portrait Editors/Portrait Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "graphics",
+      "disposition": "existing-avalonia-surface",
+      "target": "Graphics editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Item Editors/BOEG Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "item",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemEditor / item specialized editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Item Editors/Item Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "item",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemEditor / item specialized editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Item Editors/Promotion Item/Fallen Contract Promotion Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "item",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemEditor / item specialized editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Item Editors/Promotion Item/Heaven Seal Promotion Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "item",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemEditor / item specialized editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Item Editors/Promotion Item/Ocean Seal Promotion Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "item",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemEditor / item specialized editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Item Editors/Promotion Item/Promotion Item Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "item",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemEditor / item specialized editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Item Editors/Promotion Item/Promotion Pointer Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "item",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemEditor / item specialized editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Item Editors/Spell Association Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "item",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemEditor / item specialized editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Item Editors/Stat Bonuses Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "item",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemEditor / item specialized editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Chest Editors/Chapter 11H.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Chest Editors/Chapter 15.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Chest Editors/Chapter 17.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Chest Editors/Chapter 19x.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Chest Editors/Chapter 19xx.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Chest Editors/Chapter 20.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Chest Editors/Chapter 22.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Chest Editors/Chapter 23x.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Chest Editors/Chapter 26.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Chest Editors/Chapter 27A.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Chest Editors/Chapter 27B.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Chest Editors/Chapter 28.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Chest Editors/Chapter 28x.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Chest Editors/Chapter 29.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Chest Editors/Chapter 30H.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Chest Editors/Chapter 31.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Chest Editors/Chapter 32x.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Chest Editors/Chapter 6.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Chest Editors/Chapter 7x.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Chest Editors/Chapter Final.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Chest Editors/Chapter Unknown2.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnitFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Map Sprite Editor/Misc Map Sprite Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "map",
+      "disposition": "existing-avalonia-surface",
+      "target": "MapSetting / MapEditor / MapChange"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Map Sprite Editor/Standing Map Sprite Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "map",
+      "disposition": "existing-avalonia-surface",
+      "target": "MapSetting / MapEditor / MapChange"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Movement Editors/Movement Type Editor FE7.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "map",
+      "disposition": "existing-avalonia-surface",
+      "target": "MapSetting / MapEditor / MapChange"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Seize Throne Editors/Chapter 10.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "map",
+      "disposition": "existing-avalonia-surface",
+      "target": "MapSetting / MapEditor / MapChange"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Seize Throne Editors/Chapter 11.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "map",
+      "disposition": "existing-avalonia-surface",
+      "target": "MapSetting / MapEditor / MapChange"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Seize Throne Editors/Chapter 13.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "map",
+      "disposition": "existing-avalonia-surface",
+      "target": "MapSetting / MapEditor / MapChange"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Seize Throne Editors/Chapter 15.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "map",
+      "disposition": "existing-avalonia-surface",
+      "target": "MapSetting / MapEditor / MapChange"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Seize Throne Editors/Chapter 16.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "map",
+      "disposition": "existing-avalonia-surface",
+      "target": "MapSetting / MapEditor / MapChange"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Seize Throne Editors/Chapter 18x.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "map",
+      "disposition": "existing-avalonia-surface",
+      "target": "MapSetting / MapEditor / MapChange"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Seize Throne Editors/Chapter 19.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "map",
+      "disposition": "existing-avalonia-surface",
+      "target": "MapSetting / MapEditor / MapChange"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Seize Throne Editors/Chapter 2.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "map",
+      "disposition": "existing-avalonia-surface",
+      "target": "MapSetting / MapEditor / MapChange"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Seize Throne Editors/Chapter 9.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "map",
+      "disposition": "existing-avalonia-surface",
+      "target": "MapSetting / MapEditor / MapChange"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Seize Throne Editors/Prologue.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "map",
+      "disposition": "existing-avalonia-surface",
+      "target": "MapSetting / MapEditor / MapChange"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Custom Shop Editor/Custom Shop Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 10 Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 10 Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 11 Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 12 Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 12 Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 13 Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 13 Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 14 Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 14 Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 16 Left Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 16 Right Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 16 Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 17x Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 18 Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 18 Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 20 Secret1.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 20 Secret2.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 21 Left Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 21 Left Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 21 Right Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 21 Right Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 22 Secret.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 24A Left Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 24A Left Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 24A Right Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 24A Right Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 24A Secret.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 24B Left Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 24B Left Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 24B Right Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 24B Right Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 24B Secret.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 25 Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 25 Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 26 Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 26 Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 29 Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 29 Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 3 Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 31 Secret.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 31x Bottom Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 31x Left Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 31x Right Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 31x tLeft Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 31x tMiddle Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 31x tRight Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 32 Secret.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 5 Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 7 Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Editor/Chapter 8 Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 10 Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 10 Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 11 Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 12 Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 12 Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 13 Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 13 Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 14 Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 14 Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 16 Left Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 16 Right Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 16 Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 17x Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 18 Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 18 Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 20 Secret1.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 20 Secret2.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 21 Left Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 21 Left Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 21 Right Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 21 Right Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 22 Secret.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 24A Left Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 24A Left Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 24A Right Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 24A Right Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 24A Secret.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 24B Left Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 24B Left Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 24B Right Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 24B Right Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 24B Secret.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 25 Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 25 Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 26 Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 26 Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 29 Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 29 Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 3 Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 31 Secret.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 31x Bottom Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 31x Left Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 31x Right Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 31x tLeft Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 31x tMiddle Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 31x tRight Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 32 Secret.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 5 Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 7 Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Chapter 8 Armoury.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Shop Editors/Shop Pointer Editor/Unknown Shop.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Map-Related Editors/Terrain Editors/Terrain Stat Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "map",
+      "disposition": "existing-avalonia-surface",
+      "target": "MapSetting / MapEditor / MapChange"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Menu Editors/Turn Menu Editor FE7.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "menu",
+      "disposition": "existing-avalonia-surface",
+      "target": "Menu editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Menu Editors/Unit Menu Editor FE7.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "menu",
+      "disposition": "existing-avalonia-surface",
+      "target": "Menu editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Music Editors/Boss Music Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "audio",
+      "disposition": "existing-avalonia-surface",
+      "target": "SongTable / SoundRoom"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Music Editors/Music Array Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "audio",
+      "disposition": "existing-avalonia-surface",
+      "target": "SongTable / SoundRoom"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Music Editors/Sound Room Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "audio",
+      "disposition": "existing-avalonia-surface",
+      "target": "SongTable / SoundRoom"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Portrait Editors/Portrait Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "graphics",
+      "disposition": "existing-avalonia-surface",
+      "target": "Graphics editors"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Quote Editors/Death quote editor part 1.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "quote",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventBattleTalkFE7 / EventHaikuFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Quote Editors/Death quote editor part 2.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "quote",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventBattleTalkFE7 / EventHaikuFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Quote Editors/Specified Battle Convo Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "quote",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventBattleTalkFE7 / EventHaikuFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Quote Editors/Triangle Attack Convo Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "quote",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventBattleTalkFE7",
+      "note": "FE7 triangle-attack quotes: existing quote surface, 4 x 12 at 0xC9F130"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Quote Editors/Unspecified Battle Convo Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "quote",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventBattleTalkFE7 / EventHaikuFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Sound Room Editor/Sound Room Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "audio",
+      "disposition": "existing-avalonia-surface",
+      "target": "SongTable / SoundRoom"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Special Editors/Afa's Drop Bonus Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "hardcode-tuning",
+      "disposition": "patch-manager",
+      "target": "Patch Manager / hard-code editors",
+      "note": "Hard-coded tuning or randomizer-oriented tables are covered by patch/hard-code surfaces, not a Nightmare loader"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Special Editors/Beta Modules/Character Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "beta",
+      "disposition": "explicit-exclusion",
+      "target": "",
+      "note": "Prototype/duplicate beta Nightmare modules are not authoritative FEBuilderGBA coverage targets"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Special Editors/Beta Modules/Class Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "beta",
+      "disposition": "explicit-exclusion",
+      "target": "",
+      "note": "Prototype/duplicate beta Nightmare modules are not authoritative FEBuilderGBA coverage targets"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Special Editors/Beta Modules/Item editor/Item Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "beta",
+      "disposition": "explicit-exclusion",
+      "target": "",
+      "note": "Prototype/duplicate beta Nightmare modules are not authoritative FEBuilderGBA coverage targets"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Special Editors/Crit Bonus Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "hardcode-tuning",
+      "disposition": "patch-manager",
+      "target": "Patch Manager / hard-code editors",
+      "note": "Hard-coded tuning or randomizer-oriented tables are covered by patch/hard-code surfaces, not a Nightmare loader"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Special Editors/FE7 Vulnerary Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "hardcode-tuning",
+      "disposition": "patch-manager",
+      "target": "Patch Manager / hard-code editors",
+      "note": "Hard-coded tuning or randomizer-oriented tables are covered by patch/hard-code surfaces, not a Nightmare loader"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Special Editors/Level Cap Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "hardcode-tuning",
+      "disposition": "patch-manager",
+      "target": "Patch Manager / hard-code editors",
+      "note": "Hard-coded tuning or randomizer-oriented tables are covered by patch/hard-code surfaces, not a Nightmare loader"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Special Editors/Luck Cap Editor [P1].nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "hardcode-tuning",
+      "disposition": "patch-manager",
+      "target": "Patch Manager / hard-code editors",
+      "note": "Hard-coded tuning or randomizer-oriented tables are covered by patch/hard-code surfaces, not a Nightmare loader"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Special Editors/Luck Cap Editor [P2].nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "hardcode-tuning",
+      "disposition": "patch-manager",
+      "target": "Patch Manager / hard-code editors",
+      "note": "Hard-coded tuning or randomizer-oriented tables are covered by patch/hard-code surfaces, not a Nightmare loader"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Special Editors/Promotion Level Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "hardcode-tuning",
+      "disposition": "patch-manager",
+      "target": "Patch Manager / hard-code editors",
+      "note": "Hard-coded tuning or randomizer-oriented tables are covered by patch/hard-code surfaces, not a Nightmare loader"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Special Editors/S Rank Bonus Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "hardcode-tuning",
+      "disposition": "patch-manager",
+      "target": "Patch Manager / hard-code editors",
+      "note": "Hard-coded tuning or randomizer-oriented tables are covered by patch/hard-code surfaces, not a Nightmare loader"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Support Editors/Custom Support Pointer Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "support",
+      "disposition": "existing-avalonia-surface",
+      "target": "SupportTalk / SupportUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Support Editors/Endings Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "support",
+      "disposition": "existing-avalonia-surface",
+      "target": "SupportTalk / SupportUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Support Editors/Support Bonus Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "support",
+      "disposition": "existing-avalonia-surface",
+      "target": "SupportTalk / SupportUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Support Editors/Support Compatibility Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "support",
+      "disposition": "existing-avalonia-surface",
+      "target": "SupportTalk / SupportUnit"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Support Editors/Support Convo Availability Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "quote",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventBattleTalkFE7 / EventHaikuFE7"
+    },
+    {
+      "path": "FE7 Nightmare Modules/Support Editors/Support Pointer Editor.nmm",
+      "root": "FE7 Nightmare Modules",
+      "game": "FE7",
+      "family": "support",
+      "disposition": "existing-avalonia-surface",
+      "target": "SupportTalk / SupportUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Animation/Custom Battle Animation Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "animation",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle animation editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Animation/FE8 Battle Palette Reference.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "animation",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle animation editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Battle palette editors/FE8 Palette Association Editor Part 2.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "battle-screen",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle screen / palette editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Battle palette editors/FE8 Palette Association Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "battle-screen",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle screen / palette editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Battle screen editor/battle screen editor1.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "battle-screen",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle screen / palette editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Battle screen editor/battle screen editor2.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "battle-screen",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle screen / palette editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Battle screen editor/battle screen editor3.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "battle-screen",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle screen / palette editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Battle screen editor/battle screen editor4.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "battle-screen",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle screen / palette editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Battle screen editor/battle screen editor5.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "battle-screen",
+      "disposition": "existing-avalonia-surface",
+      "target": "Battle screen / palette editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter1.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter10A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter10B Cutscene.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter10B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter11A Cutscene.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter11A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter11B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter12A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter12B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter13A Cutscene.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter13A Cutscene2.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter13A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter13B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter14A Cutscene.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter14A Cutscene2.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter14A Cutscene3.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter14A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter14B Cutscene.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter14B Cutscene2.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter14B Cutscene3.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter14B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter15A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter15B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter16A Cutscene.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter16A Cutscene2.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter16A Cutscene3.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter16A Cutscene4.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter16A Cutscene5.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter16A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter16B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter17A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter17B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter18A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter18B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter19A Cutscene.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter19A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter19B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter2.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter20A Cutscene.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter20A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter20B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter3 Cutscene.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter3.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter4.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter5.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter5x Cutscene.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter5x Cutscene2.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter5x.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter6.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter7.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter8 Cutscene.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter8 Cutscene2.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter8.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter9A Cutscene.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter9A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter9B Cutscene.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter9B Cutscene2.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Chapter9B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/ChapterFinalA.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/ChapterFinalB + Valni1.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/ChapterFinalBoss.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Prologue Cutscene.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Prologue Cutscene2.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Prologue.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Ruins2 + Melkaen Coast.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Unknown5.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Unknown6.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Valni2.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Valni3.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter Unit Editor/Valni4 + Ruins1.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chapter data editor/Chapter Data Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "map",
+      "disposition": "existing-avalonia-surface",
+      "target": "MapSetting / MapEditor / MapChange"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 1.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 10A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 10B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 11A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 11B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 12A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 12B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 13A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 13B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 14A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 14B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 15A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 15B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 16A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 16B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 17A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 17B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 18A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 18B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 19A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 19B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 2.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 20A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 20B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 3.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 4.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 5.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 5x.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 6.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 7.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 8.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 9A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter 9B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter FinalA.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter FinalB.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter FinalBossA.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Chapter FinalBossB.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Prologue.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Unknown0.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Unknown1.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Unknown10.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Unknown11.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Unknown12.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Unknown13.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Unknown14.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Unknown15.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Unknown16.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Unknown17.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Unknown18.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Unknown19.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Unknown2.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Unknown20.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Unknown21.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Unknown3.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Unknown4.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Unknown5.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Unknown6.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Unknown7.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Unknown8.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Chest Editor/Unknown9.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Class & Character editors/FE8 Character Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE8 Nightmare modules/Class & Character editors/FE8 Class Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE8 Nightmare modules/Event data pointer table editor/Event table editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "event",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventCond / EventScript / EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Item editors/FE8 Custom Item Animation List.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "item",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemEditor / item specialized editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Item editors/FE8 Item Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "item",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemEditor / item specialized editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Item editors/FE8 Item Effect Pointer Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "item",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemEditor / item specialized editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Item editors/FE8 Item Target Pointer Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "item",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemEditor / item specialized editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Item editors/FE8 Item Usability Pointer Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "item",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemEditor / item specialized editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Item editors/FE8 Spell Association Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "item",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemEditor / item specialized editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Item editors/Ocean Seal Promotion Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "item",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemEditor / item specialized editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Item editors/Promotion Item Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "item",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemEditor / item specialized editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Item editors/Stat Bonuses Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "item",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemEditor / item specialized editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Map sprite editor/Misc map sprite editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "map",
+      "disposition": "existing-avalonia-surface",
+      "target": "MapSetting / MapEditor / MapChange"
+    },
+    {
+      "path": "FE8 Nightmare modules/Map sprite editor/Standing map sprite editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "map",
+      "disposition": "existing-avalonia-surface",
+      "target": "MapSetting / MapEditor / MapChange"
+    },
+    {
+      "path": "FE8 Nightmare modules/Menu Editors/Turn Menu Editor FE8.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "menu",
+      "disposition": "existing-avalonia-surface",
+      "target": "Menu editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Menu Editors/Unit Menu Editor FE8.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "menu",
+      "disposition": "existing-avalonia-surface",
+      "target": "Menu editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Portrait Editors/FE8 Portrait Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "graphics",
+      "disposition": "existing-avalonia-surface",
+      "target": "Graphics editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Promotion/Promotion Branch Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "promotion",
+      "disposition": "existing-avalonia-surface",
+      "target": "Promotion / CC branch editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Promotion/Promotion Pointer Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "promotion",
+      "disposition": "existing-avalonia-surface",
+      "target": "Promotion / CC branch editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Quote editors/Boss Quote Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "quote",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventBattleTalk / EventHaiku"
+    },
+    {
+      "path": "FE8 Nightmare modules/Quote editors/Death Quote Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "quote",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventBattleTalk / EventHaiku"
+    },
+    {
+      "path": "FE8 Nightmare modules/Random editors/Crit bonus editorFE8.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "hardcode-tuning",
+      "disposition": "patch-manager",
+      "target": "Patch Manager / hard-code editors",
+      "note": "Hard-coded tuning or randomizer-oriented tables are covered by patch/hard-code surfaces, not a Nightmare loader"
+    },
+    {
+      "path": "FE8 Nightmare modules/Random editors/FE8 Level Cap Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "hardcode-tuning",
+      "disposition": "patch-manager",
+      "target": "Patch Manager / hard-code editors",
+      "note": "Hard-coded tuning or randomizer-oriented tables are covered by patch/hard-code surfaces, not a Nightmare loader"
+    },
+    {
+      "path": "FE8 Nightmare modules/Random editors/FE8 Movement Cost Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "hardcode-tuning",
+      "disposition": "patch-manager",
+      "target": "Patch Manager / hard-code editors",
+      "note": "Hard-coded tuning or randomizer-oriented tables are covered by patch/hard-code surfaces, not a Nightmare loader"
+    },
+    {
+      "path": "FE8 Nightmare modules/Random editors/FE8 Promotion level editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "hardcode-tuning",
+      "disposition": "patch-manager",
+      "target": "Patch Manager / hard-code editors",
+      "note": "Hard-coded tuning or randomizer-oriented tables are covered by patch/hard-code surfaces, not a Nightmare loader"
+    },
+    {
+      "path": "FE8 Nightmare modules/Random editors/FE8 S Rank Bonus Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "hardcode-tuning",
+      "disposition": "patch-manager",
+      "target": "Patch Manager / hard-code editors",
+      "note": "Hard-coded tuning or randomizer-oriented tables are covered by patch/hard-code surfaces, not a Nightmare loader"
+    },
+    {
+      "path": "FE8 Nightmare modules/Random editors/FE8 Terrain Bonus Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "hardcode-tuning",
+      "disposition": "patch-manager",
+      "target": "Patch Manager / hard-code editors",
+      "note": "Hard-coded tuning or randomizer-oriented tables are covered by patch/hard-code surfaces, not a Nightmare loader"
+    },
+    {
+      "path": "FE8 Nightmare modules/Random editors/Support Compatibility Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "hardcode-tuning",
+      "disposition": "patch-manager",
+      "target": "Patch Manager / hard-code editors",
+      "note": "Hard-coded tuning or randomizer-oriented tables are covered by patch/hard-code surfaces, not a Nightmare loader"
+    },
+    {
+      "path": "FE8 Nightmare modules/Randomized Class&Inventory editors/FE8 Class Changer.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "hardcode-tuning",
+      "disposition": "patch-manager",
+      "target": "Patch Manager / hard-code editors",
+      "note": "Hard-coded tuning or randomizer-oriented tables are covered by patch/hard-code surfaces, not a Nightmare loader"
+    },
+    {
+      "path": "FE8 Nightmare modules/Randomized Class&Inventory editors/FE8 Random Item Probability Group Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "hardcode-tuning",
+      "disposition": "patch-manager",
+      "target": "Patch Manager / hard-code editors",
+      "note": "Hard-coded tuning or randomizer-oriented tables are covered by patch/hard-code surfaces, not a Nightmare loader"
+    },
+    {
+      "path": "FE8 Nightmare modules/Randomized Class&Inventory editors/FE8 Random Item Table.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "hardcode-tuning",
+      "disposition": "patch-manager",
+      "target": "Patch Manager / hard-code editors",
+      "note": "Hard-coded tuning or randomizer-oriented tables are covered by patch/hard-code surfaces, not a Nightmare loader"
+    },
+    {
+      "path": "FE8 Nightmare modules/Randomized Class&Inventory editors/Random Item Group Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "hardcode-tuning",
+      "disposition": "patch-manager",
+      "target": "Patch Manager / hard-code editors",
+      "note": "Hard-coded tuning or randomizer-oriented tables are covered by patch/hard-code surfaces, not a Nightmare loader"
+    },
+    {
+      "path": "FE8 Nightmare modules/Recruitment editor/Ch 10A Recruitment editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Recruitment editor/Ch 10B Recruitment editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Recruitment editor/Ch 11A Recruitment editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Recruitment editor/Ch 11B Recruitment editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Recruitment editor/Ch 12B Recruitment editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Recruitment editor/Ch 13A Recruitment editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Recruitment editor/Ch 14A Recruitment editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Recruitment editor/Ch 14B Recruitment editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Recruitment editor/Ch 17A Recruitment editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Recruitment editor/Ch 17B Recruitment editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Recruitment editor/Ch 2 Recruitment editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Recruitment editor/Ch 3 Recruitment editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Recruitment editor/Ch 5 Recruitment editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Recruitment editor/Ch 9A Recruitment editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Recruitment editor/Ch 9B Recruitment editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 1.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 10A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 10B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 11A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 11B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 12A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 12B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 13A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 13B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 14A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 14B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 15A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 15B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 16A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 16B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 17A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 17B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 18A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 18B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 19A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 19B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 2.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 20A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 20B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 3.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 4.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 5.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 6.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 7.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 8.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 9A.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter 9B.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter FinalA.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Chapter FinalB.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Unknown1.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Unknown10.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Unknown11.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Unknown12.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Unknown13.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Unknown14.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Unknown15.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Unknown16.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Unknown20.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Unknown4.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Unknown6.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Reinforcement Editor/Unknown8.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "chapter-unit",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Battle Preparations.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Battle Preperations.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Chapter 10B Armoury.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Chapter 10B Shop.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Chapter 12A Shop.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Chapter 12B Shop.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Chapter 14A Secret.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Chapter 14B Secret.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Chapter 15A Shop.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Chapter 15B Shop.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Chapter 17A Armoury.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Chapter 17A Shop.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Chapter 17B Armoury.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Chapter 17B Shop.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Chapter 19A Secret.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Chapter 19B Secret.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Chapter 2 Armoury.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Chapter 5 Armoury.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Chapter 5 Shop.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Chapter 9A Armoury.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Chapter 9A Shop.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Map - Bethroen Armoury.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Map - Bethroen Shop.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Map - Caer Pelyn Shop.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Map - Grado Keep Secret.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Map - Ide Armoury.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Map - Jehanna Hall Secret.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Map - Jehanna Hall Shop.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Map - Narube River Armoury.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Map - Narube River Shop.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Map - Port Kiris Armoury.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Map - Port Kiris Shop.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Map - Rausten Court Armoury .nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Map - Rausten Court Secret.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Map - Rausten Court Shop.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Map - Serafew Armoury.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Map - Serafew Shop.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Shop Editor/Map - Taizel Shop.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "shop",
+      "disposition": "existing-avalonia-surface",
+      "target": "ItemShopViewer / chapter event editors"
+    },
+    {
+      "path": "FE8 Nightmare modules/Sound Room Editor/Sound Room Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "audio",
+      "disposition": "existing-avalonia-surface",
+      "target": "SongTable / SoundRoom"
+    },
+    {
+      "path": "FE8 Nightmare modules/Summon editors/Summon character editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE8 Nightmare modules/Summon editors/Summon class editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "character-class",
+      "disposition": "existing-avalonia-surface",
+      "target": "UnitEditor / ClassEditor"
+    },
+    {
+      "path": "FE8 Nightmare modules/Support editors/Custom Support Pointer Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "support",
+      "disposition": "existing-avalonia-surface",
+      "target": "SupportTalk / SupportUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Support editors/EndingsEditor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "support",
+      "disposition": "existing-avalonia-surface",
+      "target": "SupportTalk / SupportUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Support editors/Support Pointer Editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "support",
+      "disposition": "existing-avalonia-surface",
+      "target": "SupportTalk / SupportUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Support editors/Support bonus editor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "support",
+      "disposition": "existing-avalonia-surface",
+      "target": "SupportTalk / SupportUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Support editors/SupportCompatibilityEditor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "support",
+      "disposition": "existing-avalonia-surface",
+      "target": "SupportTalk / SupportUnit"
+    },
+    {
+      "path": "FE8 Nightmare modules/Support editors/SupportConvoAvailabilityEditor.nmm",
+      "root": "FE8 Nightmare modules",
+      "game": "FE8",
+      "family": "quote",
+      "disposition": "existing-avalonia-surface",
+      "target": "EventBattleTalk / EventHaiku"
+    }
+  ]
+}

--- a/FEBuilderGBA.Avalonia/ViewModels/EventBattleTalkFE6ViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/EventBattleTalkFE6ViewModel.cs
@@ -18,7 +18,12 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             Main = 0,
             /// <summary>Secondary (boss generic-conversation) table — 16-byte records (event_ballte_talk2_pointer).</summary>
             Secondary = 1,
+            /// <summary>Triangle-attack quotes — direct fixed table, 6 x 16 records.</summary>
+            TriangleAttack = 2,
         }
+
+        const uint TriangleAttackCount = 6;
+        const uint TriangleAttackBlockSize = 16;
 
         // Main (12-byte) schema — matches WinForms EventBattleTalkFE6Form.Init.
         // [B0 atk][B1 def][B2][B3][W4 text][B6][B7][W8 flag][B10][B11]
@@ -31,6 +36,11 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         // [B0 unit][B1][B2][B3][W4 text][B6][B7][W8 flag][B10][B11][D12 event ptr]
         static readonly List<EditorFormRef.FieldDef> _fieldsSecondary =
             EditorFormRef.DetectFields(new[] { "B0", "B1", "B2", "B3", "W4", "B6", "B7", "W8", "B10", "B11", "D12" });
+
+        // Triangle attack quotes: direct table, exactly 6 x 16 records. Only
+        // B0/B1/W4/B8 are writable; every reserved/tail byte is preserved.
+        static readonly List<EditorFormRef.FieldDef> _fieldsTriangle =
+            EditorFormRef.DetectFields(new[] { "B0", "B1", "W4", "B8" });
 
         BattleTalkTable _table = BattleTalkTable.Main;
 
@@ -59,6 +69,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                     // Notify the derived read-only properties so bindings on
                     // IsSecondaryTable / BlockSize refresh too.
                     OnPropertyChanged(nameof(IsSecondaryTable));
+                    OnPropertyChanged(nameof(IsTriangleAttackTable));
                     OnPropertyChanged(nameof(BlockSize));
                 }
             }
@@ -67,8 +78,11 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// <summary>True when the current table uses the 16-byte secondary schema.</summary>
         public bool IsSecondaryTable => _table == BattleTalkTable.Secondary;
 
-        /// <summary>Block size (stride) of the current table: 12 for Main, 16 for Secondary.</summary>
-        public uint BlockSize => IsSecondaryTable ? 16u : 12u;
+        /// <summary>True when the current table is the direct fixed triangle-attack quote table.</summary>
+        public bool IsTriangleAttackTable => _table == BattleTalkTable.TriangleAttack;
+
+        /// <summary>Block size (stride) of the current table: 12 for Main, 16 for Secondary/Triangle.</summary>
+        public uint BlockSize => _table == BattleTalkTable.Main ? 12u : 16u;
 
         public uint CurrentAddr { get => _currentAddr; set => SetField(ref _currentAddr, value); }
         public bool IsLoaded { get => _isLoaded; set => SetField(ref _isLoaded, value); }
@@ -91,13 +105,22 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         public uint EventPointer { get => _eventPointer; set => SetField(ref _eventPointer, value); }
 
         /// <summary>
-        /// Resolves the pointer-location for the given table to its data base
-        /// address (after a p32 deref). Returns 0 when the pointer is missing
-        /// or the dereffed base is unsafe.
+        /// Resolves the selected table to its data base address. Main/Secondary
+        /// dereference their ROM pointer fields; TriangleAttack uses its direct
+        /// fixed ROM address and requires the full 6 x 16 byte range to fit.
+        /// Returns 0 when the source is missing, unsafe, or short.
         /// </summary>
         public static uint ResolveBaseAddr(ROM rom, BattleTalkTable table)
         {
             if (rom?.RomInfo == null) return 0;
+            if (table == BattleTalkTable.TriangleAttack)
+            {
+                uint directBase = rom.RomInfo.event_triangle_attack_quote_address;
+                return HasFullTableRange(rom, directBase, TriangleAttackCount, TriangleAttackBlockSize)
+                    ? U.toOffset(directBase)
+                    : 0;
+            }
+
             uint pointer = table == BattleTalkTable.Secondary
                 ? rom.RomInfo.event_ballte_talk2_pointer
                 : rom.RomInfo.event_ballte_talk_pointer;
@@ -105,6 +128,24 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             uint baseAddr = rom.p32(pointer);
             if (!U.isSafetyOffset(baseAddr, rom)) return 0;
             return baseAddr;
+        }
+
+        static bool HasFullTableRange(ROM rom, uint directBase, uint count, uint blockSize)
+        {
+            if (rom?.Data == null || directBase == 0 || count == 0 || blockSize == 0) return false;
+            uint baseAddr = U.toOffset(directBase);
+            if (!U.isSafetyOffset(baseAddr, rom)) return false;
+            ulong end = (ulong)baseAddr + (ulong)count * (ulong)blockSize;
+            return end <= (ulong)rom.Data.Length;
+        }
+
+        static bool IsTriangleAttackRecordAddr(ROM rom, uint addr)
+        {
+            uint baseAddr = ResolveBaseAddr(rom, BattleTalkTable.TriangleAttack);
+            if (baseAddr == 0 || addr < baseAddr) return false;
+            uint delta = addr - baseAddr;
+            return delta % TriangleAttackBlockSize == 0
+                && delta / TriangleAttackBlockSize < TriangleAttackCount;
         }
 
         /// <summary>
@@ -145,6 +186,8 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
             if (table == BattleTalkTable.Secondary)
                 return LoadSecondaryList(rom, baseAddr);
+            if (table == BattleTalkTable.TriangleAttack)
+                return LoadTriangleAttackList(rom, baseAddr);
 
             const uint blockSize = 12; // FE6 main uses 12-byte blocks
             var result = new List<AddrResult>();
@@ -183,15 +226,47 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             return result;
         }
 
+        static List<AddrResult> LoadTriangleAttackList(ROM rom, uint baseAddr)
+        {
+            var result = new List<AddrResult>((int)TriangleAttackCount);
+            if (!HasFullTableRange(rom, baseAddr, TriangleAttackCount, TriangleAttackBlockSize))
+                return result;
+
+            for (uint i = 0; i < TriangleAttackCount; i++)
+            {
+                uint addr = baseAddr + i * TriangleAttackBlockSize;
+                string unitName = NameResolver.GetUnitNameByOneBasedId(rom.u8(addr));
+                uint chapter = rom.u8(addr + 1);
+                result.Add(new AddrResult(addr, $"0x{i:X2} {unitName} Ch 0x{chapter:X2}", i));
+            }
+            return result;
+        }
+
         public void LoadEntry(uint addr)
         {
             ROM rom = CoreState.ROM;
             if (rom == null) return;
             uint blockSize = BlockSize;
             if (addr + blockSize > (uint)rom.Data.Length) return;
+            if (IsTriangleAttackTable && !IsTriangleAttackRecordAddr(rom, addr)) return;
             CurrentAddr = addr;
 
-            if (IsSecondaryTable)
+            if (IsTriangleAttackTable)
+            {
+                var v = EditorFormRef.ReadFields(rom, addr, _fieldsTriangle);
+                AttackerUnit = v["B0"];
+                DefenderUnit = v["B1"];
+                Unknown02 = rom.u8(addr + 2);
+                Unknown03 = rom.u8(addr + 3);
+                Text = v["W4"];
+                Unknown06 = rom.u8(addr + 6);
+                Unknown07 = rom.u8(addr + 7);
+                AchievementFlag = v["B8"];
+                Unknown0A = rom.u8(addr + 10);
+                Unknown0B = rom.u8(addr + 11);
+                EventPointer = 0;
+            }
+            else if (IsSecondaryTable)
             {
                 // 16-byte secondary schema (text @0x04, flag @0x08, event ptr @0x0C).
                 var v = EditorFormRef.ReadFields(rom, addr, _fieldsSecondary);
@@ -230,7 +305,17 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             ROM rom = CoreState.ROM;
             if (rom == null || CurrentAddr == 0) return;
             uint a = CurrentAddr;
-            if (IsSecondaryTable)
+            if (IsTriangleAttackTable)
+            {
+                if (!IsTriangleAttackRecordAddr(rom, a)) return;
+                var values = new Dictionary<string, uint>
+                {
+                    ["B0"] = AttackerUnit, ["B1"] = DefenderUnit,
+                    ["W4"] = Text, ["B8"] = AchievementFlag,
+                };
+                EditorFormRef.WriteFields(rom, a, values, _fieldsTriangle);
+            }
+            else if (IsSecondaryTable)
             {
                 var values = new Dictionary<string, uint>
                 {
@@ -259,6 +344,19 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
         public Dictionary<string, string> GetDataReport()
         {
+            if (IsTriangleAttackTable)
+            {
+                return new Dictionary<string, string>
+                {
+                    ["addr"] = $"0x{CurrentAddr:X08}",
+                    ["Table"] = _table.ToString(),
+                    ["Character"] = $"0x{AttackerUnit:X02}",
+                    ["Chapter"] = $"0x{DefenderUnit:X02}",
+                    ["Text"] = $"0x{Text:X04}",
+                    ["EventFlagByte"] = $"0x{AchievementFlag:X02}",
+                };
+            }
+
             var report = new Dictionary<string, string>
             {
                 ["addr"] = $"0x{CurrentAddr:X08}",
@@ -284,6 +382,18 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             ROM rom = CoreState.ROM;
             if (rom == null || CurrentAddr == 0) return new Dictionary<string, string>();
             uint a = CurrentAddr;
+            if (IsTriangleAttackTable)
+            {
+                return new Dictionary<string, string>
+                {
+                    ["addr"] = $"0x{a:X08}",
+                    ["u8@0x00_Character"] = $"0x{rom.u8(a + 0):X02}",
+                    ["u8@0x01_Chapter"] = $"0x{rom.u8(a + 1):X02}",
+                    ["u16@0x04_Text"] = $"0x{rom.u16(a + 4):X04}",
+                    ["u8@0x08_EventFlagByte"] = $"0x{rom.u8(a + 8):X02}",
+                };
+            }
+
             var report = new Dictionary<string, string>
             {
                 ["addr"] = $"0x{a:X08}",
@@ -305,6 +415,17 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
         public Dictionary<string, string> GetFieldOffsetMap()
         {
+            if (IsTriangleAttackTable)
+            {
+                return new Dictionary<string, string>
+                {
+                    ["Character"] = "u8@0x00_Character",
+                    ["Chapter"] = "u8@0x01_Chapter",
+                    ["Text"] = "u16@0x04_Text",
+                    ["EventFlagByte"] = "u8@0x08_EventFlagByte",
+                };
+            }
+
             var map = new Dictionary<string, string>
             {
                 ["AttackerUnit"] = "u8@0x00_AttackerUnit",

--- a/FEBuilderGBA.Avalonia/Views/EventBattleTalkFE6View.axaml
+++ b/FEBuilderGBA.Avalonia/Views/EventBattleTalkFE6View.axaml
@@ -4,10 +4,9 @@
              x:Class="FEBuilderGBA.Avalonia.Views.EventBattleTalkFE6View">
   <Grid ColumnDefinitions="250,*">
     <DockPanel Grid.Column="0" Margin="4">
-      <!-- Table filter: switches between the main 12-byte battle-talk table and
-           the FE6-only secondary 16-byte table (event_ballte_talk2_pointer — the
-           boss generic-conversation table), mirroring WinForms
-           EventBattleTalkFE6Form's two address lists. -->
+      <!-- Table filter: switches between the main 12-byte battle-talk table,
+           the FE6-only secondary 16-byte boss-conversation table, and the
+           direct fixed triangle-attack quote table. -->
       <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Spacing="6" Margin="0,0,0,4">
         <TextBlock Text="Table:" VerticalAlignment="Center" />
         <ComboBox AutomationProperties.AutomationId="EventBattleTalkFE6_Table_Combo"
@@ -16,6 +15,7 @@
                wrap each option in a TextBlock so its Text is localized in ja/zh. -->
           <ComboBoxItem><TextBlock Text="Main (12-byte)" /></ComboBoxItem>
           <ComboBoxItem><TextBlock Text="Boss conversation (16-byte)" /></ComboBoxItem>
+          <ComboBoxItem><TextBlock Text="Triangle attack (16-byte)" /></ComboBoxItem>
         </ComboBox>
       </StackPanel>
       <controls:AddressListControl AutomationProperties.AutomationId="EventBattleTalkFE6_Entry_List" Name="EntryList" />
@@ -33,7 +33,7 @@
           <TextBlock Grid.Row="1" Grid.Column="0" Text="Address:" VerticalAlignment="Center" Margin="0,4" />
           <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE6_Addr_Label" Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" Name="AddrLabel" VerticalAlignment="Center" Margin="0,4" />
 
-          <TextBlock Grid.Row="2" Grid.Column="0" Text="Attacker Unit:" VerticalAlignment="Center" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE6_Attacker_Label" Grid.Row="2" Grid.Column="0" Text="Attacker Unit:" VerticalAlignment="Center" Margin="0,4" Name="AttackerLabel" />
           <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE6_AttackerUnit_Input" FormatString="0" Grid.Row="2" Grid.Column="1" Name="AttackerUnitBox" Minimum="0" Maximum="255" Margin="0,4" />
           <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE6_AttackerName_Label" Grid.Row="2" Grid.Column="2" Name="AttackerNameLabel" VerticalAlignment="Center" TextWrapping="Wrap" Margin="8,4" />
 
@@ -41,38 +41,43 @@
           <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE6_DefenderUnit_Input" FormatString="0" Grid.Row="3" Grid.Column="1" Name="DefenderUnitBox" Minimum="0" Maximum="255" Margin="0,4" />
           <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE6_DefenderName_Label" Grid.Row="3" Grid.Column="2" Name="DefenderNameLabel" VerticalAlignment="Center" TextWrapping="Wrap" Margin="8,4" />
 
-          <TextBlock Grid.Row="4" Grid.Column="0" Text="Unknown (0x02):" VerticalAlignment="Center" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE6_Unknown02_Label" Grid.Row="4" Grid.Column="0" Text="Unknown (0x02):" VerticalAlignment="Center" Margin="0,4" Name="Unknown02Label" />
           <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE6_Unknown02_Input" FormatString="0" Grid.Row="4" Grid.Column="1" Name="Unknown02Box" Minimum="0" Maximum="255" Margin="0,4" />
 
-          <TextBlock Grid.Row="5" Grid.Column="0" Text="Unknown (0x03):" VerticalAlignment="Center" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE6_Unknown03_Label" Grid.Row="5" Grid.Column="0" Text="Unknown (0x03):" VerticalAlignment="Center" Margin="0,4" Name="Unknown03Label" />
           <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE6_Unknown03_Input" FormatString="0" Grid.Row="5" Grid.Column="1" Name="Unknown03Box" Minimum="0" Maximum="255" Margin="0,4" />
 
           <TextBlock Grid.Row="6" Grid.Column="0" Text="Text:" VerticalAlignment="Center" Margin="0,4" />
           <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE6_Text_Input" FormatString="0" Grid.Row="6" Grid.Column="1" Name="TextIdBox" Minimum="0" Maximum="65535" Margin="0,4" />
           <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE6_TextPreview_Label" Grid.Row="6" Grid.Column="2" Name="TextPreviewLabel" VerticalAlignment="Center" TextWrapping="Wrap" Margin="8,4" />
 
-          <TextBlock Grid.Row="7" Grid.Column="0" Text="Unknown (0x06):" VerticalAlignment="Center" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE6_Unknown06_Label" Grid.Row="7" Grid.Column="0" Text="Unknown (0x06):" VerticalAlignment="Center" Margin="0,4" Name="Unknown06Label" />
           <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE6_Unknown06_Input" FormatString="0" Grid.Row="7" Grid.Column="1" Name="Unknown06Box" Minimum="0" Maximum="255" Margin="0,4" />
 
-          <TextBlock Grid.Row="8" Grid.Column="0" Text="Unknown (0x07):" VerticalAlignment="Center" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE6_Unknown07_Label" Grid.Row="8" Grid.Column="0" Text="Unknown (0x07):" VerticalAlignment="Center" Margin="0,4" Name="Unknown07Label" />
           <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE6_Unknown07_Input" FormatString="0" Grid.Row="8" Grid.Column="1" Name="Unknown07Box" Minimum="0" Maximum="255" Margin="0,4" />
 
-          <TextBlock Grid.Row="9" Grid.Column="0" Text="Achievement Flag:" VerticalAlignment="Center" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE6_AchievementFlag_Label" Grid.Row="9" Grid.Column="0" Text="Achievement Flag:" VerticalAlignment="Center" Margin="0,4" Name="AchievementFlagLabel" />
           <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE6_AchievementFlag_Input" FormatString="0" Grid.Row="9" Grid.Column="1" Name="AchievementFlagBox" Minimum="0" Maximum="65535" Margin="0,4" />
 
-          <TextBlock Grid.Row="10" Grid.Column="0" Text="Unknown (0x0A):" VerticalAlignment="Center" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE6_Unknown0A_Label" Grid.Row="10" Grid.Column="0" Text="Unknown (0x0A):" VerticalAlignment="Center" Margin="0,4" Name="Unknown0ALabel" />
           <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE6_Unknown0A_Input" FormatString="0" Grid.Row="10" Grid.Column="1" Name="Unknown0ABox" Minimum="0" Maximum="255" Margin="0,4" />
 
-          <TextBlock Grid.Row="11" Grid.Column="0" Text="Unknown (0x0B):" VerticalAlignment="Center" Margin="0,4" />
+          <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE6_Unknown0B_Label" Grid.Row="11" Grid.Column="0" Text="Unknown (0x0B):" VerticalAlignment="Center" Margin="0,4" Name="Unknown0BLabel" />
           <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE6_Unknown0B_Input" FormatString="0" Grid.Row="11" Grid.Column="1" Name="Unknown0BBox" Minimum="0" Maximum="255" Margin="0,4" />
 
           <!-- Event pointer (offset +0x0C) — only present in the secondary
-               16-byte boss-conversation table. Hidden in main-table mode. -->
+               16-byte boss-conversation table. Hidden in main/triangle modes. -->
           <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE6_EventPointer_Label" Grid.Row="12" Grid.Column="0" Text="Event Pointer:" VerticalAlignment="Center" Margin="0,4" Name="EventPointerLabel" IsVisible="False" />
           <NumericUpDown AutomationProperties.AutomationId="EventBattleTalkFE6_EventPointer_Input" FormatString="0" Grid.Row="12" Grid.Column="1" Name="EventPointerBox" Minimum="0" Maximum="4294967295" Margin="0,4" IsVisible="False" />
         </Grid>
 
-        <TextBlock Text="A mid-battle conversation triggered when the attacker and defender units fight. The boss-conversation table holds FE6's generic boss lines (a single triggering unit plus an event pointer)." TextWrapping="Wrap" Foreground="Gray" Margin="0,8" />
+        <TextBlock AutomationProperties.AutomationId="EventBattleTalkFE6_Help_Label"
+                   Name="HelpTextLabel"
+                   Text="Main battle-dialogue rows are 12-byte attacker/defender/text/flag records triggered when those two units fight."
+                   TextWrapping="Wrap"
+                   Foreground="Gray"
+                   Margin="0,8" />
 
         <Button AutomationProperties.AutomationId="EventBattleTalkFE6_Write_Button" Name="WriteButton" Content="Write" HorizontalAlignment="Left" Margin="0,8" />
       </StackPanel>

--- a/FEBuilderGBA.Avalonia/Views/EventBattleTalkFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/EventBattleTalkFE6View.axaml.cs
@@ -9,6 +9,11 @@ namespace FEBuilderGBA.Avalonia.Views
 {
     public partial class EventBattleTalkFE6View : TranslatedUserControl, IEmbeddableEditor, IDataVerifiableView
     {
+        const string TriangleCharacterLabelKey = "Character (Unit):";
+        const string MainHelpText = "Main battle-dialogue rows are 12-byte attacker/defender/text/flag records triggered when those two units fight.";
+        const string SecondaryHelpText = "FE6's boss-conversation table stores 16-byte generic boss lines: one triggering unit, a chapter/map id, text, flag, and an event pointer.";
+        const string TriangleHelpText = "FE6's triangle-attack quotes use a direct 6-row 16-byte table: character, chapter/map id, text, and event/flag byte only. There is no event pointer.";
+
         readonly EventBattleTalkFE6ViewModel _vm = new();
         readonly UndoService _undoService = new();
 
@@ -29,10 +34,10 @@ namespace FEBuilderGBA.Avalonia.Views
             WriteButton.Click += OnWrite;
 
             // Live name/text previews while editing. The second field is a unit
-            // only on the main table (it is a chapter id on the secondary table),
-            // so its name preview is suppressed in secondary mode.
+            // only on the main table (it is a chapter id on secondary/triangle),
+            // so its name preview is suppressed outside main mode.
             AttackerUnitBox.ValueChanged += (_, _) => AttackerNameLabel.Text = UnitName(AttackerUnitBox);
-            DefenderUnitBox.ValueChanged += (_, _) => DefenderNameLabel.Text = _vm.IsSecondaryTable ? "" : UnitName(DefenderUnitBox);
+            DefenderUnitBox.ValueChanged += (_, _) => DefenderNameLabel.Text = (_vm.IsSecondaryTable || _vm.IsTriangleAttackTable) ? "" : UnitName(DefenderUnitBox);
             TextIdBox.ValueChanged += (_, _) => TextPreviewLabel.Text = TextPreview(TextIdBox);        }
 
 
@@ -55,9 +60,12 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         EventBattleTalkFE6ViewModel.BattleTalkTable SelectedTable =>
-            TableFilter.SelectedIndex == 1
-                ? EventBattleTalkFE6ViewModel.BattleTalkTable.Secondary
-                : EventBattleTalkFE6ViewModel.BattleTalkTable.Main;
+            TableFilter.SelectedIndex switch
+            {
+                1 => EventBattleTalkFE6ViewModel.BattleTalkTable.Secondary,
+                2 => EventBattleTalkFE6ViewModel.BattleTalkTable.TriangleAttack,
+                _ => EventBattleTalkFE6ViewModel.BattleTalkTable.Main,
+            };
 
         void TableFilter_SelectionChanged(object? sender, SelectionChangedEventArgs e)
         {
@@ -92,20 +100,46 @@ namespace FEBuilderGBA.Avalonia.Views
 
         // Adjust the editor chrome for the active table:
         // - The event-pointer field (offset +0x0C) exists only in the secondary
-        //   16-byte boss-conversation table; hide it on the main table.
-        // - In the secondary table WinForms labels B1 as 章ID (chapter/map id),
-        //   not a defender unit (EventBattleTalkFE6Form.Designer N_J_1_MAP), so
-        //   relabel the second field and hide its unit-name preview there.
+        //   16-byte boss-conversation table; hide it on main/triangle tables.
+        // - Secondary and triangle tables use B1 as a chapter/map id rather than
+        //   a defender unit, so relabel the second field and hide its unit-name
+        //   preview there.
         void ApplyTableVisibility()
         {
             bool secondary = _vm.IsSecondaryTable;
+            bool triangle = _vm.IsTriangleAttackTable;
+            bool showUnknowns = !triangle;
+
             EventPointerLabel.IsVisible = secondary;
             EventPointerBox.IsVisible = secondary;
 
-            DefenderLabel.Text = R._(secondary ? "Chapter/Map ID:" : "Defender Unit:");
+            AttackerLabel.Text = triangle ? TriangleCharacterLabelText() : R._("Attacker Unit:");
+            DefenderLabel.Text = R._((secondary || triangle) ? "Chapter/Map ID:" : "Defender Unit:");
             // The second field is a unit only on the main table; on the secondary
-            // table it is a chapter id, so suppress the misleading unit-name preview.
-            DefenderNameLabel.IsVisible = !secondary;
+            // and triangle tables it is a chapter/map id.
+            DefenderNameLabel.IsVisible = !(secondary || triangle);
+
+            Unknown02Label.IsVisible = Unknown02Box.IsVisible = showUnknowns;
+            Unknown03Label.IsVisible = Unknown03Box.IsVisible = showUnknowns;
+            Unknown06Label.IsVisible = Unknown06Box.IsVisible = showUnknowns;
+            Unknown07Label.IsVisible = Unknown07Box.IsVisible = showUnknowns;
+            Unknown0ALabel.IsVisible = Unknown0ABox.IsVisible = showUnknowns;
+            Unknown0BLabel.IsVisible = Unknown0BBox.IsVisible = showUnknowns;
+
+            AchievementFlagLabel.Text = R._(triangle ? "Event/Flag Byte:" : "Achievement Flag:");
+            AchievementFlagBox.Maximum = triangle ? 255 : 65535;
+            HelpTextLabel.Text = R._(_vm.Table switch
+            {
+                EventBattleTalkFE6ViewModel.BattleTalkTable.Secondary => SecondaryHelpText,
+                EventBattleTalkFE6ViewModel.BattleTalkTable.TriangleAttack => TriangleHelpText,
+                _ => MainHelpText,
+            });
+        }
+
+        static string TriangleCharacterLabelText()
+        {
+            string translated = R._(TriangleCharacterLabelKey);
+            return translated == TriangleCharacterLabelKey ? "Character:" : translated;
         }
 
         void OnSelected(uint addr)
@@ -132,7 +166,12 @@ namespace FEBuilderGBA.Avalonia.Views
             // Route through R._() at assignment time — TranslatedUserControl.TranslateAll()
             // runs once at window open, so values assigned afterward must be
             // localized explicitly to apply in ja/zh.
-            TableLabel.Text = R._(_vm.IsSecondaryTable ? "Boss conversation (16-byte)" : "Main (12-byte)");
+            TableLabel.Text = _vm.Table switch
+            {
+                EventBattleTalkFE6ViewModel.BattleTalkTable.Secondary => R._("Boss conversation (16-byte)"),
+                EventBattleTalkFE6ViewModel.BattleTalkTable.TriangleAttack => R._("Triangle attack (16-byte)"),
+                _ => R._("Main (12-byte)"),
+            };
             AddrLabel.Text = string.Format("0x{0:X08}", _vm.CurrentAddr);
             AttackerUnitBox.Value = _vm.AttackerUnit;
             DefenderUnitBox.Value = _vm.DefenderUnit;
@@ -147,9 +186,9 @@ namespace FEBuilderGBA.Avalonia.Views
             EventPointerBox.Value = _vm.EventPointer;
 
             AttackerNameLabel.Text = UnitName(AttackerUnitBox);
-            // On the secondary table the second field is a chapter id (not a unit),
+            // Outside the main table the second field is a chapter id (not a unit),
             // so don't render a unit-name preview for it.
-            DefenderNameLabel.Text = _vm.IsSecondaryTable ? "" : UnitName(DefenderUnitBox);
+            DefenderNameLabel.Text = (_vm.IsSecondaryTable || _vm.IsTriangleAttackTable) ? "" : UnitName(DefenderUnitBox);
             TextPreviewLabel.Text = TextPreview(TextIdBox);
         }
 
@@ -185,7 +224,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.Unknown0A = (uint)(Unknown0ABox.Value ?? 0);
                 _vm.Unknown0B = (uint)(Unknown0BBox.Value ?? 0);
                 // Only the secondary 16-byte table carries the event pointer;
-                // the VM ignores EventPointer for main-table writes.
+                // the VM ignores EventPointer for main/triangle writes.
                 _vm.EventPointer = (uint)(EventPointerBox.Value ?? 0);
                 _vm.Write();
                 _undoService.Commit();
@@ -201,10 +240,10 @@ namespace FEBuilderGBA.Avalonia.Views
         /// <summary>
         /// Select the row whose address matches <paramref name="address"/>.
         /// Resolves which physical table the address belongs to — the main
-        /// 12-byte table or the secondary 16-byte boss-conversation table
-        /// (<c>event_ballte_talk2_pointer</c>) — switches the Table filter combo
-        /// to that table (reloading the list under the correct schema), then
-        /// selects the row.
+        /// 12-byte table, secondary 16-byte boss-conversation table, or direct
+        /// fixed triangle-attack table — switches the Table filter combo to that
+        /// table (reloading the list under the correct schema), then selects the
+        /// row.
         /// </summary>
         public void NavigateTo(uint address)
         {
@@ -227,8 +266,9 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         /// <summary>
-        /// Returns the Table filter combo index (0=Main, 1=Secondary) whose
-        /// data region contains <paramref name="address"/>, or -1 if none.
+        /// Returns the Table filter combo index (0=Main, 1=Secondary,
+        /// 2=TriangleAttack) whose data region contains <paramref name="address"/>,
+        /// or -1 if none.
         /// Read-only: does not mutate the VM's current-table state.
         /// FE6 main is 12-byte stride (stop on u16==0||0xFFFF); the secondary
         /// boss-conversation table is 16-byte stride (also u16 termination —
@@ -261,6 +301,15 @@ namespace FEBuilderGBA.Avalonia.Views
                     if (u == 0 || u == 0xFFFF) break;
                     if (a == address) return 1;
                 }
+            }
+
+            // Triangle attack: direct fixed 6 x 16 table. No pointer deref and
+            // no terminator scan.
+            uint triBase = EventBattleTalkFE6ViewModel.ResolveBaseAddr(rom, EventBattleTalkFE6ViewModel.BattleTalkTable.TriangleAttack);
+            if (triBase != 0 && address >= triBase && (address - triBase) % 16 == 0)
+            {
+                uint index = (address - triBase) / 16;
+                if (index < 6) return 2;
             }
             return -1;
         }

--- a/FEBuilderGBA.Core.Tests/TextRefTableRegistryTests.cs
+++ b/FEBuilderGBA.Core.Tests/TextRefTableRegistryTests.cs
@@ -385,6 +385,74 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Equal(12u, dt.MaxCount);
         }
 
+
+        [Fact]
+        public void FE6_TriangleAttackTalk_HasDirectFixedDescriptor()
+        {
+            var rom = MakeRomFE6();
+            Assert.Equal(0x666528u, rom.RomInfo.event_triangle_attack_quote_address);
+
+            var tables = TextRefTableRegistry.BuildForRom(rom);
+            var tri = tables.First(t => t.Kind == "TriangleAttackTalk");
+            Assert.Equal(0u, tri.PointerField);
+            Assert.Equal(0x666528u, tri.DirectBase);
+            Assert.Equal(16u, tri.EntrySize);
+            Assert.Equal(6u, tri.MaxCount);
+            Assert.True(tri.RequireFullRange);
+            Assert.Equal(new uint[] { 4 }, tri.TextIdOffsets);
+            Assert.Null(tri.Terminator);
+        }
+
+        [Fact]
+        public void FE6_TriangleAttackTalk_TextReferences_UseFixedDirectCount_NoTerminatorOrNeighborScan()
+        {
+            var rom = MakeRomFE6();
+            uint baseAddr = rom.RomInfo.event_triangle_attack_quote_address;
+
+            for (uint i = 0; i < 6; i++)
+            {
+                uint addr = baseAddr + i * 16;
+                rom.Data[addr + 0] = i == 0 ? (byte)0x00 : i == 1 ? (byte)0xFF : (byte)(0x10 + i);
+                rom.Data[addr + 1] = i == 1 ? (byte)0xFF : (byte)i;
+                rom.write_u16(addr + 4, 0x600 + i);
+            }
+            rom.write_u16(baseAddr + 6 * 16 + 4, 0x700);
+
+            var ids = TextReferenceFinder.CollectReferencedTextIds(
+                rom, TextRefTableRegistry.BuildForRom(rom));
+
+            for (uint id = 0x600; id < 0x606; id++)
+                Assert.Contains(id, ids);
+            Assert.DoesNotContain(0x700u, ids);
+        }
+
+        [Fact]
+        public void FE6_TriangleAttackTalk_TextReferences_ShortRomFailsClosed()
+        {
+            var rom = MakeRomFE6();
+            uint baseAddr = rom.RomInfo.event_triangle_attack_quote_address;
+            var shortData = new byte[(int)(baseAddr + 5 * 16 + 6)];
+            shortData[baseAddr + 4] = 0x34;
+            shortData[baseAddr + 5] = 0x12;
+            rom.SwapNewROMDataDirect(shortData);
+
+            var ids = TextReferenceFinder.CollectReferencedTextIds(
+                rom, TextRefTableRegistry.BuildForRom(rom));
+
+            Assert.DoesNotContain(0x1234u, ids);
+        }
+
+        [Fact]
+        public void NonFE6_Roms_DoNotExposeTriangleAttackTalkAddress()
+        {
+            var roms = new[] { MakeRomFE7JP(), MakeRomFE7U(), MakeRomFE8JP(), MakeRomFE8U() };
+            foreach (var rom in roms)
+            {
+                Assert.Equal(0u, rom.RomInfo.event_triangle_attack_quote_address);
+                Assert.DoesNotContain(TextRefTableRegistry.BuildForRom(rom), t => t.Kind == "TriangleAttackTalk");
+            }
+        }
+
         // ---------- Configuration validity sweep ----------
 
         [Fact]

--- a/FEBuilderGBA.Core.Tests/UseFlagScanCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/UseFlagScanCoreTests.cs
@@ -399,6 +399,88 @@ namespace FEBuilderGBA.Core.Tests
             });
         }
 
+
+        // =================================================================
+        // Issue #2114 — FE6 triangle-attack quotes, direct 6 x 16 table.
+        // =================================================================
+
+        const int Fe6RomSize = 0x800000;
+        const uint Fe6TriangleBase = 0x666528u;
+
+        static void WithFe6Triangle(System.Action<ROM> body)
+        {
+            var prevRom = CoreState.ROM;
+            var prevEs = CoreState.EventScript;
+            var prevComment = CoreState.CommentCache;
+            try
+            {
+                var rom = new ROM();
+                Assert.True(rom.LoadLow("flagscan-fe6.gba", new byte[Fe6RomSize], "AFEJ01"));
+                Assert.Equal(Fe6TriangleBase, rom.RomInfo.event_triangle_attack_quote_address);
+                CoreState.ROM = rom;
+                CoreState.EventScript = null;
+                CoreState.CommentCache = null;
+                body(rom);
+            }
+            finally
+            {
+                CoreState.ROM = prevRom;
+                CoreState.EventScript = prevEs;
+                CoreState.CommentCache = prevComment;
+            }
+        }
+
+        [Fact]
+        public void Scan_FE6TriangleAttack_FindsByteFlags_IgnoresTerminatorsAndNeighbor()
+        {
+            WithFe6Triangle(rom =>
+            {
+                // Record 0 begins with u16==0; record 1 begins with u16==0xFFFF.
+                // A terminator scan would miss one or both. The direct table must
+                // still scan exactly the fixed six records and no seventh neighbor.
+                rom.Data[Fe6TriangleBase + 0] = 0x00;
+                rom.Data[Fe6TriangleBase + 1] = 0x00;
+                rom.Data[Fe6TriangleBase + 8] = 0x41;
+
+                uint row1 = Fe6TriangleBase + 16;
+                rom.Data[row1 + 0] = 0xFF;
+                rom.Data[row1 + 1] = 0xFF; // any chapter marker
+                rom.Data[row1 + 8] = 0x42;
+
+                uint row5 = Fe6TriangleBase + 5 * 16;
+                rom.Data[row5 + 0] = 0x20;
+                rom.Data[row5 + 1] = 0x02;
+                rom.Data[row5 + 8] = 0x43;
+
+                rom.Data[Fe6TriangleBase + 6 * 16 + 1] = 0x00;
+                rom.Data[Fe6TriangleBase + 6 * 16 + 8] = 0x44;
+
+                var map0 = UseFlagScanCore.Scan(rom, 0u);
+                Assert.Contains(map0, u => u.ID == 0x41 && u.DataType == FELintCore.Type.BATTTLE_TALK && u.Addr == Fe6TriangleBase);
+                Assert.Contains(map0, u => u.ID == 0x42 && u.DataType == FELintCore.Type.BATTTLE_TALK && u.Addr == row1);
+                Assert.DoesNotContain(map0, u => u.ID == 0x43);
+                Assert.DoesNotContain(map0, u => u.ID == 0x44);
+
+                var map2 = UseFlagScanCore.Scan(rom, 2u);
+                Assert.Contains(map2, u => u.ID == 0x43 && u.DataType == FELintCore.Type.BATTTLE_TALK && u.Addr == row5);
+            });
+        }
+
+        [Fact]
+        public void Scan_FE6TriangleAttack_ShortRomFailsClosed()
+        {
+            WithFe6Triangle(rom =>
+            {
+                var shortData = new byte[(int)(Fe6TriangleBase + 5 * 16 + 9)];
+                shortData[Fe6TriangleBase + 1] = 0x00;
+                shortData[Fe6TriangleBase + 8] = 0x55;
+                rom.SwapNewROMDataDirect(shortData);
+
+                var list = UseFlagScanCore.Scan(rom, 0u);
+                Assert.DoesNotContain(list, u => u.ID == 0x55 && u.DataType == FELintCore.Type.BATTTLE_TALK);
+            });
+        }
+
         // =================================================================
         // Real-ROM regression test for the PR #1254 duplicate-row bug
         // (skipped when the ROM is absent — e.g. CI without roms/).

--- a/FEBuilderGBA.Core/ROMFE6JP.cs
+++ b/FEBuilderGBA.Core/ROMFE6JP.cs
@@ -100,6 +100,7 @@ namespace FEBuilderGBA
             sound_room_cg_pointer = 0x0;  // サウンドルームの背景リスト(FE7のみ)
             event_ballte_talk_pointer = 0x6b660;  // 交戦時セリフの開始位置
             event_ballte_talk2_pointer = 0x6b744; // 交戦時セリフの開始位置2 (FE6だとボス汎用会話テーブルがある)
+            event_triangle_attack_quote_address = 0x666528; // FE6 triangle-attack quote table direct address
             event_haiku_pointer = 0x6b7fc;  // 死亡時セリフの開始位置
             event_haiku_tutorial_1_pointer = 0x0;  // リン編チュートリアル 死亡時セリフの開始位置 FE7のみ
             event_haiku_tutorial_2_pointer = 0x0;  // エリウッド編チュートリアル 死亡時セリフの開始位置 FE7のみ

--- a/FEBuilderGBA.Core/Rom.cs
+++ b/FEBuilderGBA.Core/Rom.cs
@@ -87,6 +87,7 @@ namespace FEBuilderGBA
         public uint sound_room_cg_pointer { get; protected set; } // サウンドルームの背景リスト(FE7のみ)
         public uint event_ballte_talk_pointer { get; protected set; } // 交戦時セリフの開始位置
         public uint event_ballte_talk2_pointer { get; protected set; } // 交戦時セリフの開始位置2 (FE6だとボス汎用会話テーブルがある)
+        public uint event_triangle_attack_quote_address { get; protected set; } // FE6 triangle-attack quote table direct address
         public uint event_haiku_pointer { get; protected set; } // 死亡時セリフの開始位置
         public uint event_haiku_tutorial_1_pointer { get; protected set; } // リン編チュートリアル 死亡時セリフの開始位置 FE7のみ
         public uint event_haiku_tutorial_2_pointer { get; protected set; } // エリウッド編チュートリアル 死亡時セリフの開始位置 FE7のみ

--- a/FEBuilderGBA.Core/TextRefTableRegistry.cs
+++ b/FEBuilderGBA.Core/TextRefTableRegistry.cs
@@ -934,6 +934,23 @@ namespace FEBuilderGBA
                 });
             }
 
+            // EventTriangleAttackTalk (FE6) — direct 0x666528 table, exactly
+            // six 16-byte records, W4 text id. This is NOT a pointer field and
+            // has no terminator scan; short/unsafe ROMs skip the whole table.
+            if (info.event_triangle_attack_quote_address != 0)
+            {
+                list.Add(new TextRefTableDescriptor
+                {
+                    Kind = "TriangleAttackTalk",
+                    DirectBase = info.event_triangle_attack_quote_address,
+                    EntrySize = 16,
+                    MaxCount = 6,
+                    RequireFullRange = true,
+                    TextIdOffsets = new uint[] { 4 },
+                    NameResolver = id => $"TriangleAttack {id:X02}",
+                });
+            }
+
             // SoundRoom (FE6) — offsets {4, 8} (different from FE7/8 which use {12}).
             // SoundRoomFE6Form.MakeVarsIDArray uses { 4, 8 }; Init: stop on
             // u32==0xFFFFFFFF OR (i > 10 && IsEmpty(addr, size*10)).

--- a/FEBuilderGBA.Core/TextReferenceFinder.cs
+++ b/FEBuilderGBA.Core/TextReferenceFinder.cs
@@ -46,6 +46,13 @@ namespace FEBuilderGBA
         /// <summary>Maximum number of entries to scan.</summary>
         public uint MaxCount { get; init; }
 
+        /// <summary>
+        /// When true, the full <see cref="MaxCount"/> * <see cref="EntrySize"/>
+        /// range must fit in the ROM or the table is skipped. Use for fixed
+        /// direct-address tables where partial tail scans would be unsafe.
+        /// </summary>
+        public bool RequireFullRange { get; init; }
+
         /// <summary>Byte offsets within each entry that hold a u16 text ID.</summary>
         public uint[] TextIdOffsets { get; init; } = Array.Empty<uint>();
 
@@ -211,6 +218,7 @@ namespace FEBuilderGBA
             ulong end = (ulong)baseAddr + (ulong)t.MaxCount * (ulong)t.EntrySize;
             if (end > (ulong)rom.Data.Length)
             {
+                if (t.RequireFullRange) return;
                 ulong available = (ulong)rom.Data.Length - (ulong)baseAddr;
                 fittingCount = (uint)(available / t.EntrySize);
                 if (fittingCount == 0) return;

--- a/FEBuilderGBA.Core/UseFlagScanCore.cs
+++ b/FEBuilderGBA.Core/UseFlagScanCore.cs
@@ -390,6 +390,11 @@ namespace FEBuilderGBA
                 // WF N_Init stops on u16==0 || 0xFFFF (NOT 0xFFFF only) — #1256.
                 AppendFlagTable(rom, mapId, list, FELintCore.Type.BATTTLE_TALK,
                     talk2Ptr, 16, 8, 1, TableTerm.U16ZeroOrSentinel);
+                // + Triangle attack quotes: direct fixed table, exactly 6 x 16,
+                // byte flag/event id at +8, chapter at +1. No pointer deref and
+                // no terminator/empty-run scan.
+                AppendDirectByteFlagTable(rom, mapId, list, FELintCore.Type.BATTTLE_TALK,
+                    rom.RomInfo.event_triangle_attack_quote_address, 6, 16, 8, 1);
             }
         }
 
@@ -460,6 +465,36 @@ namespace FEBuilderGBA
                 uint mapid = anyChapter ? U.NOT_FOUND : mapId;
                 UseFlagIDCore.AppendUseFlagID(
                     list, type, addr, U.ToHexString((uint)i), flag, mapid, (uint)i);
+            }
+        }
+
+        static void AppendDirectByteFlagTable(
+            ROM rom, uint mapId, List<UseFlagIDCore> list, FELintCore.Type type,
+            uint directBase, uint count, uint blockSize, uint flagOffset, uint chapterOffset)
+        {
+            if (list == null) return;
+            if (directBase == 0 || count == 0 || blockSize == 0) return;
+            if (flagOffset >= blockSize || chapterOffset >= blockSize) return;
+
+            uint baseAddr = U.toOffset(directBase);
+            if (!U.isSafetyOffset(baseAddr, rom)) return;
+
+            ulong end = (ulong)baseAddr + (ulong)count * (ulong)blockSize;
+            if (end > (ulong)rom.Data.Length) return;
+
+            for (uint i = 0; i < count; i++)
+            {
+                uint addr = baseAddr + i * blockSize;
+                uint flag = rom.u8(addr + flagOffset);
+                if (flag == 0) continue;
+
+                uint chapter = rom.u8(addr + chapterOffset);
+                bool anyChapter = chapter >= 0xF0;
+                if (!anyChapter && chapter != mapId) continue;
+
+                uint resolvedMapId = anyChapter ? U.NOT_FOUND : mapId;
+                UseFlagIDCore.AppendUseFlagID(
+                    list, type, addr, U.ToHexString(i), flag, resolvedMapId, i);
             }
         }
 

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -21188,3 +21188,21 @@ Enter the new entry count for the AI pointer table (current: {0}, max: {1}).
 
 :GitHubでバグを報告
 Report a Bug on GitHub
+
+:Triangle attack (16-byte)
+Triangle attack (16-byte)
+
+:Event/Flag Byte:
+Event/Flag Byte:
+
+:Character (Unit):
+Character:
+
+:Main battle-dialogue rows are 12-byte attacker/defender/text/flag records triggered when those two units fight.
+Main battle-dialogue rows are 12-byte attacker/defender/text/flag records triggered when those two units fight.
+
+:FE6's boss-conversation table stores 16-byte generic boss lines: one triggering unit, a chapter/map id, text, flag, and an event pointer.
+FE6's boss-conversation table stores 16-byte generic boss lines: one triggering unit, a chapter/map id, text, flag, and an event pointer.
+
+:FE6's triangle-attack quotes use a direct 6-row 16-byte table: character, chapter/map id, text, and event/flag byte only. There is no event pointer.
+FE6's triangle-attack quotes use a direct 6-row 16-byte table: character, chapter/map id, text, and event/flag byte only. There is no event pointer.

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -14714,3 +14714,21 @@ Git: {0} ...
 
 :Expanded Song Table to {0} entries.
 ソングテーブルを{0}エントリに拡張しました。
+
+:Triangle attack (16-byte)
+トライアングルアタック (16バイト)
+
+:Event/Flag Byte:
+イベント/フラグ バイト:
+
+:Character (Unit):
+ユニット:
+
+:Main battle-dialogue rows are 12-byte attacker/defender/text/flag records triggered when those two units fight.
+FE6のメイン戦闘会話テーブルは、2ユニットの交戦時に発生する12バイトの [攻撃ユニット / 防御ユニット / テキスト / フラグ] レコードです。
+
+:FE6's boss-conversation table stores 16-byte generic boss lines: one triggering unit, a chapter/map id, text, flag, and an event pointer.
+FE6のボス会話テーブルは、汎用ボス台詞を格納する16バイトレコードです。内容は [トリガーユニット / 章・マップID / テキスト / フラグ / イベントポインタ] です。
+
+:FE6's triangle-attack quotes use a direct 6-row 16-byte table: character, chapter/map id, text, and event/flag byte only. There is no event pointer.
+FE6のトライアングルアタック台詞は、直接配置された6行固定の16バイトテーブルです。内容は [ユニット / 章・マップID / テキスト / イベント/フラグバイト] のみで、イベントポインタはありません。

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -28544,3 +28544,21 @@ Git: {0} ...
 
 :Expanded Song Table to {0} entries.
 已将歌曲表扩展到{0}个条目。
+
+:Triangle attack (16-byte)
+三角攻击 (16字节)
+
+:Event/Flag Byte:
+事件/标志字节:
+
+:Character (Unit):
+单位:
+
+:Main battle-dialogue rows are 12-byte attacker/defender/text/flag records triggered when those two units fight.
+FE6的主战斗对话表是当这两个单位交战时触发的12字节 [攻击单位 / 防御单位 / 文本 / 标志] 记录。
+
+:FE6's boss-conversation table stores 16-byte generic boss lines: one triggering unit, a chapter/map id, text, flag, and an event pointer.
+FE6的Boss对话表保存16字节的通用Boss台词记录，内容为 [触发单位 / 章节/地图ID / 文本 / 标志 / 事件指针]。
+
+:FE6's triangle-attack quotes use a direct 6-row 16-byte table: character, chapter/map id, text, and event/flag byte only. There is no event pointer.
+FE6的三角攻击台词使用直接写死的6行16字节表，内容只有 [单位 / 章节/地图ID / 文本 / 事件/标志字节]，没有事件指针。

--- a/docs/nightmare-module-coverage.md
+++ b/docs/nightmare-module-coverage.md
@@ -1,0 +1,30 @@
+# Nightmare module coverage inventory
+
+Issue #2114 records an offline, pinned inventory for `laqieer/Fire-Emblem-Nightmare-Modules` at commit `e854861a7c16dadd3f2ea26be4b8c3d71c0e9c10`. The inventory uses GitHub tree path metadata only; module file contents are not cloned, executed, built, or applied.
+
+## Counts and hash
+
+- FE6 Nightmare Modules: 102 `.nmm` paths
+- FE7 Nightmare Modules: 373 `.nmm` paths
+- FE8 Nightmare modules: 280 `.nmm` paths
+- Total: 755 `.nmm` paths
+- Path-list SHA-256: `a8019f8688da5766c740e4620a662914670fc21a002a0803c28f90cfe0661c6a`
+
+The hash is computed over the sorted path list joined with LF and a trailing LF. The full inert manifest is `FEBuilderGBA.Avalonia.Tests/TestData/nightmare-module-coverage.json`; tests read it offline.
+
+## Dispositions
+
+- `existing-avalonia-surface`: already covered by an existing Avalonia/catalog editor or cross-platform scanner.
+- `integrated-surface`: covered by issue #2114 implementation work.
+- `patch-manager`: hard-code tuning/randomizer-oriented tables covered by Patch Manager or hard-code surfaces.
+- `explicit-exclusion`: prototype or duplicate beta modules that are not authoritative coverage targets.
+- `missing`: no FEBuilderGBA surface identified. The pinned manifest contains zero `missing` paths.
+
+## Family mapping
+
+The manifest maps each path exactly once to one collapsed family: animation, arena, audio, battle-screen, beta, chapter-unit, character-class, event, graphics, hardcode-tuning, item, map, menu, promotion, quote, shop, support, or summon when present.
+
+## Triangle attack quote decisions
+
+- `FE6 Nightmare Modules/Quote editor/Triangle attack quote editor.nmm` is the only genuine gap. It is now integrated into `EventBattleTalkFE6` as a direct fixed table at `0x666528`, 6 records, stride 16, writable B0 Character, B1 Chapter, W4 Text ID, and B8 Event/flag byte.
+- FE7 triangle paths, including `FE7 Nightmare Modules/Quote Editors/Triangle Attack Convo Editor.nmm`, map to the existing `EventBattleTalkFE7` quote surface (4 records, stride 12, direct `0xC9F130`).


### PR DESCRIPTION
## Summary
- add FE6's direct six-row triangle-attack quote table to the Avalonia Battle Dialogue editor
- preserve the fixed 16-byte schema by writing only character, chapter/map, text, and event/flag byte fields
- include the table in text-reference and event/flag scans without changing existing pointer-based FE6 dialogue tables
- pin an offline audit of all 755 FE6-FE8 Nightmare module paths and their Avalonia/integrated/Patch Manager dispositions

Accepted plan: https://github.com/laqieer/FEBuilderGBA/issues/2114#issuecomment-5340911067

Closes #2114

## Validation
- [x] Targeted Core tests: 51 passed
- [x] Targeted Avalonia tests: 26 passed, plus 4/4 localized triangle-view regressions after review fixes
- [x] FEBuilderGBA.Core.Tests Release: 7,584 passed, 19 skipped
- [x] FEBuilderGBA.Avalonia.Tests Release: 9,863 passed, 10 skipped
- [x] Core Release build
- [x] Avalonia Release build
- [x] Independent high-risk code review approved the final diff

## GUI Test Report
Validated the real Release Avalonia desktop app with a safe synthetic FE6 ROM. The Triangle attack selector displayed exactly six rows and only Character, Chapter/Map ID, Text, and Event/Flag Byte fields; no event-pointer field was present. Changed one event/flag byte, wrote and reloaded it, then rolled back through Undo History and confirmed the original value was restored.

![FE6 Triangle attack quote editor](https://github.com/user-attachments/assets/6a0a0f0b-f7fa-47dc-977e-b52d9dce4a4b)

Copilot CLI: 1.0.80
Model: GPT-5.6 Sol (gpt-5.6-sol)
