### PR TITLE
fix(avalonia): support macOS app bundle picker

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/ExternalToolAppBundleTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ExternalToolAppBundleTests.cs
@@ -163,7 +163,7 @@ public sealed class ExternalToolAppBundleTests : IDisposable
 
         Assert.Equal(ExternalProcessResultKind.Exited, result.Kind);
         Assert.Equal(0, result.ExitCode);
-        Assert.Equal("READY", result.StandardOutput.Trim());
+        Assert.Equal("NSOpenPanel|true|false|false", result.StandardOutput.Trim());
     }
 
     [AvaloniaFact]

--- a/FEBuilderGBA.Avalonia.Tests/ExternalToolAppBundleTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ExternalToolAppBundleTests.cs
@@ -9,6 +9,7 @@ using global::Avalonia.Headless.XUnit;
 using global::Avalonia.Threading;
 using FEBuilderGBA;
 using FEBuilderGBA.Avalonia.Dialogs;
+using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
 using FEBuilderGBA.Avalonia.Views;
 using Xunit;
@@ -82,6 +83,87 @@ public sealed class ExternalToolAppBundleTests : IDisposable
                 Assert.Equal("All Files", allFiles.Name);
                 Assert.Equal(new[] { "*" }, allFiles.Patterns);
             });
+    }
+
+    [Fact]
+    public void MacExternalToolPickerRequest_UsesStaticJxaScriptAndSeparateTitleArgument()
+    {
+        ExternalProcessRequest request =
+            FileDialogHelper.CreateMacExternalToolPickerRequest("Select File");
+
+        Assert.Equal("/usr/bin/osascript", request.Executable);
+        Assert.Equal("-l", request.ArgumentList[0]);
+        Assert.Equal("JavaScript", request.ArgumentList[1]);
+        Assert.Equal("-e", request.ArgumentList[2]);
+        Assert.Contains("treatsFilePackagesAsDirectories = false", request.ArgumentList[3]);
+        Assert.Contains("canChooseFiles = true", request.ArgumentList[3]);
+        Assert.Contains("canChooseDirectories = false", request.ArgumentList[3]);
+        Assert.DoesNotContain("Select File", request.ArgumentList[3]);
+        Assert.Equal("Select File", request.ArgumentList[4]);
+        Assert.True(request.CaptureStandardOutput);
+        Assert.True(request.CaptureStandardError);
+    }
+
+    [Theory]
+    [InlineData("/Applications/mGBA.app")]
+    [InlineData("/usr/local/bin/mgba")]
+    public void MacExternalToolPickerResult_AcceptsAppBundleOrOrdinaryFile(string path)
+    {
+        bool isBundle = path.EndsWith(".app", StringComparison.OrdinalIgnoreCase);
+        var result = FileDialogHelper.ResolveMacExternalToolPickerResult(
+            ExternalProcessResult.Exited(0, path + Environment.NewLine, string.Empty),
+            fileExists: candidate => !isBundle && candidate == path,
+            directoryExists: candidate => isBundle && candidate == path);
+
+        Assert.Equal(MacExternalToolPickerResultKind.Selected, result.Kind);
+        Assert.Equal(path, result.Path);
+        Assert.True(string.IsNullOrEmpty(result.Message));
+    }
+
+    [Fact]
+    public void MacExternalToolPickerResult_TreatsEmptySuccessAsCancellation()
+    {
+        var result = FileDialogHelper.ResolveMacExternalToolPickerResult(
+            ExternalProcessResult.Exited(0, Environment.NewLine, string.Empty),
+            fileExists: _ => false,
+            directoryExists: _ => false);
+
+        Assert.Equal(MacExternalToolPickerResultKind.Cancelled, result.Kind);
+        Assert.Null(result.Path);
+    }
+
+    [Fact]
+    public void MacExternalToolPickerResult_FallsBackForProcessFailureOrOrdinaryDirectory()
+    {
+        var failed = FileDialogHelper.ResolveMacExternalToolPickerResult(
+            ExternalProcessResult.StartFailure("osascript missing"),
+            fileExists: _ => false,
+            directoryExists: _ => false);
+        var directory = FileDialogHelper.ResolveMacExternalToolPickerResult(
+            ExternalProcessResult.Exited(0, "/tmp/not-an-app" + Environment.NewLine, string.Empty),
+            fileExists: _ => false,
+            directoryExists: _ => true);
+
+        Assert.Equal(MacExternalToolPickerResultKind.Fallback, failed.Kind);
+        Assert.Contains("osascript missing", failed.Message);
+        Assert.Equal(MacExternalToolPickerResultKind.Fallback, directory.Kind);
+        Assert.Contains("not an executable file", directory.Message);
+    }
+
+    [SkippableFact]
+    public async System.Threading.Tasks.Task MacExternalToolPickerJxa_InitializesAppKit()
+    {
+        Skip.IfNot(OperatingSystem.IsMacOS(), "macOS-only AppKit probe");
+
+        ExternalProcessResult result =
+            await ExternalLauncher.Current.RunCapturedProcessAsync(
+                FileDialogHelper.CreateMacExternalToolPickerRequest(
+                    "Select File",
+                    validateOnly: true));
+
+        Assert.Equal(ExternalProcessResultKind.Exited, result.Kind);
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("READY", result.StandardOutput.Trim());
     }
 
     [AvaloniaFact]

