### PR TITLE
fix(avalonia): explain unsupported Patch Manager actions

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/PatchManagerAvailabilityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/PatchManagerAvailabilityTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using global::Avalonia.Automation;
 using global::Avalonia.Controls;
 using global::Avalonia.Headless.XUnit;
 using global::Avalonia.Threading;
@@ -128,6 +129,10 @@ namespace FEBuilderGBA.Avalonia.Tests
                 Assert.Contains(
                     "Event Assembler",
                     view.FindControl<TextBlock>("StatusMessageLabel")!.Text);
+                Assert.Equal(
+                    AutomationLiveSetting.Polite,
+                    AutomationProperties.GetLiveSetting(
+                        view.FindControl<TextBlock>("StatusMessageLabel")!));
                 Assert.False(view.FindControl<Button>("InstallButton")!.IsEnabled);
                 Assert.False(view.FindControl<Button>("ForceInstallButton")!.IsEnabled);
                 Assert.False(view.FindControl<Button>("ForceInstallButton")!.IsVisible);

--- a/FEBuilderGBA.Avalonia.Tests/PatchManagerAvailabilityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/PatchManagerAvailabilityTests.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using global::Avalonia.Controls;
+using global::Avalonia.Headless.XUnit;
+using global::Avalonia.Threading;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests
+{
+    [Collection("SharedState")]
+    public class PatchManagerAvailabilityTests
+    {
+        [Theory]
+        [InlineData("", "Available", true)]
+        [InlineData("BIN", "Available", true)]
+        [InlineData("bin", "Available", true)]
+        [InlineData("EA", "Unsupported", false)]
+        [InlineData("ea", "Unsupported", false)]
+        [InlineData("CUSTOM", "Unsupported", false)]
+        public void NotInstalledPatch_StatusAndInstallEligibilityReflectType(
+            string type,
+            string expectedStatus,
+            bool expectedCanInstall)
+        {
+            var patch = new PatchEntry
+            {
+                Status = PatchMetadataCore.PatchStatus.NotInstalled,
+                Type = type,
+                PatchFilePath = "PATCH_Test.txt",
+            };
+            var vm = new PatchManagerViewModel { SelectedPatch = patch };
+
+            Assert.Equal(expectedStatus, patch.StatusText);
+            Assert.Equal(expectedCanInstall, vm.CanInstall);
+            Assert.Equal(expectedCanInstall, string.IsNullOrEmpty(patch.ActionRestrictionMessage));
+        }
+
+        [Fact]
+        public void InstalledUnsupportedPatch_RemainsInstalledButCannotUninstall()
+        {
+            var patch = new PatchEntry
+            {
+                Status = PatchMetadataCore.PatchStatus.Installed,
+                Type = "EA",
+                PatchFilePath = "PATCH_Test.txt",
+            };
+            var vm = new PatchManagerViewModel { SelectedPatch = patch };
+
+            Assert.Equal("Installed", patch.StatusText);
+            Assert.False(vm.CanUninstall);
+            Assert.Contains("Event Assembler", patch.ActionRestrictionMessage);
+        }
+
+        [Fact]
+        public void UnknownUnsupportedType_HasGenericExplanation()
+        {
+            var patch = new PatchEntry
+            {
+                Status = PatchMetadataCore.PatchStatus.NotInstalled,
+                Type = "CUSTOM",
+                PatchFilePath = "PATCH_Test.txt",
+            };
+
+            Assert.Contains("CUSTOM", patch.ActionRestrictionMessage);
+            Assert.Contains("not currently supported", patch.ActionRestrictionMessage);
+        }
+
+        [AvaloniaFact]
+        public void SelectingUnsupportedEaPatch_ShowsExplanationAndDisablesActions()
+        {
+            ROM? savedRom = CoreState.ROM;
+            CoreState.ROM = null!;
+            var view = new PatchManagerView();
+            var host = new Window { Content = view };
+            host.Show();
+            try
+            {
+                Dispatcher.UIThread.RunJobs();
+                var patch = new PatchEntry
+                {
+                    Name = "EA Test",
+                    Status = PatchMetadataCore.PatchStatus.NotInstalled,
+                    Type = "EA",
+                    PatchFilePath = "PATCH_Test.txt",
+                    UnsatisfiedDependencyCount = 1,
+                    UnsatisfiedDependencies = new List<PatchMetadataCore.PatchDependency>
+                    {
+                        new() { Comment = "Dependency needed" },
+                    },
+                };
+                ListBox list = view.FindControl<ListBox>("PatchListBox")!;
+                list.ItemsSource = new[] { patch };
+                list.SelectedIndex = 0;
+                Dispatcher.UIThread.RunJobs();
+
+                Assert.Equal("Unsupported", view.FindControl<TextBlock>("DetailStatus")!.Text);
+                Assert.Contains(
+                    "Event Assembler",
+                    view.FindControl<TextBlock>("StatusMessageLabel")!.Text);
+                Assert.False(view.FindControl<Button>("InstallButton")!.IsEnabled);
+                Assert.False(view.FindControl<Button>("ForceInstallButton")!.IsEnabled);
+                Assert.False(view.FindControl<Button>("ForceInstallButton")!.IsVisible);
+                Assert.False(view.FindControl<Button>("UninstallButton")!.IsEnabled);
+            }
+            finally
+            {
+                host.Close();
+                CoreState.ROM = savedRom!;
+            }
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/PatchManagerAvailabilityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/PatchManagerAvailabilityTests.cs
@@ -16,7 +16,7 @@ namespace FEBuilderGBA.Avalonia.Tests
         [Theory]
         [InlineData("", "Available", true)]
         [InlineData("BIN", "Available", true)]
-        [InlineData("bin", "Available", true)]
+        [InlineData("bin", "Unsupported", false)]
         [InlineData("EA", "Unsupported", false)]
         [InlineData("ea", "Unsupported", false)]
         [InlineData("CUSTOM", "Unsupported", false)]
@@ -68,6 +68,33 @@ namespace FEBuilderGBA.Avalonia.Tests
             Assert.Contains("not currently supported", patch.ActionRestrictionMessage);
         }
 
+        [Theory]
+        [InlineData("ja", "未対応")]
+        [InlineData("zh", "不支持")]
+        public void UnsupportedStatus_LocalizesFromShippedTable(string language, string expected)
+        {
+            string path = Path.Combine(
+                FindRepoRoot(),
+                "config",
+                "translate",
+                language + ".txt");
+            try
+            {
+                MyTranslateResource.LoadResource(path);
+                var patch = new PatchEntry
+                {
+                    Status = PatchMetadataCore.PatchStatus.NotInstalled,
+                    Type = "EA",
+                };
+
+                Assert.Equal(expected, patch.StatusText);
+            }
+            finally
+            {
+                MyTranslateResource.Clear();
+            }
+        }
+
         [AvaloniaFact]
         public void SelectingUnsupportedEaPatch_ShowsExplanationAndDisablesActions()
         {
@@ -110,6 +137,18 @@ namespace FEBuilderGBA.Avalonia.Tests
                 host.Close();
                 CoreState.ROM = savedRom!;
             }
+        }
+
+        static string FindRepoRoot()
+        {
+            for (var dir = new DirectoryInfo(AppContext.BaseDirectory);
+                 dir != null;
+                 dir = dir.Parent)
+            {
+                if (File.Exists(Path.Combine(dir.FullName, "FEBuilderGBA.sln")))
+                    return dir.FullName;
+            }
+            throw new InvalidOperationException("Could not locate FEBuilderGBA.sln.");
         }
     }
 }

