### PR TITLE
test(core): stabilize EA timeout cold start

### DIFF
--- a/FEBuilderGBA.Core.Tests/EventAssemblerCompileCoreProductionRunnerTests.cs
+++ b/FEBuilderGBA.Core.Tests/EventAssemblerCompileCoreProductionRunnerTests.cs
@@ -20,7 +20,8 @@ namespace FEBuilderGBA.Core.Tests
             "warning: C_Code.lyn.event:11:1: Writing before initializing offset. You may be breaking the ROM!";
         const string ColorzCoreSuccessMarker =
             "No errors. Please continue being awesome.";
-        const int ParentExitColdStartTimeoutMs = 10_000;
+        const int ProcessStubColdStartTimeoutMs = 10_000;
+        const int TimeoutChildSurvivalObservationSeconds = 8;
 
         static ROM CreateTestRom(int size = 512)
         {
@@ -71,7 +72,7 @@ namespace FEBuilderGBA.Core.Tests
 
                 EventAssemblerCompileCore.ResolveExeOverride = () => fakeExe;
                 EventAssemblerCompileCore.RunProcessOverride = null!;
-                EventAssemblerCompileCore.RunProcessTimeoutMs = ParentExitColdStartTimeoutMs;
+                EventAssemblerCompileCore.RunProcessTimeoutMs = ProcessStubColdStartTimeoutMs;
 
                 var stopwatch = Stopwatch.StartNew();
                 EventAssemblerProcessStubSupport.LaunchRecord launch;
@@ -236,7 +237,7 @@ namespace FEBuilderGBA.Core.Tests
 
                 EventAssemblerCompileCore.ResolveExeOverride = () => fakeExe;
                 EventAssemblerCompileCore.RunProcessOverride = null!;
-                EventAssemblerCompileCore.RunProcessTimeoutMs = 500;
+                EventAssemblerCompileCore.RunProcessTimeoutMs = ProcessStubColdStartTimeoutMs;
 
                 var stopwatch = Stopwatch.StartNew();
                 EventAssemblerProcessStubSupport.LaunchRecord launch;
@@ -244,7 +245,8 @@ namespace FEBuilderGBA.Core.Tests
                 using (EventAssemblerProcessStubSupport.Configure(
                     EventAssemblerProcessStubSupport.TimeoutParentMode,
                     launchRecordPath,
-                    markerPath))
+                    markerPath,
+                    ProcessStubColdStartTimeoutMs))
                 {
                     result = EventAssemblerCompileCore.CompileAndInsert(
                         rom, eaFile, EventAssemblerCompileCore.FreeAreaMode.None,
@@ -255,7 +257,7 @@ namespace FEBuilderGBA.Core.Tests
 
                 bool childSurvived = EventAssemblerProcessStubSupport.TryReadChildMarker(
                     markerPath,
-                    TimeSpan.FromSeconds(3),
+                    TimeSpan.FromSeconds(TimeoutChildSurvivalObservationSeconds),
                     out _);
 
                 Assert.False(result.Success);
@@ -269,7 +271,7 @@ namespace FEBuilderGBA.Core.Tests
                 Assert.Equal(before, rom.Data);
                 Assert.Empty(undo.list);
                 Assert.True(
-                    stopwatch.Elapsed < TimeSpan.FromSeconds(15),
+                    stopwatch.Elapsed < TimeSpan.FromSeconds(25),
                     $"Timed-out CompileAndInsert took too long to return: {stopwatch.Elapsed}.");
             }
             finally

--- a/FEBuilderGBA.Core.Tests/EventAssemblerCompileCoreProductionRunnerTests.cs
+++ b/FEBuilderGBA.Core.Tests/EventAssemblerCompileCoreProductionRunnerTests.cs
@@ -21,7 +21,7 @@ namespace FEBuilderGBA.Core.Tests
         const string ColorzCoreSuccessMarker =
             "No errors. Please continue being awesome.";
         const int ProcessStubColdStartTimeoutMs = 10_000;
-        const int TimeoutChildSurvivalObservationSeconds = 8;
+        const int TimeoutChildSurvivalObservationSeconds = 10;
 
         static ROM CreateTestRom(int size = 512)
         {
@@ -258,7 +258,7 @@ namespace FEBuilderGBA.Core.Tests
                 bool childSurvived = EventAssemblerProcessStubSupport.TryReadChildMarker(
                     markerPath,
                     TimeSpan.FromSeconds(TimeoutChildSurvivalObservationSeconds),
-                    out _);
+                    out string? childMarker);
 
                 Assert.False(result.Success);
                 Assert.Equal(EventAssemblerProcessStubSupport.TimeoutParentMode, launch.Mode);
@@ -267,11 +267,14 @@ namespace FEBuilderGBA.Core.Tests
                 EventAssemblerProcessStubSupport.AssertSamePath(fakeExe, launch.ProcessPath);
                 Assert.Contains("Error: Event Assembler timed out after 120 seconds.", result.Output);
                 Assert.Contains("Error: Event Assembler timed out after 120 seconds.", result.ErrorMessage);
-                Assert.False(childSurvived, "The timeout child outlived the process-tree kill.");
+                Assert.False(
+                    childSurvived,
+                    "The timeout child outlived the process-tree kill. Marker: "
+                    + childMarker);
                 Assert.Equal(before, rom.Data);
                 Assert.Empty(undo.list);
                 Assert.True(
-                    stopwatch.Elapsed < TimeSpan.FromSeconds(25),
+                    stopwatch.Elapsed < TimeSpan.FromSeconds(30),
                     $"Timed-out CompileAndInsert took too long to return: {stopwatch.Elapsed}.");
             }
             finally