--- a/FEBuilderGBA.Avalonia.Tests/ExternalToolAppBundleTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ExternalToolAppBundleTests.cs
@@ -107,18 +107,21 @@ public sealed class ExternalToolAppBundleTests : IDisposable
     }
 
     [Theory]
-    [InlineData("/Applications/mGBA.app")]
-    [InlineData("/usr/local/bin/mgba")]
-    public void MacExternalToolPickerResult_AcceptsAppBundleOrOrdinaryFile(string path)
+    [InlineData("/Applications/mGBA.app", "/Applications/mGBA.app", true)]
+    [InlineData("/Applications/mGBA.app/", "/Applications/mGBA.app", true)]
+    [InlineData("/usr/local/bin/mgba", "/usr/local/bin/mgba", false)]
+    public void MacExternalToolPickerResult_AcceptsAppBundleOrOrdinaryFile(
+        string output,
+        string expected,
+        bool isBundle)
     {
-        bool isBundle = path.EndsWith(".app", StringComparison.OrdinalIgnoreCase);
         var result = FileDialogHelper.ResolveMacExternalToolPickerResult(
-            ExternalProcessResult.Exited(0, path + Environment.NewLine, string.Empty),
-            fileExists: candidate => !isBundle && candidate == path,
-            directoryExists: candidate => isBundle && candidate == path);
+            ExternalProcessResult.Exited(0, output + Environment.NewLine, string.Empty),
+            fileExists: candidate => !isBundle && candidate == expected,
+            directoryExists: candidate => isBundle && candidate == expected);
 
         Assert.Equal(MacExternalToolPickerResultKind.Selected, result.Kind);
-        Assert.Equal(path, result.Path);
+        Assert.Equal(expected, result.Path);
         Assert.True(string.IsNullOrEmpty(result.Message));
     }
 

--- a/FEBuilderGBA.Avalonia.Tests/ExternalToolAppBundleTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ExternalToolAppBundleTests.cs
@@ -86,18 +86,17 @@ public sealed class ExternalToolAppBundleTests : IDisposable
     }
 
     [Fact]
-    public void MacExternalToolPickerRequest_UsesStaticJxaScriptAndSeparateTitleArgument()
+    public void MacExternalToolPickerRequest_UsesStaticAppleScriptAndSeparateTitleArgument()
     {
         ExternalProcessRequest request =
             FileDialogHelper.CreateMacExternalToolPickerRequest("Select File");
 
         Assert.Equal("/usr/bin/osascript", request.Executable);
         Assert.Equal("-l", request.ArgumentList[0]);
-        Assert.Equal("JavaScript", request.ArgumentList[1]);
+        Assert.Equal("AppleScript", request.ArgumentList[1]);
         Assert.Equal("-e", request.ArgumentList[2]);
-        Assert.Contains("treatsFilePackagesAsDirectories = false", request.ArgumentList[3]);
-        Assert.Contains("canChooseFiles = true", request.ArgumentList[3]);
-        Assert.Contains("canChooseDirectories = false", request.ArgumentList[3]);
+        Assert.Contains("choose file with prompt pickerPrompt", request.ArgumentList[3]);
+        Assert.Contains("on error number -128", request.ArgumentList[3]);
         Assert.DoesNotContain("Select File", request.ArgumentList[3]);
         Assert.Equal("Select File", request.ArgumentList[4]);
         Assert.True(request.CaptureStandardOutput);
@@ -150,10 +149,74 @@ public sealed class ExternalToolAppBundleTests : IDisposable
         Assert.Contains("not an executable file", directory.Message);
     }
 
