### PR TITLE
fix(core): enable Git long paths for content repos

### DIFF
--- a/FEBuilderGBA.Core.Tests/GitUtilLongPathTests.cs
+++ b/FEBuilderGBA.Core.Tests/GitUtilLongPathTests.cs
@@ -1,0 +1,80 @@
+using FEBuilderGBA;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    public class GitUtilLongPathTests
+    {
+        [Fact]
+        public void BuildCloneArguments_WindowsPersistsLongPathsAndQuotesInputs()
+        {
+            string args = GitUtil.BuildCloneArguments(
+                "https://example.invalid/content repo.git",
+                @"C:\Program Files\FEBuilderGBA\resources\FE-Repo",
+                isWindows: true);
+
+            Assert.Equal(
+                "clone --progress --depth=1 -c core.longpaths=true " +
+                "\"https://example.invalid/content repo.git\" " +
+                "\"C:\\Program Files\\FEBuilderGBA\\resources\\FE-Repo\"",
+                args);
+        }
+
+        [Fact]
+        public void BuildCloneArguments_NonWindowsPreservesExistingCommand()
+        {
+            string args = GitUtil.BuildCloneArguments(
+                "https://example.invalid/content.git",
+                "/opt/febuilder/resources/FE-Repo",
+                isWindows: false);
+
+            Assert.Equal(
+                "clone --progress --depth=1 " +
+                "\"https://example.invalid/content.git\" " +
+                "\"/opt/febuilder/resources/FE-Repo\"",
+                args);
+        }
+
+        [Fact]
+        public void BuildUpdateArguments_WindowsScopesLongPathsToEveryCommand()
+        {
+            var commands = GitUtil.BuildUpdateArguments(
+                "https://example.invalid/content repo.git",
+                isWindows: true);
+
+            Assert.Equal(new[]
+            {
+                "-c core.longpaths=true remote set-url origin " +
+                "\"https://example.invalid/content repo.git\"",
+                "-c core.longpaths=true fetch --progress --depth=1 origin",
+                "-c core.longpaths=true reset --hard FETCH_HEAD",
+            }, commands);
+        }
+
+        [Fact]
+        public void BuildUpdateArguments_NonWindowsPreservesExistingCommands()
+        {
+            var commands = GitUtil.BuildUpdateArguments(
+                "https://example.invalid/content.git",
+                isWindows: false);
+
+            Assert.Equal(new[]
+            {
+                "remote set-url origin \"https://example.invalid/content.git\"",
+                "fetch --progress --depth=1 origin",
+                "reset --hard FETCH_HEAD",
+            }, commands);
+        }
+
+        [Fact]
+        public void BuildUpdateArguments_WithoutRemoteOmitsSetUrl()
+        {
+            var commands = GitUtil.BuildUpdateArguments(null, isWindows: true);
+
+            Assert.Equal(new[]
+            {
+                "-c core.longpaths=true fetch --progress --depth=1 origin",
+                "-c core.longpaths=true reset --hard FETCH_HEAD",
+            }, commands);
+        }
+    }
+}

--- a/FEBuilderGBA.Core/GitUtil.cs
+++ b/FEBuilderGBA.Core/GitUtil.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
@@ -195,15 +196,49 @@ namespace FEBuilderGBA
         /// git clone --progress --depth=1 &lt;url&gt; &lt;targetPath&gt;
         /// (targetPath must be absent or an existing EMPTY directory — git clones in place into an
         /// empty directory, which is what keeps a released placeholder root held.)
+        /// On Windows the clone-local core.longpaths setting is persisted before checkout so
+        /// content repositories with paths beyond MAX_PATH initialize and update reliably.
         /// --progress forces git to emit progress lines even when stderr is redirected.
         /// </summary>
         public static int Clone(string gitExe, string url, string targetPath,
                                 Action<string>? outputCallback = null,
                                 StringBuilder? outputLog = null)
         {
-            string args = string.Format("clone --progress --depth=1 \"{0}\" \"{1}\"", url, targetPath);
+            string args = BuildCloneArguments(url, targetPath, OperatingSystem.IsWindows());
             return RunGit(gitExe, args, null, outputCallback, outputLog);
         }