--- a/FEBuilderGBA.Avalonia.Tests/PatchManagerAvailabilityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/PatchManagerAvailabilityTests.cs
@@ -99,12 +99,13 @@ namespace FEBuilderGBA.Avalonia.Tests
         public void SelectingUnsupportedEaPatch_ShowsExplanationAndDisablesActions()
         {
             ROM? savedRom = CoreState.ROM;
-            CoreState.ROM = null!;
-            var view = new PatchManagerView();
-            var host = new Window { Content = view };
-            host.Show();
+            Window? host = null;
             try
             {
+                CoreState.ROM = null!;
+                var view = new PatchManagerView();
+                host = new Window { Content = view };
+                host.Show();
                 Dispatcher.UIThread.RunJobs();
                 var patch = new PatchEntry
                 {
@@ -134,7 +135,7 @@ namespace FEBuilderGBA.Avalonia.Tests
             }
             finally
             {
-                host.Close();
+                host?.Close();
                 CoreState.ROM = savedRom!;
             }
         }

--- a/FEBuilderGBA.Avalonia/ViewModels/PatchManagerViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/PatchManagerViewModel.cs
@@ -23,14 +23,14 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
         public bool IsInstallTypeSupported =>
             string.IsNullOrEmpty(Type) ||
-            string.Equals(Type, "BIN", StringComparison.OrdinalIgnoreCase);
+            Type == "BIN";
 
         public string StatusText => Status switch
         {
-            PatchMetadataCore.PatchStatus.Installed => "Installed",
-            PatchMetadataCore.PatchStatus.NotInstalled when !IsInstallTypeSupported => "Unsupported",
-            PatchMetadataCore.PatchStatus.NotInstalled => "Available",
-            _ => "Unknown"
+            PatchMetadataCore.PatchStatus.Installed => R._("Installed"),
+            PatchMetadataCore.PatchStatus.NotInstalled when !IsInstallTypeSupported => R._("Unsupported"),
+            PatchMetadataCore.PatchStatus.NotInstalled => R._("Available"),
+            _ => R._("Unknown")
         };
 
         public string ActionRestrictionMessage

--- a/FEBuilderGBA.Avalonia/ViewModels/PatchManagerViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/PatchManagerViewModel.cs
@@ -21,12 +21,34 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         public int UnsatisfiedDependencyCount { get; set; }
         public List<PatchMetadataCore.PatchDependency> UnsatisfiedDependencies { get; set; } = new();
 
+        public bool IsInstallTypeSupported =>
+            string.IsNullOrEmpty(Type) ||
+            string.Equals(Type, "BIN", StringComparison.OrdinalIgnoreCase);
+
         public string StatusText => Status switch
         {
             PatchMetadataCore.PatchStatus.Installed => "Installed",
+            PatchMetadataCore.PatchStatus.NotInstalled when !IsInstallTypeSupported => "Unsupported",
             PatchMetadataCore.PatchStatus.NotInstalled => "Available",
             _ => "Unknown"
         };
+
+        public string ActionRestrictionMessage
+        {
+            get
+            {
+                if (IsInstallTypeSupported)
+                    return "";
+                if (string.Equals(Type, "EA", StringComparison.OrdinalIgnoreCase))
+                {
+                    return R._(
+                        "EA patches require Event Assembler and are not currently supported by the Avalonia Patch Manager.");
+                }
+                return R._(
+                    "Patch type '{0}' is not currently supported by the Avalonia Patch Manager.",
+                    Type);
+            }
+        }
 
         /// <summary>True when this patch has unmet dependencies.</summary>
         public bool HasUnmetDependencies => UnsatisfiedDependencyCount > 0;
@@ -133,7 +155,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             _selectedPatch != null &&
             _selectedPatch.Status != PatchMetadataCore.PatchStatus.Installed &&
             !string.IsNullOrEmpty(_selectedPatch.PatchFilePath) &&
-            (_selectedPatch.Type == "BIN" || string.IsNullOrEmpty(_selectedPatch.Type));
+            _selectedPatch.IsInstallTypeSupported;
 
         /// <summary>
         /// True when a selected BIN patch is installed and can be uninstalled — either from a
@@ -144,7 +166,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             _selectedPatch != null &&
             _selectedPatch.Status == PatchMetadataCore.PatchStatus.Installed &&
             !string.IsNullOrEmpty(_selectedPatch.PatchFilePath) &&
-            (_selectedPatch.Type == "BIN" || string.IsNullOrEmpty(_selectedPatch.Type));
+            _selectedPatch.IsInstallTypeSupported;
 
         public ObservableCollection<PatchEntry> FilteredPatches => _filteredPatches;
 

--- a/FEBuilderGBA.Avalonia/Views/PatchManagerView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/PatchManagerView.axaml
@@ -105,7 +105,9 @@
           </StackPanel>
 
           <!-- Status Message -->
-          <TextBlock AutomationProperties.AutomationId="PatchManager_StatusMessage_Label" Name="StatusMessageLabel" TextWrapping="Wrap" FontSize="12"
+          <TextBlock AutomationProperties.AutomationId="PatchManager_StatusMessage_Label"
+                     AutomationProperties.LiveSetting="Polite"
+                     Name="StatusMessageLabel" TextWrapping="Wrap" FontSize="12"
                      Foreground="Gray" Margin="0,0,0,8" />
 
           <!-- Separator -->

--- a/FEBuilderGBA.Avalonia/Views/PatchManagerView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/PatchManagerView.axaml.cs
@@ -109,7 +109,7 @@ namespace FEBuilderGBA.Avalonia.Views
             }
 
             UpdateActionButtons();