-    [SkippableFact]
-    public async System.Threading.Tasks.Task MacExternalToolPickerJxa_InitializesAppKit()
+    [Fact]
+    public async System.Threading.Tasks.Task ExternalToolPickerRouting_NonMacSkipsNativePicker()
     {
-        Skip.IfNot(OperatingSystem.IsMacOS(), "macOS-only AppKit probe");
+        int nativeCalls = 0;
+        int fallbackCalls = 0;
+
+        string? result = await FileDialogHelper.OpenExternalToolCoreAsync(
+            isMacOS: false,
+            macPicker: () =>
+            {
+                nativeCalls++;
+                return System.Threading.Tasks.Task.FromResult(new MacExternalToolPickerResult(
+                    MacExternalToolPickerResultKind.Selected,
+                    "/Applications/mGBA.app",
+                    string.Empty));
+            },
+            avaloniaPicker: () =>
+            {
+                fallbackCalls++;
+                return System.Threading.Tasks.Task.FromResult<string?>("/usr/local/bin/mgba");
+            });
+
+        Assert.Equal("/usr/local/bin/mgba", result);
+        Assert.Equal(0, nativeCalls);
+        Assert.Equal(1, fallbackCalls);
+    }
+
+    [Theory]
+    [InlineData("Selected", "/Applications/mGBA.app", 0)]
+    [InlineData("Cancelled", null, 0)]
+    [InlineData("Fallback", "/usr/local/bin/mgba", 1)]
+    public async System.Threading.Tasks.Task ExternalToolPickerRouting_HandlesMacOutcome(
+        string kindName,
+        string? expected,
+        int expectedFallbackCalls)
+    {
+        var kind = Enum.Parse<MacExternalToolPickerResultKind>(kindName);
+        int nativeCalls = 0;
+        int fallbackCalls = 0;
+        string? selectedPath = kind == MacExternalToolPickerResultKind.Selected
+            ? "/Applications/mGBA.app"
+            : null;
+
+        string? result = await FileDialogHelper.OpenExternalToolCoreAsync(
+            isMacOS: true,
+            macPicker: () =>
+            {
+                nativeCalls++;
+                return System.Threading.Tasks.Task.FromResult(new MacExternalToolPickerResult(
+                    kind,
+                    selectedPath,
+                    kind == MacExternalToolPickerResultKind.Fallback ? "native picker failed" : string.Empty));
+            },
+            avaloniaPicker: () =>
+            {
+                fallbackCalls++;
+                return System.Threading.Tasks.Task.FromResult<string?>("/usr/local/bin/mgba");
+            });
+
+        Assert.Equal(expected, result);
+        Assert.Equal(1, nativeCalls);
+        Assert.Equal(expectedFallbackCalls, fallbackCalls);
+    }
+
+    [SkippableFact]
+    public async System.Threading.Tasks.Task MacExternalToolPickerAppleScript_LoadsStandardAdditions()
+    {
+        Skip.IfNot(OperatingSystem.IsMacOS(), "macOS-only AppleScript probe");
 
         ExternalProcessResult result =
             await ExternalLauncher.Current.RunCapturedProcessAsync(
@@ -163,7 +226,7 @@ public sealed class ExternalToolAppBundleTests : IDisposable
 
         Assert.Equal(ExternalProcessResultKind.Exited, result.Kind);
         Assert.Equal(0, result.ExitCode);
-        Assert.Equal("NSOpenPanel|true|false|false", result.StandardOutput.Trim());
+        Assert.Equal("READY", result.StandardOutput.Trim());
     }
 
     [AvaloniaFact]

--- a/FEBuilderGBA.Avalonia.Tests/ExternalToolAppBundleTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ExternalToolAppBundleTests.cs
@@ -95,13 +95,13 @@ public sealed class ExternalToolAppBundleTests : IDisposable
         Assert.Equal("-l", request.ArgumentList[0]);
         Assert.Equal("AppleScript", request.ArgumentList[1]);
         Assert.Equal("-e", request.ArgumentList[2]);
-        Assert.Contains("choose file with prompt pickerPrompt", request.ArgumentList[3]);
-        Assert.Contains(
-            "of type {\"com.apple.application-bundle\", \"public.data\"}",
-            request.ArgumentList[3]);
+        Assert.Contains("choose from list {appChoice, fileChoice}", request.ArgumentList[3]);
+        Assert.Contains("choose file with prompt pickerPrompt of type {\"app\"}", request.ArgumentList[3]);
         Assert.Contains("on error number -128", request.ArgumentList[3]);
         Assert.DoesNotContain("Select File", request.ArgumentList[3]);
         Assert.Equal("Select File", request.ArgumentList[4]);
+        Assert.Equal("*.app", request.ArgumentList[5]);
+        Assert.Equal("All Files", request.ArgumentList[6]);
         Assert.True(request.CaptureStandardOutput);
         Assert.True(request.CaptureStandardError);
     }

