### PR TITLE
fix(avalonia): remove false Unit Palette list entry

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteExpandTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteExpandTests.cs
@@ -3,7 +3,7 @@
 //
 // The Unit Palette editor's "Expand List" button grows the unit-palette
 // pointer table with PREDICATE-AWARE semantics:
-//   - real (sentinel-excluded) row count
+//   - exact real-row count
 //   - FIRST-fill new rows from a non-empty template row + clear each P12 so
 //     the new rows are scan-visible (P12==0 && name!=0)
 //   - a FULL all-zero 16-byte terminator row (NOT a 0xFFFFFFFF dword), so the
@@ -107,7 +107,7 @@ namespace FEBuilderGBA.Avalonia.Tests
             CoreState.ROM = rom;
             var vm = new ImageUnitPaletteViewModel();
 
-            int realCount = vm.LoadList(rom).Count - 1;
+            int realCount = vm.LoadList(rom).Count;
             Assert.Equal(3, realCount);
 
             uint newCount = (uint)(realCount + 3); // 6, well below the 512 scan bound
@@ -131,9 +131,9 @@ namespace FEBuilderGBA.Avalonia.Tests
             uint newBase = rom.p32(POINTER_SLOT);
             Assert.NotEqual(oldBase, newBase);
 
-            // LoadList now sees exactly newCount real rows (+1 sentinel).
+            // LoadList now sees exactly newCount real rows.
             var list = vm.LoadList(rom);
-            Assert.Equal((int)newCount + 1, list.Count);
+            Assert.Equal((int)newCount, list.Count);
 
             // Old rows are preserved at the new base (names intact, P12 intact==0).
             string[] oldNames = { "PLY0", "ENMY", "OTHR" };
@@ -184,7 +184,7 @@ namespace FEBuilderGBA.Avalonia.Tests
             var rom = MakeRom(out uint oldBase);
             CoreState.ROM = rom;
             var vm = new ImageUnitPaletteViewModel();
-            int realCount = vm.LoadList(rom).Count - 1;
+            int realCount = vm.LoadList(rom).Count;
             uint newCount = (uint)(realCount + 2);
 
             var ud = new Undo.UndoData
@@ -228,7 +228,7 @@ namespace FEBuilderGBA.Avalonia.Tests
             CoreState.Undo = new Undo();
 
             var vm = new ImageUnitPaletteViewModel();
-            int realCount = vm.LoadList(rom).Count - 1;
+            int realCount = vm.LoadList(rom).Count;
             Assert.Equal(3, realCount);
             uint newCount = (uint)(realCount + 4);
 
@@ -288,7 +288,7 @@ namespace FEBuilderGBA.Avalonia.Tests
             Array.Copy(rom.Data, snapshot, rom.Data.Length);
 
             var vm = new ImageUnitPaletteViewModel();
-            int realCount = vm.LoadList(rom).Count - 1;
+            int realCount = vm.LoadList(rom).Count;
             Assert.True(realCount >= 1);
 
             var ud = new Undo.UndoData
@@ -316,7 +316,7 @@ namespace FEBuilderGBA.Avalonia.Tests
             var rom = MakeRom(out uint oldBase);
             CoreState.ROM = rom;
             var vm = new ImageUnitPaletteViewModel();