--- a/FEBuilderGBA.Core.Tests/EventAssemblerCompileCoreProductionRunnerTests.cs
+++ b/FEBuilderGBA.Core.Tests/EventAssemblerCompileCoreProductionRunnerTests.cs
@@ -21,7 +21,7 @@ namespace FEBuilderGBA.Core.Tests
         const string ColorzCoreSuccessMarker =
             "No errors. Please continue being awesome.";
         const int ProcessStubColdStartTimeoutMs = 10_000;
-        const int TimeoutChildSurvivalObservationSeconds = 10;
+        const int TimeoutChildSurvivalObservationSeconds = 15;
 
         static ROM CreateTestRom(int size = 512)
         {
@@ -274,7 +274,7 @@ namespace FEBuilderGBA.Core.Tests
                 Assert.Equal(before, rom.Data);
                 Assert.Empty(undo.list);
                 Assert.True(
-                    stopwatch.Elapsed < TimeSpan.FromSeconds(30),
+                    stopwatch.Elapsed < TimeSpan.FromSeconds(35),
                     $"Timed-out CompileAndInsert took too long to return: {stopwatch.Elapsed}.");
             }
             finally

--- a/FEBuilderGBA.Core.Tests/EventAssemblerProcessStubSupport.cs
+++ b/FEBuilderGBA.Core.Tests/EventAssemblerProcessStubSupport.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Globalization;
 using System.Text.Json;
 using System.Threading;
 
@@ -16,18 +17,27 @@ internal static class EventAssemblerProcessStubSupport
     internal const string ModeEnvVar = "FEBUILDERGBA_EA_PROCESS_STUB_MODE";
     internal const string LaunchRecordEnvVar = "FEBUILDERGBA_EA_PROCESS_STUB_RECORD";
     internal const string ChildMarkerEnvVar = "FEBUILDERGBA_EA_PROCESS_STUB_CHILD_MARKER";
+    internal const string TimeoutMsEnvVar = "FEBUILDERGBA_EA_PROCESS_STUB_TIMEOUT_MS";
     internal const string ConcurrentOutputMode = "concurrent-output";
     internal const string ParentExitDescendantHoldsPipesMode = "parent-exit-descendant-holds-pipes";
     internal const string TimeoutParentMode = "timeout-parent";
     internal const int ParentExitChildSelfTerminateSeconds = 12;
 
-    internal static IDisposable Configure(string mode, string launchRecordPath, string? childMarkerPath = null)
+    internal static IDisposable Configure(
+        string mode,
+        string launchRecordPath,
+        string? childMarkerPath = null,
+        int? timeoutMs = null)
     {
+        if (timeoutMs <= 0)
+            throw new ArgumentOutOfRangeException(nameof(timeoutMs));
+
         return new EnvironmentVariableScope(new (string Name, string? Value)[]
         {
             (ModeEnvVar, mode),
             (LaunchRecordEnvVar, launchRecordPath),
             (ChildMarkerEnvVar, childMarkerPath),
+            (TimeoutMsEnvVar, timeoutMs?.ToString(CultureInfo.InvariantCulture)),
         });
     }
 

--- a/FEBuilderGBA.Core.Tests/EventAssemblerProcessStubSupport.cs
+++ b/FEBuilderGBA.Core.Tests/EventAssemblerProcessStubSupport.cs
@@ -21,6 +21,8 @@ internal static class EventAssemblerProcessStubSupport
     internal const string ConcurrentOutputMode = "concurrent-output";
     internal const string ParentExitDescendantHoldsPipesMode = "parent-exit-descendant-holds-pipes";
     internal const string TimeoutParentMode = "timeout-parent";