--- a/FEBuilderGBA.Avalonia.Tests/ExternalToolAppBundleTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ExternalToolAppBundleTests.cs
@@ -96,6 +96,9 @@ public sealed class ExternalToolAppBundleTests : IDisposable
         Assert.Equal("AppleScript", request.ArgumentList[1]);
         Assert.Equal("-e", request.ArgumentList[2]);
         Assert.Contains("choose file with prompt pickerPrompt", request.ArgumentList[3]);
+        Assert.Contains(
+            "of type {\"com.apple.application-bundle\", \"public.data\"}",
+            request.ArgumentList[3]);
         Assert.Contains("on error number -128", request.ArgumentList[3]);
         Assert.DoesNotContain("Select File", request.ArgumentList[3]);
         Assert.Equal("Select File", request.ArgumentList[4]);

--- a/FEBuilderGBA.Avalonia/Dialogs/FileDialogHelper.cs
+++ b/FEBuilderGBA.Avalonia/Dialogs/FileDialogHelper.cs
@@ -6,9 +6,22 @@ using global::Avalonia;
 using global::Avalonia.Controls;
 using global::Avalonia.Platform.Storage;
 using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Services;
 
 namespace FEBuilderGBA.Avalonia.Dialogs
 {
+    internal enum MacExternalToolPickerResultKind
+    {
+        Selected,
+        Cancelled,
+        Fallback,
+    }
+
+    internal readonly record struct MacExternalToolPickerResult(
+        MacExternalToolPickerResultKind Kind,
+        string? Path,
+        string Message);
+
     /// <summary>
     /// Helper for file open/save dialogs using Avalonia 11 StorageProvider API.
     /// All user-visible strings are wrapped with R._() for i18n.
@@ -229,6 +242,36 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         static readonly string[] GplPatterns = new[] { "*.gpl" };
         static readonly string[] TxtPatterns = new[] { "*.txt" };
         static readonly string[] AllPalettePatterns = new[] { "*.pal", "*.gbapal", "*.act", "*.gpl", "*.txt" };
+        const string MacExternalToolPickerScript = """
+            ObjC.import("Cocoa");
+
+            function run(argv) {
+                const panel = $.NSOpenPanel.openPanel;
+                panel.canChooseFiles = true;
+                panel.canChooseDirectories = false;
+                panel.allowsMultipleSelection = false;
+                panel.treatsFilePackagesAsDirectories = false;
+                panel.resolvesAliases = true;
+
+                if (argv.length > 0) {
+                    panel.message = argv[0];
+                }
+                if (argv.length > 1 && argv[1] === "--validate") {
+                    return "READY";
+                }
+
+                const response = Number(panel.runModal);
+                if (response !== 1) {
+                    return "";
+                }
+
+                const urls = panel.URLs;
+                if (Number(urls.count) === 0) {
+                    return "";
+                }
+                return ObjC.unwrap(urls.objectAtIndex(0).path);
+            }
+            """;
 
         static IStorageProvider? GetStorageProvider(TopLevel? owner, string operation)
         {
@@ -254,6 +297,83 @@ namespace FEBuilderGBA.Avalonia.Dialogs
                     MakeAllFileType(),
                 },
             };