-            int realCount = vm.LoadList(rom).Count - 1;
+            int realCount = vm.LoadList(rom).Count;
 
             var ud = new Undo.UndoData
             {
@@ -341,7 +341,7 @@ namespace FEBuilderGBA.Avalonia.Tests
             var rom = MakeRom(out _);
             CoreState.ROM = rom;
             var vm = new ImageUnitPaletteViewModel();
-            int realCount = vm.LoadList(rom).Count - 1;
+            int realCount = vm.LoadList(rom).Count;
             Assert.True(realCount >= 2);
 
             var ud = new Undo.UndoData

--- a/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteParityTests.cs
@@ -496,7 +496,7 @@ namespace FEBuilderGBA.Avalonia.Tests
                 CoreState.CommentCache = comments;
 
                 var vm = new ImageUnitPaletteViewModel();
-                var actual = vm.LoadList(rom);
+                var actual = vm.LoadList();
                 var reference = ListParityHelper.BuildReferenceList("ImageUnitPaletteView");
 
                 var actualEntry = Assert.Single(actual);
@@ -506,6 +506,46 @@ namespace FEBuilderGBA.Avalonia.Tests
                 Assert.Equal(actualEntry.name, referenceEntry.name);
                 Assert.DoesNotContain(actual, entry =>
                     entry.addr == 0 || entry.name == "Unit Palette Editor");
+            }
+            finally
+            {
+                CoreState.ROM = savedRom!;
+                CoreState.CommentCache = savedCommentCache!;
+            }
+        }
+
+        [Fact]
+        public void LoadList_ExplicitRom_DoesNotUseActiveRomComments()
+        {
+            byte[] activeData = new byte[0x10000];
+            byte[] suppliedData = new byte[0x10000];
+            uint baseAddr = 0x200;
+            U.write_u32(activeData, 0x100, U.toPointer(baseAddr));
+            U.write_u32(suppliedData, 0x100, U.toPointer(baseAddr));
+            activeData[baseAddr] = (byte)'a';
+            suppliedData[baseAddr] = (byte)'s';
+
+            var activeRom = new ROM();
+            activeRom.SwapNewROMDataDirect(activeData);
+            SetRomInfo(activeRom, new StubRomInfo(0x100));
+            var suppliedRom = new ROM();
+            suppliedRom.SwapNewROMDataDirect(suppliedData);
+            SetRomInfo(suppliedRom, new StubRomInfo(0x100));
+
+            ROM? savedRom = CoreState.ROM;
+            IEtcCache? savedCommentCache = CoreState.CommentCache;
+            try
+            {
+                var comments = new HeadlessEtcCache();
+                comments.Update(baseAddr, "Active ROM only");
+                CoreState.ROM = activeRom;
+                CoreState.CommentCache = comments;
+
+                var vm = new ImageUnitPaletteViewModel();
+                var entry = Assert.Single(vm.LoadList(suppliedRom));
+
+                Assert.Equal("0x01 s", entry.name);
+                Assert.DoesNotContain("Active ROM only", entry.name);
             }
             finally
             {

--- a/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteParityTests.cs
@@ -394,7 +394,7 @@ namespace FEBuilderGBA.Avalonia.Tests
         // ===== WU1: WF row-acceptance parity =====
 
         [Fact]
-        public void LoadList_Treats_ZeroPointer_With_NonEmptyName_As_Valid()
+        public void LoadList_Treats_ZeroPointer_With_NonEmptyName_As_OnlyRealRow()
         {
             // Build a synthetic ROM where the row at base + 0 has name="SOME" (u32 != 0)
             // and P12 (u32 at +12) = 0. WF's Init() validator accepts this row, but the
@@ -425,18 +425,30 @@ namespace FEBuilderGBA.Avalonia.Tests
             // Inject the RomInfo: set image_unit_palette_pointer = 0x100
             SetRomInfo(rom, new StubRomInfo(0x100));
 
-            // Pass the synthetic ROM directly to LoadList to avoid a race with
-            // other xUnit collections that may transiently mutate CoreState.ROM
-            // while this test runs in parallel on CI.
-            var vm = new ImageUnitPaletteViewModel();
-            var list = vm.LoadList(rom);
-            Assert.NotEmpty(list);
-            // First row must be the "SOME" row (P12=0 with name!=0).
-            Assert.Equal(baseAddr, list[0].addr);
+            ROM? savedRom = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = rom;
+                var vm = new ImageUnitPaletteViewModel();
+                var list = vm.LoadList(rom);
+                var reference = ListParityHelper.BuildReferenceList("ImageUnitPaletteView");
+
+                var entry = Assert.Single(list);
+                var referenceEntry = Assert.Single(reference);
+                Assert.Equal(baseAddr, entry.addr);
+                Assert.Equal(0u, entry.tag);
+                Assert.Equal("0x01 SOME", entry.name);
+                Assert.Equal(entry.addr, referenceEntry.addr);
+                Assert.Equal(entry.name, referenceEntry.name);
+            }
+            finally
+            {
+                CoreState.ROM = savedRom!;
+            }
         }
 
         [Fact]
-        public void LoadList_TreatsRow_With_Both_Zero_As_Terminator()
+        public void LoadList_TreatsRow_With_Both_Zero_As_EmptyTerminator()
         {
             byte[] data = new byte[0x10000];
             uint baseAddr = 0x200;
@@ -456,11 +468,49 @@ namespace FEBuilderGBA.Avalonia.Tests
             // while this test runs in parallel on CI.
             var vm = new ImageUnitPaletteViewModel();
             var list = vm.LoadList(rom);
-            // The VM appends a trailing "Unit Palette Editor" sentinel row at the
-            // end. The first row should NOT include the baseAddr terminator row.
-            foreach (var entry in list)
+            Assert.Empty(list);
+        }
+
+        [Fact]
+        public void LoadList_AndReferenceList_AppendCommentsWithoutSyntheticEditorRow()
+        {
+            byte[] data = new byte[0x10000];
+            uint baseAddr = 0x200;
+            U.write_u32(data, 0x100, U.toPointer(baseAddr));
+            data[baseAddr + 0] = (byte)'e';
+            data[baseAddr + 1] = (byte)'i';
+            data[baseAddr + 2] = (byte)'r';
+            U.write_u32(data, baseAddr + 12, U.toPointer(0x400));
+
+            var rom = new ROM();
+            rom.SwapNewROMDataDirect(data);
+            SetRomInfo(rom, new StubRomInfo(0x100));
+
+            ROM? savedRom = CoreState.ROM;
+            IEtcCache? savedCommentCache = CoreState.CommentCache;
+            try
             {
-                Assert.NotEqual(baseAddr, entry.addr);
+                var comments = new HeadlessEtcCache();
+                comments.Update(baseAddr, "Eirika");
+                CoreState.ROM = rom;
+                CoreState.CommentCache = comments;
+
+                var vm = new ImageUnitPaletteViewModel();
+                var actual = vm.LoadList(rom);
+                var reference = ListParityHelper.BuildReferenceList("ImageUnitPaletteView");
+
+                var actualEntry = Assert.Single(actual);
+                var referenceEntry = Assert.Single(reference);
+                Assert.Equal("0x01 eir Eirika", actualEntry.name);
+                Assert.Equal(actualEntry.addr, referenceEntry.addr);
+                Assert.Equal(actualEntry.name, referenceEntry.name);
+                Assert.DoesNotContain(actual, entry =>
+                    entry.addr == 0 || entry.name == "Unit Palette Editor");
+            }
+            finally
+            {
+                CoreState.ROM = savedRom!;
+                CoreState.CommentCache = savedCommentCache!;
             }
         }
 

--- a/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
+++ b/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
@@ -2913,7 +2913,10 @@ namespace FEBuilderGBA.Avalonia.Services
                     else if (b == 0) break;
                 }
 