+    internal const string ParentExitChildCommand = "__parent-exit-child";
+    internal const string TimeoutChildCommand = "__timeout-child";
     internal const int ParentExitChildSelfTerminateSeconds = 12;
 
     internal static IDisposable Configure(

--- a/FEBuilderGBA.Core.Tests/EventAssemblerProcessStubSupportTests.cs
+++ b/FEBuilderGBA.Core.Tests/EventAssemblerProcessStubSupportTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Text.Json;
 using System.Threading;
@@ -8,11 +7,9 @@ using Xunit;
 
 namespace FEBuilderGBA.Core.Tests
 {
-    [Collection(ProcessRunnerTestCollection.Name)]
     public class EventAssemblerProcessStubSupportTests
     {
         const string ParentExitChildMarker = "parent-exit helper descendant self-terminated";
-        const string TimeoutChildMarker = "child survived timeout kill";
 
         [Fact]
         public void ReadLaunchRecord_RetriesMissingFinalFileUntilAtomicPublish()
@@ -179,96 +176,6 @@ namespace FEBuilderGBA.Core.Tests
             }
             finally
             {
-                try { Directory.Delete(root, true); } catch { }
-            }
-        }
-
-        [Fact]
-        public void TimeoutChildProbe_ParentExitPublishesSurvivalMarker()
-        {
-            string root = CreateRoot();
-            string parentMarkerPath = Path.Combine(root, "parent-marker.txt");
-            string childMarkerPath = Path.Combine(root, "child-survived.txt");
-            Process? parent = null;
-            Process? child = null;
-
-            try
-            {
-                parent = StartStubProcess(
-                    EventAssemblerProcessStubSupport.ParentExitChildCommand,
-                    parentMarkerPath);
-                long parentStartTimeUtcTicks =
-                    parent.StartTime.ToUniversalTime().Ticks;
-                child = StartStubProcess(
-                    EventAssemblerProcessStubSupport.TimeoutChildCommand,
-                    childMarkerPath,
-                    parent.Id.ToString(CultureInfo.InvariantCulture),
-                    parentStartTimeUtcTicks.ToString(CultureInfo.InvariantCulture),
-                    "10000");
-
-                parent.Kill(entireProcessTree: false);
-                Assert.True(
-                    parent.WaitForExit(5000),
-                    "The watched parent did not exit.");
-
-                Assert.Equal(
-                    TimeoutChildMarker,
-                    EventAssemblerProcessStubSupport.ReadChildMarker(
-                        childMarkerPath,
-                        TimeSpan.FromSeconds(8)));
-                Assert.True(
-                    child.WaitForExit(5000),
-                    "The timeout child did not exit after publishing its marker.");
-                Assert.Equal(0, child.ExitCode);
-            }
-            finally
-            {
-                TerminateProcess(child);
-                TerminateProcess(parent);
-                try { Directory.Delete(root, true); } catch { }
-            }
-        }
-
-        [Fact]
-        public void TimeoutChildProbe_ParentAliveThroughDeadlinePublishesSurvivalMarker()
-        {
-            string root = CreateRoot();
-            string parentMarkerPath = Path.Combine(root, "parent-marker.txt");
-            string childMarkerPath = Path.Combine(root, "child-survived.txt");
-            Process? parent = null;
-            Process? child = null;
-
-            try
-            {
-                parent = StartStubProcess(
-                    EventAssemblerProcessStubSupport.ParentExitChildCommand,
-                    parentMarkerPath);
-                long parentStartTimeUtcTicks =
-                    parent.StartTime.ToUniversalTime().Ticks;
-                child = StartStubProcess(
-                    EventAssemblerProcessStubSupport.TimeoutChildCommand,
-                    childMarkerPath,
-                    parent.Id.ToString(CultureInfo.InvariantCulture),
-                    parentStartTimeUtcTicks.ToString(CultureInfo.InvariantCulture),
-                    "500");
-
-                Assert.Equal(
-                    TimeoutChildMarker,
-                    EventAssemblerProcessStubSupport.ReadChildMarker(
-                        childMarkerPath,
-                        TimeSpan.FromSeconds(12)));
-                Assert.False(
-                    parent.HasExited,
-                    "The deadline probe must publish while the watched parent is still alive.");
-                Assert.True(
-                    child.WaitForExit(5000),
-                    "The timeout child did not exit after publishing its marker.");
-                Assert.Equal(0, child.ExitCode);
-            }
-            finally
-            {
-                TerminateProcess(child);
-                TerminateProcess(parent);
                 try { Directory.Delete(root, true); } catch { }
             }
         }
@@ -497,46 +404,6 @@ namespace FEBuilderGBA.Core.Tests
                         throw;
 
                     Thread.Sleep(20);
-                }
-            }
-        }
-
-        static Process StartStubProcess(params string[] args)
-        {
-            var startInfo = new ProcessStartInfo(
-                EventAssemblerProcessStubSupport.FindExecutable())
-            {
-                UseShellExecute = false,
-                CreateNoWindow = true,
-            };
-            foreach (string arg in args)
-                startInfo.ArgumentList.Add(arg);
-
-            return Process.Start(startInfo)
-                ?? throw new InvalidOperationException(
-                    "Failed to start Event Assembler process stub.");
-        }
-
-        static void TerminateProcess(Process? process)
-        {
-            if (process == null)
-                return;
-
-            using (process)
-            {
-                try
-                {
-                    if (!process.HasExited)
-                    {
-                        process.Kill(entireProcessTree: true);
-                        process.WaitForExit(5000);
-                    }
-                }
-                catch (InvalidOperationException)
-                {
-                }
-                catch (System.ComponentModel.Win32Exception)
-                {
                 }
             }
         }