+
+        internal static string BuildCloneArguments(string url, string targetPath, bool isWindows)
+        {
+            string longPathsConfig = isWindows ? " -c core.longpaths=true" : "";
+            return string.Format(
+                "clone --progress --depth=1{0} \"{1}\" \"{2}\"",
+                longPathsConfig,
+                url,
+                targetPath);
+        }
+
+        internal static string[] BuildUpdateArguments(string? remoteUrl, bool isWindows)
+        {
+            var commands = new List<string>(3);
+            if (!string.IsNullOrEmpty(remoteUrl))
+            {
+                commands.Add(ApplyWindowsLongPaths(
+                    string.Format("remote set-url origin \"{0}\"", remoteUrl),
+                    isWindows));
+            }
+
+            commands.Add(ApplyWindowsLongPaths(
+                "fetch --progress --depth=1 origin",
+                isWindows));
+            commands.Add(ApplyWindowsLongPaths(
+                "reset --hard FETCH_HEAD",
+                isWindows));
+            return commands.ToArray();
+        }
+
+        static string ApplyWindowsLongPaths(string args, bool isWindows)
+            => isWindows ? "-c core.longpaths=true " + args : args;
 
         /// <summary>
         /// git fetch --progress --depth=1 origin  +  git reset --hard FETCH_HEAD
@@ -217,15 +252,18 @@ namespace FEBuilderGBA
                                  StringBuilder? outputLog = null,
                                  string? remoteUrl = null)
         {
+            string[] commands = BuildUpdateArguments(remoteUrl, OperatingSystem.IsWindows());
+            int commandIndex = 0;
+
             // Switch origin to the configured remote URL before fetching
             if (!string.IsNullOrEmpty(remoteUrl))
-                RunGit(gitExe, string.Format("remote set-url origin \"{0}\"", remoteUrl), repoPath);
+                RunGit(gitExe, commands[commandIndex++], repoPath);
 
-            int code = RunGit(gitExe, "fetch --progress --depth=1 origin", repoPath, outputCallback, outputLog);
+            int code = RunGit(gitExe, commands[commandIndex++], repoPath, outputCallback, outputLog);
             if (code != 0)
                 return code;
 
-            return RunGit(gitExe, "reset --hard FETCH_HEAD", repoPath, outputCallback, outputLog);
+            return RunGit(gitExe, commands[commandIndex], repoPath, outputCallback, outputLog);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

- persist `core.longpaths=true` inside new Windows content-repository clones before checkout
- apply command-scoped long-path configuration to update commands for older clones
- preserve existing Linux/macOS Git arguments and cover all command variants deterministically

Accepted plan: https://github.com/laqieer/FEBuilderGBA/issues/2129#issuecomment-5422277852

Closes #2129

## Test plan

- [x] `dotnet test FEBuilderGBA.Core.Tests\FEBuilderGBA.Core.Tests.csproj -c Release --filter FullyQualifiedName~GitUtilLongPathTests --no-restore` (5 passed)
- [x] `dotnet test FEBuilderGBA.Core.Tests\FEBuilderGBA.Core.Tests.csproj -c Release --no-restore` (7,591 passed; 19 skipped)
- [x] `dotnet test FEBuilderGBA.Tests\FEBuilderGBA.Tests.csproj -c Release` (2,357 passed)
- [x] `dotnet build FEBuilderGBA.Core\FEBuilderGBA.Core.csproj -c Release --no-restore` (0 warnings, 0 errors)

The first full Core run identified only missing declared `config/patch2` test data in the isolated worktree; after initializing that submodule, the full suite passed.

Copilot CLI: 1.0.80
Model: GPT-5.6 Sol (gpt-5.6-sol)