-                string name = ImageUnitPaletteViewModel.BuildListLabel(i, ident, addr);
+                string name = ImageUnitPaletteViewModel.BuildListLabel(
+                    i,
+                    ident,
+                    CoreState.CommentCache?.At(addr));
                 result.Add(new AddrResult(addr, name, (uint)i));
             }
             return result;

--- a/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
+++ b/FEBuilderGBA.Avalonia/Services/ListParityHelper.cs
@@ -2901,7 +2901,8 @@ namespace FEBuilderGBA.Avalonia.Services
                 uint addr = baseAddr + (uint)(i * blockSize);
                 if (addr + blockSize > (uint)rom.Data.Length) break;
                 uint p = rom.u32(addr + 12);
-                if (!U.isPointer(p)) break;
+                uint nameFirst = rom.u32(addr);
+                if (!U.isPointer(p) && (p != 0 || nameFirst == 0)) break;
 
                 // Read identifier string from bytes 0-11
                 string ident = "";
@@ -2912,11 +2913,9 @@ namespace FEBuilderGBA.Avalonia.Services
                     else if (b == 0) break;
                 }
 
-                string name = $"0x{i:X2} {ident}";
+                string name = ImageUnitPaletteViewModel.BuildListLabel(i, ident, addr);
                 result.Add(new AddrResult(addr, name, (uint)i));
             }
-            // Match ImageUnitPaletteViewModel: appends a trailing "Unit Palette Editor" entry
-            result.Add(new AddrResult(0, "Unit Palette Editor", 0));
             return result;
         }
 

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageUnitPaletteViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageUnitPaletteViewModel.cs
@@ -131,10 +131,21 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                     if (b >= 0x20 && b < 0x7F) ident += (char)b;
                     else if (b == 0) break;
                 }
-                result.Add(new AddrResult(addr, $"0x{i:X2} {ident}", (uint)i));
+                result.Add(new AddrResult(addr, BuildListLabel(i, ident, addr), (uint)i));
             }
-            result.Add(new AddrResult(0, "Unit Palette Editor", 0));
             return result;
+        }
+
+        internal static string BuildListLabel(int index, string ident, uint addr)
+        {
+            string label = $"0x{index + 1:X2}";
+            if (!string.IsNullOrWhiteSpace(ident))
+                label += " " + ident.TrimEnd();
+
+            string comment = CoreState.CommentCache?.At(addr) ?? "";
+            if (!string.IsNullOrWhiteSpace(comment))
+                label += " " + comment.Trim();
+            return label;
         }
 
         public void LoadEntry(uint addr)
