### PR TITLE
fix(android): apply AppCompat theme on startup

### DIFF
--- a/FEBuilderGBA.Android/MainActivity.cs
+++ b/FEBuilderGBA.Android/MainActivity.cs
@@ -45,9 +45,8 @@ namespace FEBuilderGBA.Android
     /// <c>config/patch2</c> is NOT bundled (deferred — see docs/ANDROID.md §5).
     /// </para>
     /// </summary>
-    // NOTE: no Theme/Icon resource is referenced — this skeleton ships no
-    // Android resource (drawable/style) files, so referencing @drawable/icon or
-    // a custom @style/ would fail aapt. A real port adds an app icon + theme.
+    // AvaloniaMainActivity uses AppCompatActivity internally, so Android must
+    // apply an AppCompat-derived theme before activity initialization.
     //
     // Exported = true is REQUIRED when targeting Android 12 / API 31+ for any
     // activity with an intent-filter. This project targets API 36, and the
@@ -56,6 +55,7 @@ namespace FEBuilderGBA.Android
     // because this is the user-facing launcher.
     [Activity(
         Label = "FEBuilderGBA",
+        Theme = "@style/FEBuilderTheme",
         MainLauncher = true,
         Exported = true,
         ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize | ConfigChanges.UiMode)]

--- a/FEBuilderGBA.Android/Resources/values/styles.xml
+++ b/FEBuilderGBA.Android/Resources/values/styles.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <style name="FEBuilderTheme" parent="Theme.AppCompat.DayNight.NoActionBar" />
+</resources>

--- a/FEBuilderGBA.Tests/Unit/AndroidThemeContractTests.cs
+++ b/FEBuilderGBA.Tests/Unit/AndroidThemeContractTests.cs
@@ -37,9 +37,10 @@ namespace FEBuilderGBA.Tests.Unit
             Assert.True(File.Exists(path), $"Android theme resource should exist at {path}");
 
             var document = XDocument.Load(path);
-            var style = Assert.Single(document.Root!.Elements("style"));
-            Assert.Equal("FEBuilderTheme", style.Attribute("name")?.Value);
-            Assert.Equal("Theme.AppCompat.DayNight.NoActionBar", style.Attribute("parent")?.Value);
+            var style = document.Root!.Elements("style")
+                .SingleOrDefault(element => element.Attribute("name")?.Value == "FEBuilderTheme");
+            Assert.NotNull(style);
+            Assert.Equal("Theme.AppCompat.DayNight.NoActionBar", style!.Attribute("parent")?.Value);
         }
     }
 }

--- a/FEBuilderGBA.Tests/Unit/AndroidThemeContractTests.cs
+++ b/FEBuilderGBA.Tests/Unit/AndroidThemeContractTests.cs
@@ -1,0 +1,45 @@
+using System.Xml.Linq;
+
+namespace FEBuilderGBA.Tests.Unit
+{
+    public class AndroidThemeContractTests
+    {
+        private static string SolutionDir
+        {
+            get
+            {
+                var dir = AppContext.BaseDirectory;
+                while (dir != null && !File.Exists(Path.Combine(dir, "FEBuilderGBA.sln")))
+                    dir = Path.GetDirectoryName(dir);
+                return dir ?? throw new InvalidOperationException("Cannot find solution root");
+            }
+        }
+
+        [Fact]
+        public void MainActivity_UsesAppCompatThemeResource()
+        {
+            string source = File.ReadAllText(
+                Path.Combine(SolutionDir, "FEBuilderGBA.Android", "MainActivity.cs"));
+
+            Assert.Contains("Theme = \"@style/FEBuilderTheme\"", source);
+        }
+
+        [Fact]
+        public void ThemeResource_InheritsAppCompatNoActionBar()
+        {
+            string path = Path.Combine(
+                SolutionDir,
+                "FEBuilderGBA.Android",
+                "Resources",
+                "values",
+                "styles.xml");
+
+            Assert.True(File.Exists(path), $"Android theme resource should exist at {path}");
+
+            var document = XDocument.Load(path);
+            var style = Assert.Single(document.Root!.Elements("style"));
+            Assert.Equal("FEBuilderTheme", style.Attribute("name")?.Value);
+            Assert.Equal("Theme.AppCompat.DayNight.NoActionBar", style.Attribute("parent")?.Value);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- apply an AppCompat DayNight no-action-bar theme before Avalonia activity initialization
- add a contract test for the Android style resource and activity reference
- remove the stale comment claiming the Android head has no theme resource

Accepted plan: https://github.com/laqieer/FEBuilderGBA/issues/2142#issuecomment-5467144331

Closes #2142

## Validation

- [x] `dotnet test FEBuilderGBA.Tests\FEBuilderGBA.Tests.csproj -c Release --filter FullyQualifiedName~AndroidThemeContractTests`
- [x] `dotnet test FEBuilderGBA.Tests\FEBuilderGBA.Tests.csproj -c Release --no-restore` (2,359 passed)
- [x] exact cross-platform Core test command (7,601 passed; 19 skipped)
- [x] `dotnet build FEBuilderGBA.Android\FEBuilderGBA.Android.csproj -c Release -p:EnableAndroidTarget=true`
- [x] verified the merged manifest applies `android:theme="@style/FEBuilderTheme"`

## GUI Test Report

No screenshot is applicable: the reported failure occurs during native activity initialization before Avalonia can render a UI. The Android release build and packaged manifest validate the resource wiring; Android boot-smoke CI is the runtime gate.

Copilot CLI: 1.0.79
Model: GPT-5.6 Sol (gpt-5.6-sol)