--- a/FEBuilderGBA.Core.Tests/EventAssemblerProcessStubSupportTests.cs
+++ b/FEBuilderGBA.Core.Tests/EventAssemblerProcessStubSupportTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Text.Json;
 using System.Threading;
@@ -7,9 +8,11 @@ using Xunit;
 
 namespace FEBuilderGBA.Core.Tests
 {
+    [Collection(ProcessRunnerTestCollection.Name)]
     public class EventAssemblerProcessStubSupportTests
     {
         const string ParentExitChildMarker = "parent-exit helper descendant self-terminated";
+        const string TimeoutChildMarker = "child survived timeout kill";
 
         [Fact]
         public void ReadLaunchRecord_RetriesMissingFinalFileUntilAtomicPublish()
@@ -176,6 +179,96 @@ namespace FEBuilderGBA.Core.Tests
             }
             finally
             {
+                try { Directory.Delete(root, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void TimeoutChildProbe_ParentExitPublishesSurvivalMarker()
+        {
+            string root = CreateRoot();
+            string parentMarkerPath = Path.Combine(root, "parent-marker.txt");
+            string childMarkerPath = Path.Combine(root, "child-survived.txt");
+            Process? parent = null;
+            Process? child = null;
+
+            try
+            {
+                parent = StartStubProcess(
+                    EventAssemblerProcessStubSupport.ParentExitChildCommand,
+                    parentMarkerPath);
+                long parentStartTimeUtcTicks =
+                    parent.StartTime.ToUniversalTime().Ticks;
+                child = StartStubProcess(
+                    EventAssemblerProcessStubSupport.TimeoutChildCommand,
+                    childMarkerPath,
+                    parent.Id.ToString(CultureInfo.InvariantCulture),
+                    parentStartTimeUtcTicks.ToString(CultureInfo.InvariantCulture),
+                    "10000");
+
+                parent.Kill(entireProcessTree: false);
+                Assert.True(
+                    parent.WaitForExit(5000),
+                    "The watched parent did not exit.");
+
+                Assert.Equal(
+                    TimeoutChildMarker,
+                    EventAssemblerProcessStubSupport.ReadChildMarker(
+                        childMarkerPath,
+                        TimeSpan.FromSeconds(8)));
+                Assert.True(
+                    child.WaitForExit(5000),
+                    "The timeout child did not exit after publishing its marker.");
+                Assert.Equal(0, child.ExitCode);
+            }
+            finally
+            {
+                TerminateProcess(child);
+                TerminateProcess(parent);
+                try { Directory.Delete(root, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void TimeoutChildProbe_ParentAliveThroughDeadlinePublishesSurvivalMarker()
+        {
+            string root = CreateRoot();
+            string parentMarkerPath = Path.Combine(root, "parent-marker.txt");
+            string childMarkerPath = Path.Combine(root, "child-survived.txt");
+            Process? parent = null;
+            Process? child = null;
+
+            try
+            {
+                parent = StartStubProcess(
+                    EventAssemblerProcessStubSupport.ParentExitChildCommand,
+                    parentMarkerPath);
+                long parentStartTimeUtcTicks =
+                    parent.StartTime.ToUniversalTime().Ticks;
+                child = StartStubProcess(
+                    EventAssemblerProcessStubSupport.TimeoutChildCommand,
+                    childMarkerPath,
+                    parent.Id.ToString(CultureInfo.InvariantCulture),
+                    parentStartTimeUtcTicks.ToString(CultureInfo.InvariantCulture),
+                    "500");
+
+                Assert.Equal(
+                    TimeoutChildMarker,
+                    EventAssemblerProcessStubSupport.ReadChildMarker(
+                        childMarkerPath,
+                        TimeSpan.FromSeconds(12)));
+                Assert.False(
+                    parent.HasExited,
+                    "The deadline probe must publish while the watched parent is still alive.");
+                Assert.True(
+                    child.WaitForExit(5000),
+                    "The timeout child did not exit after publishing its marker.");
+                Assert.Equal(0, child.ExitCode);
+            }
+            finally
+            {
+                TerminateProcess(child);
+                TerminateProcess(parent);
                 try { Directory.Delete(root, true); } catch { }
             }
         }
@@ -404,6 +497,46 @@ namespace FEBuilderGBA.Core.Tests
                         throw;
 
                     Thread.Sleep(20);
+                }
+            }
+        }
+
+        static Process StartStubProcess(params string[] args)
+        {
+            var startInfo = new ProcessStartInfo(
+                EventAssemblerProcessStubSupport.FindExecutable())
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            foreach (string arg in args)
+                startInfo.ArgumentList.Add(arg);
+
+            return Process.Start(startInfo)
+                ?? throw new InvalidOperationException(
+                    "Failed to start Event Assembler process stub.");
+        }
+
+        static void TerminateProcess(Process? process)
+        {
+            if (process == null)
+                return;
+
+            using (process)
+            {
+                try
+                {
+                    if (!process.HasExited)
+                    {
+                        process.Kill(entireProcessTree: true);
+                        process.WaitForExit(5000);
+                    }
+                }
+                catch (InvalidOperationException)
+                {
+                }
+                catch (System.ComponentModel.Win32Exception)
+                {
                 }
             }
         }

--- a/FEBuilderGBA.Core.Tests/EventAssemblerTimeoutChildProbeTests.cs
+++ b/FEBuilderGBA.Core.Tests/EventAssemblerTimeoutChildProbeTests.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    [Collection(ProcessRunnerTestCollection.Name)]
+    public class EventAssemblerTimeoutChildProbeTests
+    {
+        const string TimeoutChildMarker = "child survived timeout kill";
+
+        [Fact]
+        public void TimeoutChildProbe_ParentExitPublishesSurvivalMarker()
+        {
+            string root = CreateRoot();
+            string parentMarkerPath = Path.Combine(root, "parent-marker.txt");
+            string childMarkerPath = Path.Combine(root, "child-survived.txt");
+            Process? parent = null;
+            Process? child = null;
+
+            try
+            {
+                parent = StartStubProcess(
+                    EventAssemblerProcessStubSupport.ParentExitChildCommand,
+                    parentMarkerPath);
+                long parentStartTimeUtcTicks =
+                    parent.StartTime.ToUniversalTime().Ticks;
+                child = StartStubProcess(
+                    EventAssemblerProcessStubSupport.TimeoutChildCommand,
+                    childMarkerPath,
+                    parent.Id.ToString(CultureInfo.InvariantCulture),
+                    parentStartTimeUtcTicks.ToString(CultureInfo.InvariantCulture),
+                    "10000");
+
+                parent.Kill(entireProcessTree: false);
+                Assert.True(
+                    parent.WaitForExit(5000),
+                    "The watched parent did not exit.");
+
+                Assert.Equal(
+                    TimeoutChildMarker,
+                    EventAssemblerProcessStubSupport.ReadChildMarker(
+                        childMarkerPath,
+                        TimeSpan.FromSeconds(8)));
+                Assert.True(
+                    child.WaitForExit(5000),
+                    "The timeout child did not exit after publishing its marker.");
+                Assert.Equal(0, child.ExitCode);
+            }
+            finally
+            {
+                TerminateProcess(child);
+                TerminateProcess(parent);
+                try { Directory.Delete(root, true); } catch { }
+            }
+        }
+
+        [Fact]
+        public void TimeoutChildProbe_ParentAliveThroughDeadlinePublishesSurvivalMarker()
+        {
+            string root = CreateRoot();
+            string parentMarkerPath = Path.Combine(root, "parent-marker.txt");
+            string childMarkerPath = Path.Combine(root, "child-survived.txt");
+            Process? parent = null;
+            Process? child = null;
+
+            try
+            {
+                parent = StartStubProcess(
+                    EventAssemblerProcessStubSupport.ParentExitChildCommand,
+                    parentMarkerPath);
+                long parentStartTimeUtcTicks =
+                    parent.StartTime.ToUniversalTime().Ticks;
+                child = StartStubProcess(
+                    EventAssemblerProcessStubSupport.TimeoutChildCommand,
+                    childMarkerPath,
+                    parent.Id.ToString(CultureInfo.InvariantCulture),
+                    parentStartTimeUtcTicks.ToString(CultureInfo.InvariantCulture),
+                    "500");
+
+                Assert.Equal(
+                    TimeoutChildMarker,
+                    EventAssemblerProcessStubSupport.ReadChildMarker(
+                        childMarkerPath,
+                        TimeSpan.FromSeconds(12)));
+                Assert.False(
+                    parent.HasExited,
+                    "The deadline probe must publish while the watched parent is still alive.");
+                Assert.True(
+                    child.WaitForExit(5000),
+                    "The timeout child did not exit after publishing its marker.");
+                Assert.Equal(0, child.ExitCode);
+            }
+            finally
+            {
+                TerminateProcess(child);
+                TerminateProcess(parent);
+                try { Directory.Delete(root, true); } catch { }
+            }
+        }
+
+        static Process StartStubProcess(params string[] args)
+        {
+            var startInfo = new ProcessStartInfo(
+                EventAssemblerProcessStubSupport.FindExecutable())
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            foreach (string arg in args)
+                startInfo.ArgumentList.Add(arg);
+
+            return Process.Start(startInfo)
+                ?? throw new InvalidOperationException(
+                    "Failed to start Event Assembler process stub.");
+        }
+
+        static void TerminateProcess(Process? process)
+        {
+            if (process == null)
+                return;
+
+            using (process)
+            {
+                try
+                {
+                    if (!process.HasExited)
+                    {
+                        process.Kill(entireProcessTree: true);
+                        process.WaitForExit(5000);
+                    }
+                }
+                catch (InvalidOperationException)
+                {
+                }
+                catch (System.ComponentModel.Win32Exception)
+                {
+                }
+            }
+        }
+
+        static string CreateRoot()
+        {
+            string root = Path.Combine(
+                Path.GetTempPath(),
+                "ea-timeout-probe-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(root);
+            return root;
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/EventAssemblerTimeoutChildProbeTests.cs
+++ b/FEBuilderGBA.Core.Tests/EventAssemblerTimeoutChildProbeTests.cs
@@ -10,6 +10,7 @@ namespace FEBuilderGBA.Core.Tests
     public class EventAssemblerTimeoutChildProbeTests
     {
         const string TimeoutChildMarker = "child survived timeout kill";
+        const int TimeoutChildProbeObservationSeconds = 15;
 
         [Fact]
         public void TimeoutChildProbe_ParentExitPublishesSurvivalMarker()
@@ -43,7 +44,8 @@ namespace FEBuilderGBA.Core.Tests
                     TimeoutChildMarker,
                     EventAssemblerProcessStubSupport.ReadChildMarker(
                         childMarkerPath,
-                        TimeSpan.FromSeconds(8)));
+                        TimeSpan.FromSeconds(
+                            TimeoutChildProbeObservationSeconds)));
                 Assert.True(
                     child.WaitForExit(5000),
                     "The timeout child did not exit after publishing its marker.");
@@ -84,7 +86,8 @@ namespace FEBuilderGBA.Core.Tests
                     TimeoutChildMarker,
                     EventAssemblerProcessStubSupport.ReadChildMarker(
                         childMarkerPath,
-                        TimeSpan.FromSeconds(12)));
+                        TimeSpan.FromSeconds(
+                            TimeoutChildProbeObservationSeconds)));
                 Assert.False(
                     parent.HasExited,
                     "The deadline probe must publish while the watched parent is still alive.");

--- a/FEBuilderGBA.Core.Tests/Helpers/EventAssemblerProcessStub/Program.cs
+++ b/FEBuilderGBA.Core.Tests/Helpers/EventAssemblerProcessStub/Program.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.Text.Json;
 using System.Threading;
 
@@ -9,11 +10,13 @@ internal static class Program
     const string ModeEnvVar = "FEBUILDERGBA_EA_PROCESS_STUB_MODE";
     const string LaunchRecordEnvVar = "FEBUILDERGBA_EA_PROCESS_STUB_RECORD";
     const string ChildMarkerEnvVar = "FEBUILDERGBA_EA_PROCESS_STUB_CHILD_MARKER";
+    const string TimeoutMsEnvVar = "FEBUILDERGBA_EA_PROCESS_STUB_TIMEOUT_MS";
 
     const string ConcurrentOutputMode = "concurrent-output";
     const string ParentExitDescendantHoldsPipesMode = "parent-exit-descendant-holds-pipes";
     const string TimeoutParentMode = "timeout-parent";
     const int ParentExitChildSelfTerminateSeconds = 12;
+    const int TimeoutContainmentGraceMs = 5000;
     const int AtomicPublishRetryCount = 3;
     const int AtomicPublishRetryDelayMs = 50;
     const string ParentExitChildCommand = "__parent-exit-child";
@@ -118,7 +121,9 @@ internal static class Program
     static int RunTimeoutParent(LaunchRecord launch, string launchRecordPath)
     {
         string childMarkerPath = RequireEnvironmentVariable(ChildMarkerEnvVar);
+        int timeoutMs = RequirePositiveIntEnvironmentVariable(TimeoutMsEnvVar);
         string processPath = Environment.ProcessPath ?? throw new InvalidOperationException("Process path unavailable.");
+        long parentStartTimeUtcTicks = Process.GetCurrentProcess().StartTime.ToUniversalTime().Ticks;
         var psi = new ProcessStartInfo(processPath)
         {
             UseShellExecute = false,
@@ -127,6 +132,9 @@ internal static class Program
         };
         psi.ArgumentList.Add(TimeoutChildCommand);
         psi.ArgumentList.Add(childMarkerPath);
+        psi.ArgumentList.Add(Environment.ProcessId.ToString(CultureInfo.InvariantCulture));
+        psi.ArgumentList.Add(parentStartTimeUtcTicks.ToString(CultureInfo.InvariantCulture));
+        psi.ArgumentList.Add(timeoutMs.ToString(CultureInfo.InvariantCulture));
 
         using var child = Process.Start(psi)
             ?? throw new InvalidOperationException("Failed to start timeout child.");
@@ -150,12 +158,61 @@ internal static class Program
 
     static int RunTimeoutChild(string[] args)
     {
-        if (args.Length != 2)
-            throw new InvalidOperationException("Timeout child expects a marker path.");
+        if (args.Length != 5)
+            throw new InvalidOperationException(
+                "Timeout child expects a marker path, parent PID, parent start time, and timeout.");
 
-        Thread.Sleep(TimeSpan.FromMilliseconds(2500));
+        int parentProcessId = ParsePositiveInt(args[2], "parent PID");
+        long parentStartTimeUtcTicks = ParsePositiveLong(args[3], "parent start time");
+        int timeoutMs = ParsePositiveInt(args[4], "timeout");
+        WaitForParentExitOrContainmentDeadline(
+            parentProcessId,
+            parentStartTimeUtcTicks,
+            timeoutMs);
         WriteAtomicText(args[1], "child survived timeout kill");
         return 0;
+    }
+
+    static void WaitForParentExitOrContainmentDeadline(
+        int parentProcessId,
+        long parentStartTimeUtcTicks,
+        int timeoutMs)
+    {
+        DateTime deadlineUtc = new DateTime(
+            parentStartTimeUtcTicks,
+            DateTimeKind.Utc).AddMilliseconds(timeoutMs + TimeoutContainmentGraceMs);
+
+        try
+        {
+            using Process parent = Process.GetProcessById(parentProcessId);
+            long actualStartTimeUtcTicks;
+            try
+            {
+                actualStartTimeUtcTicks = parent.StartTime.ToUniversalTime().Ticks;
+            }
+            catch (InvalidOperationException)
+            {
+                return;
+            }
+
+            if (actualStartTimeUtcTicks != parentStartTimeUtcTicks)
+                return;
+
+            int remainingMs = (int)Math.Clamp(
+                Math.Ceiling((deadlineUtc - DateTime.UtcNow).TotalMilliseconds),
+                0,
+                int.MaxValue);
+            if (remainingMs > 0)
+                parent.WaitForExit(remainingMs);
+        }
+        catch (ArgumentException)
+        {
+            // The expected parent already exited before the child obtained a handle.
+        }
+        catch (InvalidOperationException)
+        {
+            // The expected parent exited while its process metadata was being read.
+        }
     }
 
     static void MutateOutputRom(string outputRomPath)
@@ -179,6 +236,41 @@ internal static class Program
     {
         return Environment.GetEnvironmentVariable(name)
             ?? throw new InvalidOperationException("Missing environment variable: " + name);
+    }
+
+    static int RequirePositiveIntEnvironmentVariable(string name)
+    {
+        return ParsePositiveInt(RequireEnvironmentVariable(name), name);
+    }
+
+    static int ParsePositiveInt(string value, string description)
+    {
+        if (!int.TryParse(
+                value,
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out int parsed)
+            || parsed <= 0)
+        {
+            throw new InvalidOperationException(
+                $"Invalid positive integer for {description}: {value}");
+        }
+        return parsed;
+    }
+
+    static long ParsePositiveLong(string value, string description)
+    {
+        if (!long.TryParse(
+                value,
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out long parsed)
+            || parsed <= 0)
+        {
+            throw new InvalidOperationException(
+                $"Invalid positive integer for {description}: {value}");
+        }
+        return parsed;
     }
 
     static void WriteLaunchRecord(string path, LaunchRecord launch)

--- a/FEBuilderGBA.Core.Tests/Helpers/EventAssemblerProcessStub/Program.cs
+++ b/FEBuilderGBA.Core.Tests/Helpers/EventAssemblerProcessStub/Program.cs
@@ -17,6 +17,8 @@ internal static class Program
     const string TimeoutParentMode = "timeout-parent";
     const int ParentExitChildSelfTerminateSeconds = 12;
     const int TimeoutContainmentGraceMs = 5000;
+    const int TimeoutPostParentExitGraceMs = 2500;
+    const int ParentStartIdentityToleranceMs = 2000;
     const int AtomicPublishRetryCount = 3;
     const int AtomicPublishRetryDelayMs = 50;
     const string ParentExitChildCommand = "__parent-exit-child";
@@ -169,6 +171,7 @@ internal static class Program
             parentProcessId,
             parentStartTimeUtcTicks,
             timeoutMs);
+        Thread.Sleep(TimeoutPostParentExitGraceMs);
         WriteAtomicText(args[1], "child survived timeout kill");
         return 0;
     }
@@ -195,8 +198,11 @@ internal static class Program
                 return;
             }
 
-            if (actualStartTimeUtcTicks != parentStartTimeUtcTicks)
+            if (Math.Abs(actualStartTimeUtcTicks - parentStartTimeUtcTicks)
+                > TimeSpan.FromMilliseconds(ParentStartIdentityToleranceMs).Ticks)
+            {
                 return;
+            }
 
             int remainingMs = (int)Math.Clamp(
                 Math.Ceiling((deadlineUtc - DateTime.UtcNow).TotalMilliseconds),

--- a/FEBuilderGBA.Core.Tests/Helpers/EventAssemblerProcessStub/Program.cs
+++ b/FEBuilderGBA.Core.Tests/Helpers/EventAssemblerProcessStub/Program.cs
@@ -219,6 +219,10 @@ internal static class Program
         {
             // The expected parent exited while its process metadata was being read.
         }
+        catch (System.ComponentModel.Win32Exception)
+        {
+            // Parent metadata became unavailable during the exit race.
+        }
     }
 
     static void MutateOutputRom(string outputRomPath)


### PR DESCRIPTION
## Summary
- give the Event Assembler timeout integration scenario the same 10-second .NET helper cold-start budget already used by its sibling process test
- pass the test timeout through the isolated environment scope and identify the parent by PID plus start timestamp
- make an escaped child publish its survival marker after parent exit or the bounded timeout/containment deadline, preserving detection of both child escape and parent termination failure
- keep all production Event Assembler and process-runner code unchanged

Revised plan: https://github.com/laqieer/FEBuilderGBA/issues/2112#issuecomment-5350251889
Plan amendment: https://github.com/laqieer/FEBuilderGBA/issues/2112#issuecomment-5350296162

Closes #2112

## Validation
- [x] Previously failing timeout test: passed
- [x] Timeout cleanup stress: 10/10 passed
- [x] Production-runner/support cluster: repeated runs passed
- [x] Positive escaped-child probes: parent-exit and live-parent-deadline paths passed
- [x] `FEBuilderGBA.Core.Tests` Release: 7,586 passed, 19 skipped
- [x] Core Release build: 0 warnings, 0 errors
- [x] CLI Release build: 0 warnings, 0 errors
- [x] Independent normal-risk code review: approved

The original master MSBuild artifact isolated the intermittent failure to `CompileAndInsert_ProductionRunner_TimeoutKillsProcessTreeBeforeCleanupMarker`: the 500 ms timeout killed the helper before `launch-record.json` publication. Its automatic JUnit rerun passed, confirming the cold-start race.

Copilot CLI: 1.0.80
Model: GPT-5.6 Sol (gpt-5.6-sol)