@@ -329,9 +340,8 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// for the Unit Palette row scan (which differs from #501's pointer-first
         /// scan):
         /// <list type="bullet">
-        ///   <item><b>Real count, not the sentinel count.</b> <see cref="GetListCount"/>
-        ///         includes the trailing <c>AddrResult(0,"Unit Palette Editor",0)</c>
-        ///         sentinel, so the current row count is <c>GetListCount() - 1</c>.</item>
+        ///   <item><b>Exact real-row count.</b> <see cref="GetListCount"/> returns
+        ///         only rows scanned from the ROM table.</item>
         ///   <item><b>Full all-zero terminator row.</b> <see cref="LoadList()"/>
         ///         accepts a row when <c>P12</c> is a valid pointer OR
         ///         (<c>P12==0 &amp;&amp; name!=0</c>), and stops only on a full
@@ -370,18 +380,15 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             if (!U.isSafetyOffset(rom.p32(pointer), rom))
                 return R._("Unit palette table pointer is invalid.");
 
-            // Real row count excludes the trailing sentinel row that LoadList
-            // appends (AddrResult(0, "Unit Palette Editor", 0)).
-            int listCount = GetListCount();
-            int realCount = listCount - 1;
-            if (realCount < 1)
+            int currentCount = GetListCount();
+            if (currentCount < 1)
                 return R._("Cannot expand: the unit-palette list has no rows.");
             if (newCount > 512)
                 return R._("New count ({0}) exceeds the maximum of 512.", newCount);
-            if (newCount < (uint)realCount)
+            if (newCount < (uint)currentCount)
                 return R._("New count ({0}) must be greater than or equal to current count ({1}).",
-                    newCount, realCount);
-            if (newCount == (uint)realCount)
+                    newCount, currentCount);
+            if (newCount == (uint)currentCount)
                 return ""; // no-op success
 
             // Template-row selection (guardrail #1): the FIRST row whose first
@@ -389,7 +396,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             // mutating anything.
             uint oldBase = rom.p32(pointer);
             int templateIdx = -1;
-            for (int i = 0; i < realCount; i++)
+            for (int i = 0; i < currentCount; i++)
             {
                 if (rom.u32(oldBase + (uint)(i * (int)SIZE) + 0) != 0)
                 {
@@ -402,7 +409,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
 
             // Grow the table with a FULL all-zero 16-byte terminator row.
             var result = DataExpansionCore.ExpandTableTo(
-                rom, pointer, SIZE, (uint)realCount, newCount, fullZeroTerminatorRow: true);
+                rom, pointer, SIZE, (uint)currentCount, newCount, fullZeroTerminatorRow: true);
             if (!result.Success)
                 return result.Error ?? R._("Table expansion failed.");
 
@@ -418,7 +425,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             // (P12==0 && name!=0). All writes ambient (caller owns the undo scope).
             byte[] templateIdent = rom.getBinaryData(
                 result.NewBaseAddress + (uint)(templateIdx * (int)SIZE), 12);
-            for (int i = realCount; i < (int)newCount; i++)
+            for (int i = currentCount; i < (int)newCount; i++)
             {
                 uint rowAddr = result.NewBaseAddress + (uint)(i * (int)SIZE);
                 rom.write_range(rowAddr, templateIdent);

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageUnitPaletteViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageUnitPaletteViewModel.cs
@@ -84,7 +84,8 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// 12-byte name is non-empty (i.e. <c>rom.u32(addr+0) != 0</c>). Both
         /// P12 and name being zero is the terminator.
         /// </summary>
-        public List<AddrResult> LoadList() => LoadList(CoreState.ROM);
+        public List<AddrResult> LoadList() =>
+            LoadList(CoreState.ROM, addr => CoreState.CommentCache?.At(addr));
 
         /// <summary>
         /// Test-friendly overload that scans <paramref name="rom"/> directly
@@ -93,7 +94,9 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// parallel and another test may transiently mutate
         /// <see cref="CoreState.ROM"/> between the test's set and read points.
         /// </summary>
-        public List<AddrResult> LoadList(ROM? rom)
+        public List<AddrResult> LoadList(ROM? rom) => LoadList(rom, null);
+
+        internal List<AddrResult> LoadList(ROM? rom, Func<uint, string?>? commentResolver)
         {
             if (rom?.RomInfo == null) return new List<AddrResult>();
 
@@ -131,18 +134,20 @@ namespace FEBuilderGBA.Avalonia.ViewModels
                     if (b >= 0x20 && b < 0x7F) ident += (char)b;
                     else if (b == 0) break;
                 }
-                result.Add(new AddrResult(addr, BuildListLabel(i, ident, addr), (uint)i));
+                result.Add(new AddrResult(
+                    addr,
+                    BuildListLabel(i, ident, commentResolver?.Invoke(addr)),
+                    (uint)i));
             }
             return result;
         }
 