-            StatusMessageLabel.Text = "";
+            StatusMessageLabel.Text = patch.ActionRestrictionMessage;
         }
 
         void UpdateActionButtons()
@@ -120,7 +120,7 @@ namespace FEBuilderGBA.Avalonia.Views
             // Disable normal Install if deps are unmet, but allow ForceInstall
             InstallButton.IsEnabled = canInstall && !hasUnmetDeps;
             ForceInstallButton.IsEnabled = canInstall && hasUnmetDeps;
-            ForceInstallButton.IsVisible = hasUnmetDeps;
+            ForceInstallButton.IsVisible = canInstall && hasUnmetDeps;
             UninstallButton.IsEnabled = _vm.CanUninstall;
         }
 

--- a/FEBuilderGBA.Core.Tests/PatchMetadataCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/PatchMetadataCoreTests.cs
@@ -847,6 +847,42 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void ApplyPatch_MissingType_TreatsLegacyPatchAsBin()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), "PatchLegacyBinTest_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                File.WriteAllBytes(
+                    Path.Combine(tempDir, "test.bin"),
+                    new byte[] { 0xAA, 0xBB, 0xCC, 0xDD });
+
+                string patchFile = Path.Combine(tempDir, "PATCH_Test.txt");
+                File.WriteAllLines(patchFile, new[]
+                {
+                    "BIN:0x200=test.bin",
+                    "PATCHED_IF:0x200=0xAA 0xBB 0xCC 0xDD",
+                });
+
+                var rom = new ROM();
+                rom.SwapNewROMDataDirect(new byte[0x1000]);
+
+                var result = PatchMetadataCore.ApplyPatch(rom, patchFile);
+
+                Assert.True(result.Success);
+                Assert.Equal(4, result.BytesWritten);
+                Assert.Equal(0xAAu, rom.u8(0x200));
+                Assert.Equal(0xBBu, rom.u8(0x201));
+                Assert.Equal(0xCCu, rom.u8(0x202));
+                Assert.Equal(0xDDu, rom.u8(0x203));
+            }
+            finally
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+
+        [Fact]
         public void ApplyPatch_WithUndo_TracksChanges()
         {
             string tempDir = Path.Combine(Path.GetTempPath(), "PatchUndoTest_" + Guid.NewGuid().ToString("N"));

--- a/FEBuilderGBA.Core.Tests/PatchMetadataCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/PatchMetadataCoreTests.cs
@@ -920,6 +920,40 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void ApplyPatch_DuplicateMixedCaseType_UsesLastDeclaration()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), "PatchDuplicateTypeTest_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                File.WriteAllBytes(
+                    Path.Combine(tempDir, "test.bin"),
+                    new byte[] { 0xAA, 0xBB, 0xCC, 0xDD });
+
+                string patchFile = Path.Combine(tempDir, "PATCH_Test.txt");
+                File.WriteAllLines(patchFile, new[]
+                {
+                    "TYPE=",
+                    "type=CUSTOM",
+                    "BIN:0x200=test.bin",
+                });
+
+                var rom = new ROM();
+                rom.SwapNewROMDataDirect(new byte[0x1000]);
+
+                var result = PatchMetadataCore.ApplyPatch(rom, patchFile);
+
+                Assert.False(result.Success);
+                Assert.Contains("Unsupported patch type", result.Message);
+                Assert.Equal(0u, rom.u8(0x200));
+            }
+            finally
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+
+        [Fact]
         public void ApplyPatch_WithUndo_TracksChanges()
         {
             string tempDir = Path.Combine(Path.GetTempPath(), "PatchUndoTest_" + Guid.NewGuid().ToString("N"));

--- a/FEBuilderGBA.Core.Tests/PatchMetadataCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/PatchMetadataCoreTests.cs
@@ -954,6 +954,40 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void ApplyPatch_ScopedTypeLikeKey_DoesNotOverrideExactType()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), "PatchScopedTypeTest_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                File.WriteAllBytes(
+                    Path.Combine(tempDir, "test.bin"),
+                    new byte[] { 0xAA, 0xBB, 0xCC, 0xDD });
+
+                string patchFile = Path.Combine(tempDir, "PATCH_Test.txt");
+                File.WriteAllLines(patchFile, new[]
+                {
+                    "TYPE=BIN",
+                    "TYPE:NOTE=CUSTOM",
+                    "BIN:0x200=test.bin",
+                });
+
+                var rom = new ROM();
+                rom.SwapNewROMDataDirect(new byte[0x1000]);
+
+                var result = PatchMetadataCore.ApplyPatch(rom, patchFile);
+
+                Assert.True(result.Success);
+                Assert.Equal(4, result.BytesWritten);
+                Assert.Equal(0xAAu, rom.u8(0x200));
+            }
+            finally
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+
+        [Fact]
         public void ApplyPatch_WithUndo_TracksChanges()
         {
             string tempDir = Path.Combine(Path.GetTempPath(), "PatchUndoTest_" + Guid.NewGuid().ToString("N"));

--- a/FEBuilderGBA.Core.Tests/PatchMetadataCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/PatchMetadataCoreTests.cs
@@ -882,6 +882,43 @@ namespace FEBuilderGBA.Core.Tests
             }
         }
 