+
+        internal static ExternalProcessRequest CreateMacExternalToolPickerRequest(
+            string title,
+            bool validateOnly = false)
+        {
+            var arguments = new List<string>
+            {
+                "-l",
+                "JavaScript",
+                "-e",
+                MacExternalToolPickerScript,
+                title,
+            };
+            if (validateOnly)
+                arguments.Add("--validate");
+
+            return new ExternalProcessRequest("/usr/bin/osascript")
+            {
+                ArgumentList = arguments,
+                CaptureStandardOutput = true,
+                CaptureStandardError = true,
+            };
+        }
+
+        internal static MacExternalToolPickerResult ResolveMacExternalToolPickerResult(
+            ExternalProcessResult result,
+            Func<string, bool> fileExists,
+            Func<string, bool> directoryExists)
+        {
+            if (result.Kind != ExternalProcessResultKind.Exited || result.ExitCode != 0)
+            {
+                string detail = !string.IsNullOrWhiteSpace(result.Message)
+                    ? result.Message
+                    : !string.IsNullOrWhiteSpace(result.StandardError)
+                        ? result.StandardError.Trim()
+                        : $"osascript exited with code {result.ExitCode?.ToString() ?? "unknown"}.";
+                return new MacExternalToolPickerResult(
+                    MacExternalToolPickerResultKind.Fallback,
+                    null,
+                    "macOS external-tool picker failed: " + detail);
+            }
+
+            string path = result.StandardOutput.TrimEnd('\r', '\n');
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return new MacExternalToolPickerResult(
+                    MacExternalToolPickerResultKind.Cancelled,
+                    null,
+                    string.Empty);
+            }
+
+            bool isAppBundle = directoryExists(path)
+                && string.Equals(Path.GetExtension(path), ".app", StringComparison.OrdinalIgnoreCase);
+            if (fileExists(path) || isAppBundle)
+            {
+                return new MacExternalToolPickerResult(
+                    MacExternalToolPickerResultKind.Selected,
+                    path,
+                    string.Empty);
+            }
+
+            return new MacExternalToolPickerResult(
+                MacExternalToolPickerResultKind.Fallback,
+                null,
+                $"The macOS picker returned a path that is not an executable file or .app bundle: {path}");
+        }
+
+        static async Task<MacExternalToolPickerResult> PickMacExternalToolAsync(string title)
+        {
+            ExternalProcessResult processResult =
+                await ExternalLauncher.Current.RunCapturedProcessAsync(
+                    CreateMacExternalToolPickerRequest(title));
+            return ResolveMacExternalToolPickerResult(
+                processResult,
+                File.Exists,
+                Directory.Exists);
+        }
 
         static string? ResolveExternalToolLocalPath(IReadOnlyList<IStorageFile>? files)
         {
@@ -541,12 +661,24 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         }
 
         /// <summary>
-        /// Pick a local external-tool path with the shared executable file picker.
-        /// macOS application bundles remain selectable through the <c>*.app</c>
-        /// filter, while non-desktop targets still reject picks with no local path.
+        /// Pick a local external-tool path with one shared picker path. macOS uses
+        /// NSOpenPanel so application packages remain selectable; other platforms
+        /// and macOS failures fall back to Avalonia's storage-provider picker.
         /// </summary>
         public static async Task<string?> OpenExternalTool(TopLevel? owner, string title)
         {
+            if (OperatingSystem.IsMacOS())
+            {
+                MacExternalToolPickerResult macResult =
+                    await PickMacExternalToolAsync(R._(title));
+                if (macResult.Kind == MacExternalToolPickerResultKind.Selected)
+                    return macResult.Path;
+                if (macResult.Kind == MacExternalToolPickerResultKind.Cancelled)
+                    return null;
+
+                Log.Error($"FileDialogHelper.OpenExternalTool: {macResult.Message}");
+            }
+
             var provider = GetStorageProvider(owner, nameof(OpenExternalTool));
             if (provider == null)
                 return null;

--- a/FEBuilderGBA.Avalonia/Dialogs/FileDialogHelper.cs
+++ b/FEBuilderGBA.Avalonia/Dialogs/FileDialogHelper.cs
@@ -257,9 +257,15 @@ namespace FEBuilderGBA.Avalonia.Dialogs
                     panel.message = argv[0];
                 }
                 if (argv.length > 1 && argv[1] === "--validate") {
-                    return "READY";
+                    return [
+                        ObjC.unwrap(panel.className),
+                        String(panel.canChooseFiles),
+                        String(panel.canChooseDirectories),
+                        String(panel.treatsFilePackagesAsDirectories)
+                    ].join("|");
                 }
 