-        internal static string BuildListLabel(int index, string ident, uint addr)
+        internal static string BuildListLabel(int index, string ident, string? comment)
         {
             string label = $"0x{index + 1:X2}";
             if (!string.IsNullOrWhiteSpace(ident))
                 label += " " + ident.TrimEnd();
 
-            string comment = CoreState.CommentCache?.At(addr) ?? "";
             if (!string.IsNullOrWhiteSpace(comment))
                 label += " " + comment.Trim();
             return label;

--- a/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml.cs
@@ -147,14 +147,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 var items = _vm.LoadList();
                 EntryList.SetItems(items);
                 ReadStartAddressBox.Text = _vm.LoadListBaseAddress();
-                // The VM appends a trailing "Unit Palette Editor" sentinel row
-                // (addr=0) at the end; exclude it from the displayed count so
-                // the count matches the actual table-row scan (Copilot bot #585
-                // off-by-one ask).
-                int realCount = items.Count;
-                if (realCount > 0 && items[realCount - 1].addr == 0)
-                    realCount--;
-                ReadCountBox.Text = realCount.ToString();
+                ReadCountBox.Text = items.Count.ToString();
             }
             catch (Exception ex)
             {
@@ -651,7 +644,7 @@ namespace FEBuilderGBA.Avalonia.Views
         /// an <see cref="UndoService"/> scope, and reloads the list. Mirrors
         /// <see cref="ImageMapActionAnimationView.ListExpand_Click"/> (prompt ->
         /// expand -> repoint -> reload). The VM's ExpandList is PREDICATE-AWARE:
-        /// it uses the real (sentinel-excluded) row count, FIRST-fills new rows
+        /// it uses the exact real-row count, FIRST-fills new rows
         /// from a non-empty template row + clears each new P12 so the rows are
         /// scan-visible, writes a FULL all-zero terminator row, and repoints all
         /// raw + LDR-literal references via
@@ -668,9 +661,7 @@ namespace FEBuilderGBA.Avalonia.Views
                     return;
                 }
 
-                // Real (sentinel-excluded) current row count.
-                int listCount = _vm.GetListCount();
-                int realCount = listCount - 1;
+                int realCount = _vm.GetListCount();
                 if (realCount < 1)
                 {
                     CoreState.Services?.ShowInfo(R._("Cannot expand: the unit-palette list has no rows."));


### PR DESCRIPTION
## Summary

- remove the synthetic address-zero `Unit Palette Editor` row that looked like a corrupted Eirika entry
- align visible palette IDs with WinForms one-based numbering and append address comments so named entries remain searchable
- simplify list display and expansion logic to use the exact number of real ROM rows

Accepted plan: https://github.com/laqieer/FEBuilderGBA/issues/2136#issuecomment-5462067331

Closes #2136

## Test plan

- [x] focused Unit Palette list/expansion/cache-isolation regressions (10 passed)
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests\FEBuilderGBA.Avalonia.Tests.csproj -c Release --no-restore` (9,891 passed; 11 skipped)
- [x] `dotnet build FEBuilderGBA.Avalonia\FEBuilderGBA.Avalonia.csproj -c Release --no-restore` (0 warnings, 0 errors)
- [x] FE8U E2E workflow run 33251338835 (passed)

## GUI Test Report

The real FE8U Avalonia screenshot shows only numbered ROM-backed rows, beginning at `0x01`; the synthetic `Unit Palette Editor` row is gone. The editor layout remains clean. Eirika is not in the currently visible top slice, but row labels now append the same address comments used by WinForms, so named entries are searchable by `Eirika` when the shipped comment table supplies that name.

![After: Unit Palette list contains only real one-based rows](https://github.com/user-attachments/assets/17167c0a-a76b-4768-8922-2be319c72106)

Copilot CLI: 1.0.80
Model: GPT-5.6 Sol (gpt-5.6-sol)