+        [Theory]
+        [InlineData("type=EA", "EA-type")]
+        [InlineData("type=CUSTOM", "Unsupported patch type")]
+        public void ApplyPatch_LowercaseTypeKey_DoesNotBypassValidation(
+            string typeLine,
+            string expectedError)
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), "PatchLowerTypeTest_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                File.WriteAllBytes(
+                    Path.Combine(tempDir, "test.bin"),
+                    new byte[] { 0xAA, 0xBB, 0xCC, 0xDD });
+
+                string patchFile = Path.Combine(tempDir, "PATCH_Test.txt");
+                File.WriteAllLines(patchFile, new[]
+                {
+                    typeLine,
+                    "BIN:0x200=test.bin",
+                });
+
+                var rom = new ROM();
+                rom.SwapNewROMDataDirect(new byte[0x1000]);
+
+                var result = PatchMetadataCore.ApplyPatch(rom, patchFile);
+
+                Assert.False(result.Success);
+                Assert.Contains(expectedError, result.Message);
+                Assert.Equal(0u, rom.u8(0x200));
+            }
+            finally
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+
         [Fact]
         public void ApplyPatch_WithUndo_TracksChanges()
         {

--- a/FEBuilderGBA.Core.Tests/PatchMetadataCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/PatchMetadataCoreTests.cs
@@ -701,6 +701,40 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void ParsePatchFile_TypeWithWhitespace_MatchesActionParsing()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), "PatchTypeWhitespace_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                string patchFile = Path.Combine(tempDir, "PATCH_Test.txt");
+                File.WriteAllLines(patchFile, new[]
+                {
+                    "TYPE = CUSTOM",
+                    "BIN:0x20=test.bin",
+                });
+
+                var rom = new ROM();
+                rom.SwapNewROMDataDirect(new byte[0x100]);
+
+                var info = PatchMetadataCore.ParsePatchFile(patchFile, "TestDir", rom, "en");
+                var typeParam = Assert.Single(
+                    PatchMetadataCore.ParsePatchParams(patchFile),
+                    p => string.Equals(p.RawKey, "TYPE", StringComparison.OrdinalIgnoreCase));
+                var result = PatchMetadataCore.ApplyPatch(rom, patchFile);
+
+                Assert.Equal("CUSTOM", info.Type);
+                Assert.Equal("CUSTOM", typeParam.Value);
+                Assert.False(result.Success);
+                Assert.Contains("Unsupported patch type", result.Message);
+            }
+            finally
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+
+        [Fact]
         public void ParsePatchFile_JapaneseLanguage_UsesDefaultName()
         {
             string tempDir = Path.Combine(Path.GetTempPath(), "PatchMetadataCoreTests_" + Guid.NewGuid().ToString("N"));

--- a/FEBuilderGBA.Core.Tests/PatchUninstallCleanRomCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/PatchUninstallCleanRomCoreTests.cs
@@ -176,6 +176,28 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void CollectPatchRegions_DuplicateMixedCaseType_UsesLastDeclaration()
+        {
+            byte[] clean = Clean();
+            var rom = MakeRom(clean);
+            string binName = "DuplicateType_250.bin";
+            File.WriteAllBytes(Path.Combine(_tempDir, binName), new byte[0x10]);
+            string outFile = Path.Combine(_tempDir, "PATCH_DuplicateType.txt");
+            File.WriteAllLines(outFile, new[]
+            {
+                "NAME=DuplicateType",
+                "TYPE=",
+                "type=CUSTOM",
+                "BIN:0x250=" + binName,
+            });
+
+            var regions = PatchMetadataCore.CollectPatchRegions(rom, outFile, out int untraceable);
+
+            Assert.Empty(regions);
+            Assert.True(untraceable > 0);
+        }
+
+        [Fact]
         public void Uninstall_TwoSeparateRuns_RestoresBothRuns_BatchedWrites()
         {
             // Two disjoint differing runs inside one over-length region. The batched

--- a/FEBuilderGBA.Core.Tests/PatchUninstallCleanRomCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/PatchUninstallCleanRomCoreTests.cs
@@ -176,6 +176,27 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void CollectPatchRegions_NoncanonicalLowercaseBinValue_IsUntraceable()
+        {
+            byte[] clean = Clean();
+            var rom = MakeRom(clean);
+            string binName = "LowercaseBin_250.bin";
+            File.WriteAllBytes(Path.Combine(_tempDir, binName), new byte[0x10]);
+            string outFile = Path.Combine(_tempDir, "PATCH_LowercaseBin.txt");
+            File.WriteAllLines(outFile, new[]
+            {
+                "NAME=LowercaseBin",
+                "TYPE=bin",
+                "BIN:0x250=" + binName,
+            });
+
+            var regions = PatchMetadataCore.CollectPatchRegions(rom, outFile, out int untraceable);
+
+            Assert.Empty(regions);
+            Assert.True(untraceable > 0);
+        }
+
+        [Fact]
         public void CollectPatchRegions_DuplicateMixedCaseType_UsesLastDeclaration()
         {
             byte[] clean = Clean();

--- a/FEBuilderGBA.Core.Tests/PatchUninstallCleanRomCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/PatchUninstallCleanRomCoreTests.cs
@@ -155,6 +155,27 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void CollectPatchRegions_LowercaseCustomTypeKey_IsUntraceable()
+        {
+            byte[] clean = Clean();
+            var rom = MakeRom(clean);
+            string binName = "Custom_250.bin";
+            File.WriteAllBytes(Path.Combine(_tempDir, binName), new byte[0x10]);
+            string outFile = Path.Combine(_tempDir, "PATCH_Custom.txt");
+            File.WriteAllLines(outFile, new[]
+            {
+                "NAME=Custom",
+                "type=CUSTOM",
+                "BIN:0x250=" + binName,
+            });
+
+            var regions = PatchMetadataCore.CollectPatchRegions(rom, outFile, out int untraceable);
+
+            Assert.Empty(regions);
+            Assert.True(untraceable > 0);
+        }
+
+        [Fact]
         public void Uninstall_TwoSeparateRuns_RestoresBothRuns_BatchedWrites()
         {
             // Two disjoint differing runs inside one over-length region. The batched

--- a/FEBuilderGBA.Core.Tests/PatchUninstallCleanRomCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/PatchUninstallCleanRomCoreTests.cs
@@ -219,6 +219,29 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void CollectPatchRegions_ScopedTypeLikeKey_DoesNotOverrideExactType()
+        {
+            byte[] clean = Clean();
+            var rom = MakeRom(WithPatchAt(clean, 0x250, new byte[0x10]));
+            string binName = "ScopedType_250.bin";
+            File.WriteAllBytes(Path.Combine(_tempDir, binName), new byte[0x10]);
+            string outFile = Path.Combine(_tempDir, "PATCH_ScopedType.txt");
+            File.WriteAllLines(outFile, new[]
+            {
+                "NAME=ScopedType",
+                "TYPE=BIN",
+                "TYPE:NOTE=CUSTOM",
+                "BIN:0x250=" + binName,
+            });
+
+            var regions = PatchMetadataCore.CollectPatchRegions(rom, outFile, out int untraceable);
+
+            Assert.Single(regions);
+            Assert.Equal(0x250u, regions[0].address);
+            Assert.Equal(0, untraceable);
+        }
+
+        [Fact]
         public void Uninstall_TwoSeparateRuns_RestoresBothRuns_BatchedWrites()
         {
             // Two disjoint differing runs inside one over-length region. The batched

--- a/FEBuilderGBA.Core/PatchMetadataCore.cs
+++ b/FEBuilderGBA.Core/PatchMetadataCore.cs
@@ -1388,7 +1388,7 @@ namespace FEBuilderGBA
         }
 
         static string GetPatchType(IEnumerable<PatchParam> patchParams)
-            => patchParams.FirstOrDefault(p =>
+            => patchParams.LastOrDefault(p =>
                 string.Equals(p.Keyword, "TYPE", StringComparison.OrdinalIgnoreCase))?.Value ?? "";
 
         /// <summary>

--- a/FEBuilderGBA.Core/PatchMetadataCore.cs
+++ b/FEBuilderGBA.Core/PatchMetadataCore.cs
@@ -1387,6 +1387,10 @@ namespace FEBuilderGBA
             return result;
         }
 
+        static string GetPatchType(IEnumerable<PatchParam> patchParams)
+            => patchParams.FirstOrDefault(p =>
+                string.Equals(p.Keyword, "TYPE", StringComparison.OrdinalIgnoreCase))?.Value ?? "";
+
         /// <summary>
         /// Exporter-only bounded seam (#1936 review remediation, byte-bounded per #1965).
         /// Identical key=value parsing semantics to <see cref="ParsePatchParams"/> but the file
@@ -1534,7 +1538,7 @@ namespace FEBuilderGBA
             var allParams = ParsePatchParams(patchFilePath);
 
             // Check TYPE
-            string type = allParams.FirstOrDefault(p => p.Keyword == "TYPE")?.Value ?? "";
+            string type = GetPatchType(allParams);
             if (type == "EA")
                 return PatchApplyResult.Fail("EA-type patches require an external assembler and are not yet supported in the Avalonia port.");
 
@@ -1815,7 +1819,7 @@ namespace FEBuilderGBA
             if (rom == null || !File.Exists(patchFilePath)) return regions;
 
             var allParams = ParsePatchParams(patchFilePath);
-            string type = allParams.FirstOrDefault(p => p.Keyword == "TYPE")?.Value ?? "";
+            string type = GetPatchType(allParams);
             // BIN patches have a portable fixed-address region map. An EMPTY/missing TYPE is
             // treated as BIN — matching the Avalonia Patch Manager's CanInstall/CanUninstall
             // convention (string.IsNullOrEmpty(Type)) so legacy BIN patches that omit TYPE= are

--- a/FEBuilderGBA.Core/PatchMetadataCore.cs
+++ b/FEBuilderGBA.Core/PatchMetadataCore.cs
@@ -678,8 +678,9 @@ namespace FEBuilderGBA
                 if (line.StartsWith("TAG=", StringComparison.OrdinalIgnoreCase))
                     info.Tags = line.Substring(4).Trim();
 
-                if (line.StartsWith("TYPE=", StringComparison.OrdinalIgnoreCase))
-                    info.Type = line.Substring(5).Trim();
+                if (TryParsePatchParamLine(rawLine, out PatchParam metadataParam) &&
+                    string.Equals(metadataParam.RawKey, "TYPE", StringComparison.OrdinalIgnoreCase))
+                    info.Type = metadataParam.Value;
 
                 if (line.StartsWith("PATCHED_IF:", StringComparison.OrdinalIgnoreCase))
                     patchedIf = line.Substring(11);
@@ -1368,23 +1369,29 @@ namespace FEBuilderGBA
             string[] lines = File.ReadAllLines(patchFilePath);
             foreach (string rawLine in lines)
             {
-                string line = rawLine.Trim();
-                if (line.StartsWith("//")) continue;
-
-                int sep = line.IndexOf('=');
-                if (sep < 0) continue;
-
-                string key = line.Substring(0, sep).Trim();
-                string value = line.Substring(sep + 1).Trim();
-
-                result.Add(new PatchParam
-                {
-                    RawKey = key,
-                    Value = value,
-                    KeyParts = key.Split(':'),
-                });
+                if (TryParsePatchParamLine(rawLine, out PatchParam param))
+                    result.Add(param);
             }
             return result;
+        }
+
+        static bool TryParsePatchParamLine(string rawLine, out PatchParam param)
+        {
+            param = null!;
+            string line = rawLine.Trim();
+            if (line.StartsWith("//")) return false;
+
+            int sep = line.IndexOf('=');
+            if (sep < 0) return false;
+
+            string key = line.Substring(0, sep).Trim();
+            param = new PatchParam
+            {
+                RawKey = key,
+                Value = line.Substring(sep + 1).Trim(),
+                KeyParts = key.Split(':'),
+            };
+            return true;
         }
 
         static string GetPatchType(IEnumerable<PatchParam> patchParams)
@@ -1494,11 +1501,7 @@ namespace FEBuilderGBA
             var parsed = new List<PatchParam>();
             foreach (string rawLine in lines)
             {
-                string line = rawLine.Trim();
-                if (line.StartsWith("//")) continue;
-
-                int sep = line.IndexOf('=');
-                if (sep < 0) continue;
+                if (!TryParsePatchParamLine(rawLine, out PatchParam param)) continue;
 
                 if (parsed.Count >= maxEntries)
                 {
@@ -1507,15 +1510,7 @@ namespace FEBuilderGBA
                                   // the locally-built `parsed` list is simply discarded.
                 }
 
-                string key = line.Substring(0, sep).Trim();
-                string value = line.Substring(sep + 1).Trim();
-
-                parsed.Add(new PatchParam
-                {
-                    RawKey = key,
-                    Value = value,
-                    KeyParts = key.Split(':'),
-                });
+                parsed.Add(param);
             }
             result = parsed;
             return true;

--- a/FEBuilderGBA.Core/PatchMetadataCore.cs
+++ b/FEBuilderGBA.Core/PatchMetadataCore.cs
@@ -1538,7 +1538,7 @@ namespace FEBuilderGBA
             if (type == "EA")
                 return PatchApplyResult.Fail("EA-type patches require an external assembler and are not yet supported in the Avalonia port.");
 
-            if (type != "BIN")
+            if (!string.IsNullOrEmpty(type) && type != "BIN")
                 return PatchApplyResult.Fail($"Unsupported patch type: '{type}'. Only BIN patches are currently supported.");
 
             // Collect BIN/JUMP entries in order

--- a/FEBuilderGBA.Core/PatchMetadataCore.cs
+++ b/FEBuilderGBA.Core/PatchMetadataCore.cs
@@ -1389,7 +1389,7 @@ namespace FEBuilderGBA
 
         static string GetPatchType(IEnumerable<PatchParam> patchParams)
             => patchParams.LastOrDefault(p =>
-                string.Equals(p.Keyword, "TYPE", StringComparison.OrdinalIgnoreCase))?.Value ?? "";
+                string.Equals(p.RawKey, "TYPE", StringComparison.OrdinalIgnoreCase))?.Value ?? "";
 
         /// <summary>
         /// Exporter-only bounded seam (#1936 review remediation, byte-bounded per #1965).

--- a/FEBuilderGBA.Core/PatchMetadataCore.cs
+++ b/FEBuilderGBA.Core/PatchMetadataCore.cs
@@ -1824,7 +1824,7 @@ namespace FEBuilderGBA
             // treated as BIN — matching the Avalonia Patch Manager's CanInstall/CanUninstall
             // convention (string.IsNullOrEmpty(Type)) so legacy BIN patches that omit TYPE= are
             // still uninstallable. EA tracing is WF-only.
-            bool isBin = string.IsNullOrEmpty(type) || type.Equals("BIN", StringComparison.OrdinalIgnoreCase);
+            bool isBin = string.IsNullOrEmpty(type) || type == "BIN";
             if (!isBin)
             {
                 // Count every action-bearing line as untraceable so EA is reported as not supported.

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -14743,7 +14743,7 @@ Song Table のデータ拡張を表示
 Song Table にデータ拡張を表示します。Song Table を再配置すると Sappy が認識できなくなる場合があり、通常の ROM には多くの空きエントリがあります。
 
 :EA patches require Event Assembler and are not currently supported by the Avalonia Patch Manager.
-EAパッチをインストールするにはEvent Assemblerが必要ですが、Avalonia版パッチマネージャでは現在サポートされていません。
+EAパッチにはEvent Assemblerが必要で、Avalonia版パッチマネージャでは現在サポートされていません。
 
 :Patch type '{0}' is not currently supported by the Avalonia Patch Manager.
 パッチタイプ「{0}」はAvalonia版パッチマネージャでは現在サポートされていません。

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -14747,3 +14747,15 @@ EAパッチをインストールするにはEvent Assemblerが必要ですが、
 
 :Patch type '{0}' is not currently supported by the Avalonia Patch Manager.
 パッチタイプ「{0}」はAvalonia版パッチマネージャでは現在サポートされていません。
+
+:Installed
+インストール済み
+
+:Available
+利用可能
+
+:Unsupported
+未対応
+
+:Unknown
+不明

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -14741,3 +14741,9 @@ Song Table のデータ拡張を表示
 
 :Shows Data Expansion in Song Table. Repointing the Song Table may stop Sappy from finding it, and vanilla ROMs usually have spare entries.
 Song Table にデータ拡張を表示します。Song Table を再配置すると Sappy が認識できなくなる場合があり、通常の ROM には多くの空きエントリがあります。
+
+:EA patches require Event Assembler and are not currently supported by the Avalonia Patch Manager.
+EAパッチをインストールするにはEvent Assemblerが必要ですが、Avalonia版パッチマネージャでは現在サポートされていません。
+
+:Patch type '{0}' is not currently supported by the Avalonia Patch Manager.
+パッチタイプ「{0}」はAvalonia版パッチマネージャでは現在サポートされていません。

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -28577,3 +28577,15 @@ EA 补丁需要 Event Assembler，Avalonia 补丁管理器目前不支持安装�
 
 :Patch type '{0}' is not currently supported by the Avalonia Patch Manager.
 Avalonia 补丁管理器目前不支持补丁类型“{0}”。
+
+:Installed
+已安装
+
+:Available
+可用
+
+:Unsupported
+不支持
+
+:Unknown
+未知

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -28571,3 +28571,9 @@ FE6的三角攻击台词使用直接写死的6行16字节表，内容只有 [单
 
 :Shows Data Expansion in Song Table. Repointing the Song Table may stop Sappy from finding it, and vanilla ROMs usually have spare entries.
 在歌曲表中显示数据扩展。重新定位歌曲表可能导致 Sappy 无法识别，而且原版 ROM 通常已有许多空闲条目。
+
+:EA patches require Event Assembler and are not currently supported by the Avalonia Patch Manager.
+EA 补丁需要 Event Assembler，Avalonia 补丁管理器目前不支持安装。
+
+:Patch type '{0}' is not currently supported by the Avalonia Patch Manager.
+Avalonia 补丁管理器目前不支持补丁类型“{0}”。

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -28573,7 +28573,7 @@ FE6的三角攻击台词使用直接写死的6行16字节表，内容只有 [单
 在歌曲表中显示数据扩展。重新定位歌曲表可能导致 Sappy 无法识别，而且原版 ROM 通常已有许多空闲条目。
 
 :EA patches require Event Assembler and are not currently supported by the Avalonia Patch Manager.
-EA 补丁需要 Event Assembler，Avalonia 补丁管理器目前不支持安装。
+EA 补丁需要 Event Assembler，Avalonia 补丁管理器目前不支持此类补丁。
 
 :Patch type '{0}' is not currently supported by the Avalonia Patch Manager.
 Avalonia 补丁管理器目前不支持补丁类型“{0}”。


### PR DESCRIPTION
## Summary

- label not-installed EA and unknown patch types as `Unsupported` instead of `Available`
- explain why Patch Manager actions are disabled, announce the dynamic reason accessibly, and prevent force-install visibility for unsupported entries
- align UI, apply, and trace eligibility with canonical/legacy BIN rules, including shared whitespace normalization, exact case-insensitive keys, and last-definition semantics for duplicate `TYPE` entries

Accepted plan: https://github.com/laqieer/FEBuilderGBA/issues/2132#issuecomment-5460328923

Closes #2132

## Test plan

- [x] `dotnet test FEBuilderGBA.Avalonia.Tests\FEBuilderGBA.Avalonia.Tests.csproj -c Release --filter FullyQualifiedName~PatchManagerAvailabilityTests --no-restore` (11 passed)
- [x] focused behavior + code-literal localization tests (13 passed)
- [x] focused Core exact-key/type-consistency tests (latest selector: 4 passed)
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests\FEBuilderGBA.Avalonia.Tests.csproj -c Release --no-restore` (9,889 passed; 11 skipped)
- [x] `dotnet test FEBuilderGBA.Core.Tests\FEBuilderGBA.Core.Tests.csproj -c Release --no-restore` (7,601 passed; 19 skipped)
- [x] `dotnet build FEBuilderGBA.Avalonia\FEBuilderGBA.Avalonia.csproj -c Release --no-restore` (0 warnings, 0 errors)

## GUI Test Report

The reported macOS state is reproduced in the issue screenshot: the selected EA patch is labelled `Available` while Install and Uninstall are disabled with no explanation. The new headless selection test verifies `Unsupported`, an Event Assembler explanation, and all unsupported actions disabled; the dynamic explanation is also a polite accessibility live region.

**macOS validation:** satisfied. The after screenshot shows the selected EA patch as `Unsupported`, the Event Assembler explanation visible, Install/Uninstall disabled, and Install Anyway hidden. Later Core/parser and test-cleanup commits do not change this UI.

![Before: EA patch shown Available with disabled actions](https://github.com/user-attachments/assets/c6701cf3-3c51-486c-97c3-1cf0857234c3)

![After: EA patch shown Unsupported with explanation](https://github.com/user-attachments/assets/74418eae-d9cd-4358-8ce1-f75fedf2fcf1)

Copilot CLI: 1.0.80
Model: GPT-5.6 Sol (gpt-5.6-sol)