+                $.NSApplication.sharedApplication.activateIgnoringOtherApps(true);
                 const response = Number(panel.runModal);
                 if (response !== 1) {
                     return "";

--- a/FEBuilderGBA.Avalonia/Dialogs/FileDialogHelper.cs
+++ b/FEBuilderGBA.Avalonia/Dialogs/FileDialogHelper.cs
@@ -347,20 +347,26 @@ namespace FEBuilderGBA.Avalonia.Dialogs
                     string.Empty);
             }
 
-            bool isAppBundle = directoryExists(path)
-                && string.Equals(Path.GetExtension(path), ".app", StringComparison.OrdinalIgnoreCase);
-            if (fileExists(path) || isAppBundle)
+            string normalizedPath = path.TrimEnd(
+                Path.DirectorySeparatorChar,
+                Path.AltDirectorySeparatorChar);
+            if (normalizedPath.Length == 0)
+                normalizedPath = path;
+
+            bool isAppBundle = directoryExists(normalizedPath)
+                && string.Equals(Path.GetExtension(normalizedPath), ".app", StringComparison.OrdinalIgnoreCase);
+            if (fileExists(normalizedPath) || isAppBundle)
             {
                 return new MacExternalToolPickerResult(
                     MacExternalToolPickerResultKind.Selected,
-                    path,
+                    normalizedPath,
                     string.Empty);
             }
 
             return new MacExternalToolPickerResult(
                 MacExternalToolPickerResultKind.Fallback,
                 null,
-                $"The macOS picker returned a path that is not an executable file or .app bundle: {path}");
+                $"The macOS picker returned a path that is not an executable file or .app bundle: {normalizedPath}");
         }
 
         static async Task<MacExternalToolPickerResult> PickMacExternalToolAsync(string title)

--- a/FEBuilderGBA.Avalonia/Dialogs/FileDialogHelper.cs
+++ b/FEBuilderGBA.Avalonia/Dialogs/FileDialogHelper.cs
@@ -245,14 +245,24 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         const string MacExternalToolPickerScript = """
             on run argv
                 set pickerPrompt to item 1 of argv
-                if (count of argv) > 1 then
-                    if item 2 of argv is "--validate" then
+                set appChoice to item 2 of argv
+                set fileChoice to item 3 of argv
+                if (count of argv) > 3 then
+                    if item 4 of argv is "--validate" then
                         return "READY"
                     end if
                 end if
 
                 try
-                    set pickedFile to choose file with prompt pickerPrompt of type {"com.apple.application-bundle", "public.data"}
+                    set pickerKind to choose from list {appChoice, fileChoice} with title pickerPrompt with prompt pickerPrompt default items {fileChoice}
+                    if pickerKind is false then
+                        return ""
+                    end if
+                    if item 1 of pickerKind is appChoice then
+                        set pickedFile to choose file with prompt pickerPrompt of type {"app"}
+                    else
+                        set pickedFile to choose file with prompt pickerPrompt
+                    end if
                     return POSIX path of pickedFile
                 on error number -128
                     return ""
@@ -296,6 +306,8 @@ namespace FEBuilderGBA.Avalonia.Dialogs
                 "-e",
                 MacExternalToolPickerScript,
                 title,
+                "*.app",
+                R._("All Files"),
             };
             if (validateOnly)
                 arguments.Add("--validate");

--- a/FEBuilderGBA.Avalonia/Dialogs/FileDialogHelper.cs
+++ b/FEBuilderGBA.Avalonia/Dialogs/FileDialogHelper.cs
@@ -243,40 +243,21 @@ namespace FEBuilderGBA.Avalonia.Dialogs
         static readonly string[] TxtPatterns = new[] { "*.txt" };
         static readonly string[] AllPalettePatterns = new[] { "*.pal", "*.gbapal", "*.act", "*.gpl", "*.txt" };
         const string MacExternalToolPickerScript = """
