### PR TITLE
fix(avalonia): expose Song Table expansion option

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/SongTableExpansionOptionsTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/SongTableExpansionOptionsTests.cs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+using System;
+using System.IO;
+using System.Reflection;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Interactivity;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+[Collection("SharedState")]
+public class SongTableExpansionOptionsTests : IDisposable
+{
+    const string ConfigKey = "func_show_song_table_extends";
+    readonly Config? _savedConfig = CoreState.Config;
+    readonly ROM? _savedRom = CoreState.ROM;
+    readonly string? _savedBaseDirectory = CoreState.BaseDirectory;
+    readonly string? _savedLanguage = CoreState.Language;
+    readonly string _savedGitPath = CoreState.GitPath;
+    readonly string _baseDirectory;
+    readonly string _configPath;
+
+    public SongTableExpansionOptionsTests()
+    {
+        _baseDirectory = Path.Combine(
+            Path.GetTempPath(), $"song_table_option_{Guid.NewGuid():N}");
+        _configPath = Path.Combine(_baseDirectory, "config", "config.xml");
+        Directory.CreateDirectory(Path.GetDirectoryName(_configPath)!);
+        CoreState.BaseDirectory = _baseDirectory;
+        CoreState.Config = Config.LoadOrCreate(_configPath);
+        CoreState.Language = "en";
+    }
+
+    public void Dispose()
+    {
+        CoreStateTestState.RestoreConfig(_savedConfig);
+        CoreState.ROM = _savedRom;
+        CoreStateTestState.RestoreBaseDirectory(_savedBaseDirectory);
+        CoreStateTestState.RestoreLanguage(_savedLanguage);
+        CoreState.GitPath = _savedGitPath;
+        try
+        {
+            if (Directory.Exists(_baseDirectory))
+                Directory.Delete(_baseDirectory, true);
+        }
+        catch
+        {
+            // Best-effort test cleanup.
+        }
+    }
+
+    [Fact]
+    public void Load_DefaultsFalse_AndReadsSharedWinFormsKey()
+    {
+        var vm = new OptionsViewModel();
+
+        vm.Load();
+        Assert.False(vm.ShowSongTableExpansion);
+
+        CoreState.Config![ConfigKey] = "1";
+        vm.Load();
+        Assert.True(vm.ShowSongTableExpansion);
+    }
+
+    [Fact]
+    public void Save_PersistsSharedKey_WithoutChangingUnrelatedSetting()
+    {
+        CoreState.Config!["unrelated_setting"] = "keep";
+        var vm = new OptionsViewModel();
+        vm.Load();
+        vm.ShowSongTableExpansion = true;
+
+        vm.Save();
+
+        CoreState.Config = Config.LoadOrCreate(_configPath);
+        Assert.Equal("1", CoreState.Config.at(ConfigKey));
+        Assert.Equal("keep", CoreState.Config.at("unrelated_setting"));
+    }
+
+    [Fact]
+    public void SavedOption_MakesVanillaSongTableExpansionVisible()
+    {
+        CoreState.ROM = MakeRomWithSongTable();
+        var options = new OptionsViewModel();
+        options.Load();
+        options.ShowSongTableExpansion = true;
+        options.Save();
+
+        Assert.True(new SongTableViewModel().ShouldShowExpansion());
+    }
+
+    [AvaloniaFact]
+    public void OptionsView_LoadsAndSavesExpansionCheckbox()
+    {
+        CoreState.Config![ConfigKey] = "1";
+        var view = new OptionsView();
+        InvokePrivate(view, "LoadOptions");
+        CheckBox checkBox = Assert.IsType<CheckBox>(
+            view.FindControl<CheckBox>("ShowSongTableExpansionCheckBox"));
+        Assert.True(checkBox.IsChecked);
+
+        checkBox.IsChecked = false;
+        InvokePrivate(
+            view,
+            "OkButton_Click",
+            null,
+            new RoutedEventArgs());
+
+        CoreState.Config = Config.LoadOrCreate(_configPath);
+        Assert.Equal("0", CoreState.Config.at(ConfigKey));
+    }
+
+    static void InvokePrivate(object target, string methodName, params object?[] args)
+    {
+        MethodInfo? method = target.GetType().GetMethod(
+            methodName,
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        method.Invoke(target, args);
+    }
+
+    static ROM MakeRomWithSongTable()
+    {
+        const uint tableBase = 0x3000;
+        var rom = new ROM();
+        rom.LoadLow("song-table-option.gba", new byte[0x1000000], "BE8E01");
+        WriteU32(
+            rom.Data,
+            (int)rom.RomInfo.sound_table_pointer,
+            U.toPointer(tableBase));
+        WriteU32(rom.Data, (int)tableBase, U.toPointer(0x4000));
+        WriteU32(rom.Data, (int)(tableBase + 8), 0xFFFFFFFF);
+        return rom;
+    }
+
+    static void WriteU32(byte[] data, int offset, uint value)
+    {
+        data[offset + 0] = (byte)value;
+        data[offset + 1] = (byte)(value >> 8);
+        data[offset + 2] = (byte)(value >> 16);
+        data[offset + 3] = (byte)(value >> 24);
+    }
+}

--- a/FEBuilderGBA.Avalonia/ViewModels/OptionsViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/OptionsViewModel.cs
@@ -58,6 +58,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         string _autoUpdateRaw = "3";
         bool _autoSaveEnabled = false;
         int _autoSaveIntervalMinutes = 5;
+        bool _showSongTableExpansion;
 
         // External tool paths — keys match WinForms config.xml exactly
         string _emulator = "";
@@ -246,6 +247,13 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         {
             get => _autoSaveIntervalMinutes;
             set => SetField(ref _autoSaveIntervalMinutes, Math.Clamp(value, 1, 60));
+        }
+
+        /// <summary>Whether Song Table exposes its opt-in data-expansion action.</summary>
+        public bool ShowSongTableExpansion
+        {
+            get => _showSongTableExpansion;
+            set => SetField(ref _showSongTableExpansion, value);
         }
 
         // ---- External Tool Paths ----
@@ -767,6 +775,8 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                     int asInterval = 5;
                     int.TryParse(cfg.at("autosave_interval_minutes", "5"), out asInterval);
                     AutoSaveIntervalMinutes = Math.Clamp(asInterval, 1, 60);
+                    ShowSongTableExpansion =
+                        cfg.at("func_show_song_table_extends", "0") == "1";
 
                     // Load all tool paths using WinForms-compatible keys
                     Emulator = GetToolPath(cfg, "emulator", "Emulator_Path");
@@ -857,6 +867,8 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                 // Auto-save settings
                 cfg["autosave_enabled"] = AutoSaveEnabled ? "true" : "false";
                 cfg["autosave_interval_minutes"] = AutoSaveIntervalMinutes.ToString();
+                cfg["func_show_song_table_extends"] =
+                    ShowSongTableExpansion ? "1" : "0";
 
                 // Save all tool paths using WinForms-compatible keys
                 cfg["emulator"] = Emulator ?? "";

--- a/FEBuilderGBA.Avalonia/Views/OptionsView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/OptionsView.axaml
@@ -58,6 +58,18 @@
               <TextBlock Text="Interval (minutes):" VerticalAlignment="Center" Margin="0,0,8,0" />
               <NumericUpDown AutomationProperties.AutomationId="Options_AutoSaveInterval_Input" Name="AutoSaveIntervalBox" Minimum="1" Maximum="60" Value="5" Width="100" />
             </StackPanel>
+
+            <Expander AutomationProperties.AutomationId="Options_AdvancedRomEditing_Expander"
+                      Header="Advanced ROM Editing" Margin="0,12,0,0" IsExpanded="False">
+              <StackPanel Spacing="4" Margin="8,4,0,0">
+                <CheckBox AutomationProperties.AutomationId="Options_ShowSongTableExpansion_Check"
+                          Name="ShowSongTableExpansionCheckBox"
+                          Content="Show Song Table Data Expansion" />
+                <TextBlock AutomationProperties.AutomationId="Options_ShowSongTableExpansionHelp_Label"
+                           Text="Shows Data Expansion in Song Table. Repointing the Song Table may stop Sappy from finding it, and vanilla ROMs usually have spare entries."
+                           TextWrapping="Wrap" FontSize="11" Foreground="Gray" />
+              </StackPanel>
+            </Expander>
           </StackPanel>
         </ScrollViewer>
       </TabItem>

--- a/FEBuilderGBA.Avalonia/Views/OptionsView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/OptionsView.axaml.cs
@@ -99,6 +99,8 @@ namespace FEBuilderGBA.Avalonia.Views
             AutoUpdateCheckBox.IsChecked = _vm.AutoUpdateEnabled;
             AutoSaveCheckBox.IsChecked = _vm.AutoSaveEnabled;
             AutoSaveIntervalBox.Value = _vm.AutoSaveIntervalMinutes;
+            ShowSongTableExpansionCheckBox.IsChecked =
+                _vm.ShowSongTableExpansion;
             Patch2UrlTextBox.Text = _vm.SubmodulePatch2Url;
             FERepoUrlTextBox.Text = _vm.SubmoduleFERepoUrl;
             FERepoMusicUrlTextBox.Text = _vm.SubmoduleFERepoMusicUrl;
@@ -293,6 +295,8 @@ namespace FEBuilderGBA.Avalonia.Views
             _vm.AutoUpdateEnabled = AutoUpdateCheckBox.IsChecked == true;
             _vm.AutoSaveEnabled = AutoSaveCheckBox.IsChecked == true;
             _vm.AutoSaveIntervalMinutes = (int)(AutoSaveIntervalBox.Value ?? 5);
+            _vm.ShowSongTableExpansion =
+                ShowSongTableExpansionCheckBox.IsChecked == true;
             _vm.SubmodulePatch2Url = Patch2UrlTextBox.Text ?? "";
             _vm.SubmoduleFERepoUrl = FERepoUrlTextBox.Text ?? "";
             _vm.SubmoduleFERepoMusicUrl = FERepoMusicUrlTextBox.Text ?? "";

--- a/config/translate/en.txt
+++ b/config/translate/en.txt
@@ -21206,3 +21206,12 @@ FE6's boss-conversation table stores 16-byte generic boss lines: one triggering 
 
 :FE6's triangle-attack quotes use a direct 6-row 16-byte table: character, chapter/map id, text, and event/flag byte only. There is no event pointer.
 FE6's triangle-attack quotes use a direct 6-row 16-byte table: character, chapter/map id, text, and event/flag byte only. There is no event pointer.
+
+:Show Song Table Data Expansion
+Show Song Table Data Expansion
+
+:Advanced ROM Editing
+Advanced ROM Editing
+
+:Shows Data Expansion in Song Table. Repointing the Song Table may stop Sappy from finding it, and vanilla ROMs usually have spare entries.
+Shows Data Expansion in Song Table. Repointing the Song Table may stop Sappy from finding it, and vanilla ROMs usually have spare entries.

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -14732,3 +14732,12 @@ FE6のボス会話テーブルは、汎用ボス台詞を格納する16バイト
 
 :FE6's triangle-attack quotes use a direct 6-row 16-byte table: character, chapter/map id, text, and event/flag byte only. There is no event pointer.
 FE6のトライアングルアタック台詞は、直接配置された6行固定の16バイトテーブルです。内容は [ユニット / 章・マップID / テキスト / イベント/フラグバイト] のみで、イベントポインタはありません。
+
+:Show Song Table Data Expansion
+Song Table のデータ拡張を表示
+
+:Advanced ROM Editing
+高度な ROM 編集
+
+:Shows Data Expansion in Song Table. Repointing the Song Table may stop Sappy from finding it, and vanilla ROMs usually have spare entries.
+Song Table にデータ拡張を表示します。Song Table を再配置すると Sappy が認識できなくなる場合があり、通常の ROM には多くの空きエントリがあります。

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -28562,3 +28562,12 @@ FE6的Boss对话表保存16字节的通用Boss台词记录，内容为 [触发�
 
 :FE6's triangle-attack quotes use a direct 6-row 16-byte table: character, chapter/map id, text, and event/flag byte only. There is no event pointer.
 FE6的三角攻击台词使用直接写死的6行16字节表，内容只有 [单位 / 章节/地图ID / 文本 / 事件/标志字节]，没有事件指针。
+
+:Show Song Table Data Expansion
+显示歌曲表数据扩展
+
+:Advanced ROM Editing
+高级 ROM 编辑
+
+:Shows Data Expansion in Song Table. Repointing the Song Table may stop Sappy from finding it, and vanilla ROMs usually have spare entries.
+在歌曲表中显示数据扩展。重新定位歌曲表可能导致 Sappy 无法识别，而且原版 ROM 通常已有许多空闲条目。


### PR DESCRIPTION
## Summary
- expose the existing unc_show_song_table_extends toggle in Avalonia Options for macOS and other cross-platform users
- keep the dangerous action opt-in and located only in Song Table, matching WinForms; Song Track remains unchanged
- add safety guidance, English/Japanese/Chinese localization, and config/UI integration coverage

Accepted plan: https://github.com/laqieer/FEBuilderGBA/issues/2116#issuecomment-5343575566

Closes #2116

## Validation
- [x] Targeted Song Table/Options tests: 21 passed
- [x] Localization plus new option tests: 8 passed
- [x] FEBuilderGBA.Avalonia.Tests Release: 9,867 passed, 10 skipped
- [x] Avalonia Release build: 0 warnings, 0 errors
- [x] Independent normal-risk code review: approved

## GUI Test Report
Validated the real Release Avalonia desktop app with a safe synthetic FE8U ROM. The new Advanced ROM Editing checkbox loaded unchecked by default, saved unc_show_song_table_extends=1, and persisted after reopening Options. Opening **Audio → Song Table** then revealed the existing **Data Expansion** button beneath the list. The mutation action itself was not clicked.

![Avalonia Options Song Table expansion toggle](https://github.com/user-attachments/assets/8cdd7590-cfa4-4628-baf3-7e08747624e1)

![Avalonia Song Table Data Expansion button](https://github.com/user-attachments/assets/c968e6c6-dbb2-486e-b289-76c168f466a8)

Copilot CLI: 1.0.80
Model: GPT-5.6 Sol (gpt-5.6-sol)