-            ObjC.import("Cocoa");
+            on run argv
+                set pickerPrompt to item 1 of argv
+                if (count of argv) > 1 then
+                    if item 2 of argv is "--validate" then
+                        return "READY"
+                    end if
+                end if
 
-            function run(argv) {
-                const panel = $.NSOpenPanel.openPanel;
-                panel.canChooseFiles = true;
-                panel.canChooseDirectories = false;
-                panel.allowsMultipleSelection = false;
-                panel.treatsFilePackagesAsDirectories = false;
-                panel.resolvesAliases = true;
-
-                if (argv.length > 0) {
-                    panel.message = argv[0];
-                }
-                if (argv.length > 1 && argv[1] === "--validate") {
-                    return [
-                        ObjC.unwrap(panel.className),
-                        String(panel.canChooseFiles),
-                        String(panel.canChooseDirectories),
-                        String(panel.treatsFilePackagesAsDirectories)
-                    ].join("|");
-                }
-
-                $.NSApplication.sharedApplication.activateIgnoringOtherApps(true);
-                const response = Number(panel.runModal);
-                if (response !== 1) {
-                    return "";
-                }
-
-                const urls = panel.URLs;
-                if (Number(urls.count) === 0) {
-                    return "";
-                }
-                return ObjC.unwrap(urls.objectAtIndex(0).path);
-            }
+                try
+                    set pickedFile to choose file with prompt pickerPrompt
+                    return POSIX path of pickedFile
+                on error number -128
+                    return ""
+                end try
+            end run
             """;
 
         static IStorageProvider? GetStorageProvider(TopLevel? owner, string operation)
@@ -311,7 +292,7 @@ namespace FEBuilderGBA.Avalonia.Dialogs
             var arguments = new List<string>
             {
                 "-l",
-                "JavaScript",
+                "AppleScript",
                 "-e",
                 MacExternalToolPickerScript,
                 title,
@@ -375,10 +356,42 @@ namespace FEBuilderGBA.Avalonia.Dialogs
             ExternalProcessResult processResult =
                 await ExternalLauncher.Current.RunCapturedProcessAsync(
                     CreateMacExternalToolPickerRequest(title));
-            return ResolveMacExternalToolPickerResult(
+            MacExternalToolPickerResult result = ResolveMacExternalToolPickerResult(
                 processResult,
                 File.Exists,
                 Directory.Exists);
+            if (result.Kind == MacExternalToolPickerResultKind.Fallback)
+                Log.Error($"FileDialogHelper.OpenExternalTool: {result.Message}");
+            return result;
+        }
+
+        internal static async Task<string?> OpenExternalToolCoreAsync(
+            bool isMacOS,
+            Func<Task<MacExternalToolPickerResult>> macPicker,
+            Func<Task<string?>> avaloniaPicker)
+        {
+            if (isMacOS)
+            {
+                MacExternalToolPickerResult macResult = await macPicker();
+                if (macResult.Kind == MacExternalToolPickerResultKind.Selected)
+                    return macResult.Path;
+                if (macResult.Kind == MacExternalToolPickerResultKind.Cancelled)
+                    return null;
+            }
+
+            return await avaloniaPicker();
+        }
+
+        static async Task<string?> OpenExternalToolWithStorageProviderAsync(
+            TopLevel? owner,
+            string title)
+        {
+            var provider = GetStorageProvider(owner, nameof(OpenExternalTool));
+            if (provider == null)
+                return null;
+
+            var files = await provider.OpenFilePickerAsync(CreateExternalToolOpenOptions(title));
+            return ResolveExternalToolLocalPath(files);
         }
 
         static string? ResolveExternalToolLocalPath(IReadOnlyList<IStorageFile>? files)
@@ -668,30 +681,14 @@ namespace FEBuilderGBA.Avalonia.Dialogs
 
         /// <summary>
         /// Pick a local external-tool path with one shared picker path. macOS uses
-        /// NSOpenPanel so application packages remain selectable; other platforms
-        /// and macOS failures fall back to Avalonia's storage-provider picker.
+        /// the system scripting addition so application packages remain selectable;
+        /// other platforms and macOS failures use Avalonia's storage-provider picker.
         /// </summary>
-        public static async Task<string?> OpenExternalTool(TopLevel? owner, string title)
-        {
-            if (OperatingSystem.IsMacOS())
-            {
-                MacExternalToolPickerResult macResult =
-                    await PickMacExternalToolAsync(R._(title));
-                if (macResult.Kind == MacExternalToolPickerResultKind.Selected)
-                    return macResult.Path;
-                if (macResult.Kind == MacExternalToolPickerResultKind.Cancelled)
-                    return null;
-
-                Log.Error($"FileDialogHelper.OpenExternalTool: {macResult.Message}");
-            }
-
-            var provider = GetStorageProvider(owner, nameof(OpenExternalTool));
-            if (provider == null)
-                return null;
-
-            var files = await provider.OpenFilePickerAsync(CreateExternalToolOpenOptions(title));
-            return ResolveExternalToolLocalPath(files);
-        }
+        public static Task<string?> OpenExternalTool(TopLevel? owner, string title)
+            => OpenExternalToolCoreAsync(
+                OperatingSystem.IsMacOS(),
+                () => PickMacExternalToolAsync(R._(title)),
+                () => OpenExternalToolWithStorageProviderAsync(owner, title));
 
         /// <summary>Open any file with custom filter.</summary>
         public static async Task<string?> OpenFile(TopLevel? owner, string title, string pattern, bool requireLocalPath = false)

--- a/FEBuilderGBA.Avalonia/Dialogs/FileDialogHelper.cs
+++ b/FEBuilderGBA.Avalonia/Dialogs/FileDialogHelper.cs
@@ -252,7 +252,7 @@ namespace FEBuilderGBA.Avalonia.Dialogs
                 end if
 
                 try
-                    set pickedFile to choose file with prompt pickerPrompt
+                    set pickedFile to choose file with prompt pickerPrompt of type {"com.apple.application-bundle", "public.data"}
                     return POSIX path of pickedFile
                 on error number -128
                     return ""


### PR DESCRIPTION
## Summary

- route the shared external-tool picker through a blocking macOS Standard Additions dialog while preserving the Avalonia fallback
- keep process creation behind `ExternalLauncher` and pass the translated title and picker choices separately from the static AppleScript
- cover file/app selection (including slash-terminated bundles), cancellation, fallback, non-macOS behavior, and a macOS-only Standard Additions probe

Accepted plan: https://github.com/laqieer/FEBuilderGBA/issues/2125#issuecomment-5387346570

Closes #2125

## Test plan

- [x] `dotnet test FEBuilderGBA.Avalonia.Tests\FEBuilderGBA.Avalonia.Tests.csproj -c Release --filter FullyQualifiedName~ExternalToolAppBundleTests --no-restore`
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests\FEBuilderGBA.Avalonia.Tests.csproj -c Release --no-restore` (9,877 passed; 11 skipped)
- [x] `dotnet build FEBuilderGBA.Avalonia\FEBuilderGBA.Avalonia.csproj -c Release --no-restore` (0 warnings, 0 errors)
- [x] Real desktop-Skia `OptionsView` capture completed

## GUI Test Report

The real desktop application rendered the ROM-independent Options editor successfully. The external-tool path and Browse controls are present with no change to their shared wiring. The screenshot is attached below. Fresh macOS CI executes and passes the AppleScript Standard Additions probe. Real macOS testing identified and demonstrated the trailing-separator bundle issue; latest commit `85d37f238` independently normalizes it with regression coverage.

**macOS validation:** satisfied on latest commit `85d37f238`. CI passed the Standard Additions probe; interactive testing confirmed ordinary executable selection and normalized `/Applications/mGBA.app` selection. Final macOS proof: https://github.com/laqieer/FEBuilderGBA/pull/2126#issuecomment-5389388329

![Avalonia Options editor external-tool controls](https://github.com/user-attachments/assets/2c45265f-cf31-4f11-b98b-40c64aec6fbb)

![macOS external-tool picker selected mGBA.app](https://github.com/user-attachments/assets/98eccea8-5b46-4392-88f4-5a5b9f57986b)

Copilot CLI: 1.0.80
Model: GPT-5.6 Sol (gpt-5.6-sol)
