### PR TITLE
fix(avalonia): clarify Unit Palette numeric input

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/NumericInputParserTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/NumericInputParserTests.cs
@@ -1,0 +1,44 @@
+using FEBuilderGBA.Avalonia.Services;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+public class NumericInputParserTests
+{
+    [Theory]
+    [InlineData("0", 0u)]
+    [InlineData("66", 66u)]
+    [InlineData("255", 255u)]
+    [InlineData("0x00", 0u)]
+    [InlineData("0x42", 66u)]
+    [InlineData("0XFF", 255u)]
+    [InlineData(" 0x2a ", 42u)]
+    public void TryParseUInt32_AcceptsDecimalOrPrefixedHex(string text, uint expected)
+    {
+        Assert.True(NumericInputParser.TryParseUInt32(text, 0, 255, out uint actual));
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("FF")]
+    [InlineData("0x")]
+    [InlineData("-1")]
+    [InlineData("256")]
+    [InlineData("0x100")]
+    [InlineData("12.5")]
+    public void TryParseUInt32_RejectsAmbiguousMalformedOrOutOfRangeText(string? text)
+    {
+        Assert.False(NumericInputParser.TryParseUInt32(text, 0, 255, out _));
+    }
+
+    [Fact]
+    public void FormatHexByte_UsesCanonicalTwoDigitUppercaseForm()
+    {
+        Assert.Equal("0x00", NumericInputParser.FormatHexByte(0));
+        Assert.Equal("0x2A", NumericInputParser.FormatHexByte(42));
+        Assert.Equal("0xFF", NumericInputParser.FormatHexByte(255));
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/UnitPaletteViewTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/UnitPaletteViewTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Interactivity;
@@ -48,6 +49,28 @@ public sealed class UnitPaletteViewTests : IDisposable
         Assert.Equal("Promoted Class 2:", view.FindControl<TextBlock>("PromotedClass2Label")?.Text);
         Assert.Equal("Promoted Class 3:", view.FindControl<TextBlock>("PromotedClass3Label")?.Text);
         Assert.Equal("Promoted Class 4:", view.FindControl<TextBlock>("PromotedClass4Label")?.Text);
+    }
+
+    [AvaloniaFact]
+    public void NamedLabels_HaveStableAutomationIds()
+    {
+        var view = new UnitPaletteView();
+        var expected = new Dictionary<string, string>
+        {
+            ["InputFormatHeader"] = "UnitPalette_InputFormat_Label",
+            ["HexValueHeader"] = "UnitPalette_HexValue_Label",
+            ["PromotedClass1Label"] = "UnitPalette_PromotedClass1_Label",
+            ["PromotedClass2Label"] = "UnitPalette_PromotedClass2_Label",
+            ["PromotedClass3Label"] = "UnitPalette_PromotedClass3_Label",
+            ["PromotedClass4Label"] = "UnitPalette_PromotedClass4_Label",
+        };
+
+        foreach (var pair in expected)
+        {
+            TextBlock? label = view.FindControl<TextBlock>(pair.Key);
+            Assert.NotNull(label);
+            Assert.Equal(pair.Value, AutomationProperties.GetAutomationId(label));
+        }
     }
 
     [AvaloniaFact]

--- a/FEBuilderGBA.Avalonia.Tests/UnitPaletteViewTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/UnitPaletteViewTests.cs
@@ -3,6 +3,7 @@ using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Interactivity;
+using Avalonia.Threading;
 using FEBuilderGBA.Avalonia.ViewModels;
 using FEBuilderGBA.Avalonia.Views;
 using Xunit;
@@ -89,6 +90,39 @@ public sealed class UnitPaletteViewTests : IDisposable
 
         input.Text = "FF";
         Assert.Equal("Invalid", hex.Text);
+    }
+
+    [AvaloniaFact]
+    public async Task LanguageChange_AfterInvalidReattach_PreservesCorrectedHexValue()
+    {
+        var view = new UnitPaletteView();
+        var input = Assert.IsType<TextBox>(view.FindControl<Control>("BaseClass1Box"));
+        var hex = view.FindControl<TextBlock>("BaseClass1HexLabel");
+        Assert.NotNull(hex);
+
+        var firstWindow = new Window { Content = view };
+        firstWindow.Show();
+        input.Text = "FF";
+        Assert.Equal("Invalid", hex!.Text);
+        firstWindow.Content = null;
+        firstWindow.Close();
+
+        var secondWindow = new Window { Content = view };
+        secondWindow.Show();
+        try
+        {
+            input.Text = "66";
+            Assert.Equal("0x42", hex.Text);
+
+            CoreState.RaiseLanguageChanged();
+            await Dispatcher.UIThread.InvokeAsync(() => { });
+
+            Assert.Equal("0x42", hex.Text);
+        }
+        finally
+        {
+            secondWindow.Close();
+        }
     }
 
     [AvaloniaFact]

--- a/FEBuilderGBA.Avalonia.Tests/UnitPaletteViewTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/UnitPaletteViewTests.cs
@@ -1,0 +1,163 @@
+using System.Reflection;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Interactivity;
+using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Avalonia.Views;
+using Xunit;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+[Collection("SharedState")]
+public sealed class UnitPaletteViewTests : IDisposable
+{
+    const uint EntryAddress = 0x300;
+
+    readonly ROM? _savedRom = CoreState.ROM;
+    readonly Undo? _savedUndo = CoreState.Undo;
+    readonly IAppServices? _savedServices = CoreState.Services;
+
+    public void Dispose()
+    {
+        CoreStateTestState.RestoreRom(_savedRom);
+        CoreStateTestState.RestoreUndo(_savedUndo);
+        CoreStateTestState.RestoreServices(_savedServices);
+    }
+
+    sealed class RecordingServices : IAppServices
+    {
+        public string? LastError { get; private set; }
+        public string? LastInfo { get; private set; }
+
+        public void ShowError(string message) => LastError = message;
+        public void ShowInfo(string message) => LastInfo = message;
+        public bool ShowQuestion(string message) => false;
+        public bool ShowYesNo(string message) => false;
+        public void RunOnUIThread(Action action) => action();
+        public bool IsMainThread() => true;
+    }
+
+    [AvaloniaFact]
+    public void Labels_UsePromotedClassTerminology()
+    {
+        var view = new UnitPaletteView();
+
+        Assert.Equal("Input (decimal or 0x hex)", view.FindControl<TextBlock>("InputFormatHeader")?.Text);
+        Assert.Equal("Hex value", view.FindControl<TextBlock>("HexValueHeader")?.Text);
+        Assert.Equal("Promoted Class 1:", view.FindControl<TextBlock>("PromotedClass1Label")?.Text);
+        Assert.Equal("Promoted Class 2:", view.FindControl<TextBlock>("PromotedClass2Label")?.Text);
+        Assert.Equal("Promoted Class 3:", view.FindControl<TextBlock>("PromotedClass3Label")?.Text);
+        Assert.Equal("Promoted Class 4:", view.FindControl<TextBlock>("PromotedClass4Label")?.Text);
+    }
+
+    [AvaloniaFact]
+    public void DecimalAndHexInput_UpdateCanonicalHexCompanion()
+    {
+        var view = new UnitPaletteView();
+        var input = Assert.IsType<TextBox>(view.FindControl<Control>("BaseClass1Box"));
+        var hex = view.FindControl<TextBlock>("BaseClass1HexLabel");
+        Assert.NotNull(hex);
+
+        input.Text = "66";
+        Assert.Equal("0x42", hex!.Text);
+
+        input.Text = "0X2a";
+        Assert.Equal("0x2A", hex.Text);
+
+        input.Text = "FF";
+        Assert.Equal("Invalid", hex.Text);
+    }
+
+    [AvaloniaFact]
+    public void Write_AcceptsMixedDecimalAndHexInput()
+    {
+        var view = CreateLoadedView(new byte[] { 1, 2, 3, 4, 5, 6, 7 }, out ROM rom, out RecordingServices services);
+
+        SetText(view, "TraineeClassBox", "0x42");
+        SetText(view, "BaseClass1Box", "67");
+        SetText(view, "BaseClass2Box", "0x44");
+        SetText(view, "AdvancedClass1Box", "69");
+        SetText(view, "AdvancedClass2Box", "0x46");
+        SetText(view, "AdvancedClass3Box", "71");
+        SetText(view, "AdvancedClass4Box", "0x48");
+
+        InvokeWrite(view);
+
+        Assert.Equal(new byte[] { 66, 67, 68, 69, 70, 71, 72 },
+            rom.Data.Skip((int)EntryAddress).Take(7).ToArray());
+        Assert.Null(services.LastError);
+        Assert.NotNull(services.LastInfo);
+    }
+
+    [AvaloniaFact]
+    public void Write_InvalidInputReportsErrorWithoutMutation()
+    {
+        byte[] original = { 1, 2, 3, 4, 5, 6, 7 };
+        var view = CreateLoadedView(original, out ROM rom, out RecordingServices services);
+        UnitPaletteViewModel vm = GetViewModel(view);
+
+        SetText(view, "BaseClass1Box", "0x100");
+        InvokeWrite(view);
+
+        Assert.Equal(original, rom.Data.Skip((int)EntryAddress).Take(7).ToArray());
+        Assert.Equal(1u, vm.TraineeClass);
+        Assert.Equal(2u, vm.BaseClass1);
+        Assert.Equal(3u, vm.BaseClass2);
+        Assert.NotNull(services.LastError);
+        Assert.False(CoreState.Undo!.IsModified);
+    }
+
+    static UnitPaletteView CreateLoadedView(
+        byte[] values,
+        out ROM rom,
+        out RecordingServices services)
+    {
+        byte[] data = new byte[0x1000];
+        values.CopyTo(data, (int)EntryAddress);
+
+        rom = new ROM();
+        rom.SwapNewROMDataDirect(data);
+        CoreState.ROM = rom;
+        CoreState.Undo = new Undo();
+        services = new RecordingServices();
+        CoreState.Services = services;
+
+        var view = new UnitPaletteView();
+        UnitPaletteViewModel vm = GetViewModel(view);
+        vm.LoadEntry(EntryAddress);
+        InvokePrivate(view, "UpdateUI");
+        return view;
+    }
+
+    static UnitPaletteViewModel GetViewModel(UnitPaletteView view)
+    {
+        FieldInfo? field = typeof(UnitPaletteView).GetField(
+            "_vm",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        return Assert.IsType<UnitPaletteViewModel>(field?.GetValue(view));
+    }
+
+    static void SetText(UnitPaletteView view, string name, string value)
+    {
+        var input = Assert.IsType<TextBox>(view.FindControl<Control>(name));
+        input.Text = value;
+    }
+
+    static void InvokeWrite(UnitPaletteView view)
+    {
+        MethodInfo? method = typeof(UnitPaletteView).GetMethod(
+            "Write_Click",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        method!.Invoke(view, new object?[] { null, new RoutedEventArgs() });
+    }
+
+    static void InvokePrivate(UnitPaletteView view, string methodName)
+    {
+        MethodInfo? method = typeof(UnitPaletteView).GetMethod(
+            methodName,
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        method!.Invoke(view, null);
+    }
+}

--- a/FEBuilderGBA.Avalonia/Services/NumericInputParser.cs
+++ b/FEBuilderGBA.Avalonia/Services/NumericInputParser.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Globalization;
+
+namespace FEBuilderGBA.Avalonia.Services
+{
+    public static class NumericInputParser
+    {
+        public static bool TryParseUInt32(
+            string? text,
+            uint minimum,
+            uint maximum,
+            out uint value)
+        {
+            value = 0;
+            if (minimum > maximum || string.IsNullOrWhiteSpace(text))
+            {
+                return false;
+            }
+
+            string trimmed = text.Trim();
+            uint parsed;
+            if (trimmed.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+            {
+                string digits = trimmed.Substring(2);
+                if (digits.Length == 0
+                    || !uint.TryParse(
+                        digits,
+                        NumberStyles.AllowHexSpecifier,
+                        CultureInfo.InvariantCulture,
+                        out parsed))
+                {
+                    return false;
+                }
+            }
+            else if (!uint.TryParse(
+                trimmed,
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out parsed))
+            {
+                return false;
+            }
+
+            if (parsed < minimum || parsed > maximum)
+            {
+                return false;
+            }
+
+            value = parsed;
+            return true;
+        }
+
+        public static string FormatHexByte(uint value)
+        {
+            if (value > byte.MaxValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value));
+            }
+
+            return $"0x{value:X2}";
+        }
+    }
+}

--- a/FEBuilderGBA.Avalonia/Views/UnitPaletteView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/UnitPaletteView.axaml
@@ -9,12 +9,12 @@
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="Unit Palette Assignment" FontSize="18" FontWeight="Bold" />
 
-        <Grid ColumnDefinitions="Auto,160,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+        <Grid ColumnDefinitions="Auto,Auto,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
           <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
           <TextBlock AutomationProperties.AutomationId="UnitPalette_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
 
-          <TextBlock Grid.Row="1" Grid.Column="1" Name="InputFormatHeader" Text="Input (decimal or 0x hex)" FontWeight="SemiBold" Margin="0,4,0,2" />
-          <TextBlock Grid.Row="1" Grid.Column="2" Name="HexValueHeader" Text="Hex value" FontWeight="SemiBold" Margin="8,4,0,2" />
+          <TextBlock AutomationProperties.AutomationId="UnitPalette_InputFormat_Label" Grid.Row="1" Grid.Column="1" Name="InputFormatHeader" Text="Input (decimal or 0x hex)" FontWeight="SemiBold" Margin="0,4,0,2" />
+          <TextBlock AutomationProperties.AutomationId="UnitPalette_HexValue_Label" Grid.Row="1" Grid.Column="2" Name="HexValueHeader" Text="Hex value" FontWeight="SemiBold" Margin="8,4,0,2" />
 
           <TextBlock Grid.Row="2" Grid.Column="0" Text="Trainee Class (trainee only):" VerticalAlignment="Center" Margin="0,2" />
           <TextBox AutomationProperties.AutomationId="UnitPalette_TraineeClass_Input" Grid.Row="2" Grid.Column="1" Name="TraineeClassBox" Width="160" Margin="0,2" Watermark="Decimal or 0x hex" />
@@ -28,19 +28,19 @@
           <TextBox AutomationProperties.AutomationId="UnitPalette_BaseClass2_Input" Grid.Row="4" Grid.Column="1" Name="BaseClass2Box" Width="160" Margin="0,2" Watermark="Decimal or 0x hex" />
           <TextBlock AutomationProperties.AutomationId="UnitPalette_BaseClass2_Hex_Label" Grid.Row="4" Grid.Column="2" Name="BaseClass2HexLabel" Text="0x00" FontFamily="Consolas" VerticalAlignment="Center" Margin="8,2,0,2" />
 
-          <TextBlock Grid.Row="5" Grid.Column="0" Name="PromotedClass1Label" Text="Promoted Class 1:" VerticalAlignment="Center" Margin="0,2" />
+          <TextBlock AutomationProperties.AutomationId="UnitPalette_PromotedClass1_Label" Grid.Row="5" Grid.Column="0" Name="PromotedClass1Label" Text="Promoted Class 1:" VerticalAlignment="Center" Margin="0,2" />
           <TextBox AutomationProperties.AutomationId="UnitPalette_AdvancedClass1_Input" Grid.Row="5" Grid.Column="1" Name="AdvancedClass1Box" Width="160" Margin="0,2" Watermark="Decimal or 0x hex" />
           <TextBlock AutomationProperties.AutomationId="UnitPalette_AdvancedClass1_Hex_Label" Grid.Row="5" Grid.Column="2" Name="AdvancedClass1HexLabel" Text="0x00" FontFamily="Consolas" VerticalAlignment="Center" Margin="8,2,0,2" />
 
-          <TextBlock Grid.Row="6" Grid.Column="0" Name="PromotedClass2Label" Text="Promoted Class 2:" VerticalAlignment="Center" Margin="0,2" />
+          <TextBlock AutomationProperties.AutomationId="UnitPalette_PromotedClass2_Label" Grid.Row="6" Grid.Column="0" Name="PromotedClass2Label" Text="Promoted Class 2:" VerticalAlignment="Center" Margin="0,2" />
           <TextBox AutomationProperties.AutomationId="UnitPalette_AdvancedClass2_Input" Grid.Row="6" Grid.Column="1" Name="AdvancedClass2Box" Width="160" Margin="0,2" Watermark="Decimal or 0x hex" />
           <TextBlock AutomationProperties.AutomationId="UnitPalette_AdvancedClass2_Hex_Label" Grid.Row="6" Grid.Column="2" Name="AdvancedClass2HexLabel" Text="0x00" FontFamily="Consolas" VerticalAlignment="Center" Margin="8,2,0,2" />
 
-          <TextBlock Grid.Row="7" Grid.Column="0" Name="PromotedClass3Label" Text="Promoted Class 3:" VerticalAlignment="Center" Margin="0,2" />
+          <TextBlock AutomationProperties.AutomationId="UnitPalette_PromotedClass3_Label" Grid.Row="7" Grid.Column="0" Name="PromotedClass3Label" Text="Promoted Class 3:" VerticalAlignment="Center" Margin="0,2" />
           <TextBox AutomationProperties.AutomationId="UnitPalette_AdvancedClass3_Input" Grid.Row="7" Grid.Column="1" Name="AdvancedClass3Box" Width="160" Margin="0,2" Watermark="Decimal or 0x hex" />
           <TextBlock AutomationProperties.AutomationId="UnitPalette_AdvancedClass3_Hex_Label" Grid.Row="7" Grid.Column="2" Name="AdvancedClass3HexLabel" Text="0x00" FontFamily="Consolas" VerticalAlignment="Center" Margin="8,2,0,2" />
 
-          <TextBlock Grid.Row="8" Grid.Column="0" Name="PromotedClass4Label" Text="Promoted Class 4:" VerticalAlignment="Center" Margin="0,2" />
+          <TextBlock AutomationProperties.AutomationId="UnitPalette_PromotedClass4_Label" Grid.Row="8" Grid.Column="0" Name="PromotedClass4Label" Text="Promoted Class 4:" VerticalAlignment="Center" Margin="0,2" />
           <TextBox AutomationProperties.AutomationId="UnitPalette_AdvancedClass4_Input" Grid.Row="8" Grid.Column="1" Name="AdvancedClass4Box" Width="160" Margin="0,2" Watermark="Decimal or 0x hex" />
           <TextBlock AutomationProperties.AutomationId="UnitPalette_AdvancedClass4_Hex_Label" Grid.Row="8" Grid.Column="2" Name="AdvancedClass4HexLabel" Text="0x00" FontFamily="Consolas" VerticalAlignment="Center" Margin="8,2,0,2" />
         </Grid>

--- a/FEBuilderGBA.Avalonia/Views/UnitPaletteView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/UnitPaletteView.axaml
@@ -9,30 +9,40 @@
       <StackPanel Spacing="8" Margin="8">
         <TextBlock Text="Unit Palette Assignment" FontSize="18" FontWeight="Bold" />
 
-        <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+        <Grid ColumnDefinitions="Auto,160,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
           <TextBlock Grid.Row="0" Grid.Column="0" Text="Address:" VerticalAlignment="Center" />
           <TextBlock AutomationProperties.AutomationId="UnitPalette_Addr_Label" Grid.Row="0" Grid.Column="1" Name="AddrLabel" VerticalAlignment="Center" />
 
-          <TextBlock Grid.Row="1" Grid.Column="0" Text="Trainee Class (trainee only):" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="UnitPalette_TraineeClass_Input" FormatString="0" Grid.Row="1" Grid.Column="1" Name="TraineeClassBox" Minimum="0" Maximum="255" Width="180" Margin="0,2" />
+          <TextBlock Grid.Row="1" Grid.Column="1" Name="InputFormatHeader" Text="Input (decimal or 0x hex)" FontWeight="SemiBold" Margin="0,4,0,2" />
+          <TextBlock Grid.Row="1" Grid.Column="2" Name="HexValueHeader" Text="Hex value" FontWeight="SemiBold" Margin="8,4,0,2" />
 
-          <TextBlock Grid.Row="2" Grid.Column="0" Text="Base Class 1:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="UnitPalette_BaseClass1_Input" FormatString="0" Grid.Row="2" Grid.Column="1" Name="BaseClass1Box" Minimum="0" Maximum="255" Width="180" Margin="0,2" />
+          <TextBlock Grid.Row="2" Grid.Column="0" Text="Trainee Class (trainee only):" VerticalAlignment="Center" Margin="0,2" />
+          <TextBox AutomationProperties.AutomationId="UnitPalette_TraineeClass_Input" Grid.Row="2" Grid.Column="1" Name="TraineeClassBox" Width="160" Margin="0,2" Watermark="Decimal or 0x hex" />
+          <TextBlock AutomationProperties.AutomationId="UnitPalette_TraineeClass_Hex_Label" Grid.Row="2" Grid.Column="2" Name="TraineeClassHexLabel" Text="0x00" FontFamily="Consolas" VerticalAlignment="Center" Margin="8,2,0,2" />
 
-          <TextBlock Grid.Row="3" Grid.Column="0" Text="Base Class 2 (trainee only):" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="UnitPalette_BaseClass2_Input" FormatString="0" Grid.Row="3" Grid.Column="1" Name="BaseClass2Box" Minimum="0" Maximum="255" Width="180" Margin="0,2" />
+          <TextBlock Grid.Row="3" Grid.Column="0" Text="Base Class 1:" VerticalAlignment="Center" Margin="0,2" />
+          <TextBox AutomationProperties.AutomationId="UnitPalette_BaseClass1_Input" Grid.Row="3" Grid.Column="1" Name="BaseClass1Box" Width="160" Margin="0,2" Watermark="Decimal or 0x hex" />
+          <TextBlock AutomationProperties.AutomationId="UnitPalette_BaseClass1_Hex_Label" Grid.Row="3" Grid.Column="2" Name="BaseClass1HexLabel" Text="0x00" FontFamily="Consolas" VerticalAlignment="Center" Margin="8,2,0,2" />
 
-          <TextBlock Grid.Row="4" Grid.Column="0" Text="Advanced Class 1:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="UnitPalette_AdvancedClass1_Input" FormatString="0" Grid.Row="4" Grid.Column="1" Name="AdvancedClass1Box" Minimum="0" Maximum="255" Width="180" Margin="0,2" />
+          <TextBlock Grid.Row="4" Grid.Column="0" Text="Base Class 2 (trainee only):" VerticalAlignment="Center" Margin="0,2" />
+          <TextBox AutomationProperties.AutomationId="UnitPalette_BaseClass2_Input" Grid.Row="4" Grid.Column="1" Name="BaseClass2Box" Width="160" Margin="0,2" Watermark="Decimal or 0x hex" />
+          <TextBlock AutomationProperties.AutomationId="UnitPalette_BaseClass2_Hex_Label" Grid.Row="4" Grid.Column="2" Name="BaseClass2HexLabel" Text="0x00" FontFamily="Consolas" VerticalAlignment="Center" Margin="8,2,0,2" />
 
-          <TextBlock Grid.Row="5" Grid.Column="0" Text="Advanced Class 2:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="UnitPalette_AdvancedClass2_Input" FormatString="0" Grid.Row="5" Grid.Column="1" Name="AdvancedClass2Box" Minimum="0" Maximum="255" Width="180" Margin="0,2" />
+          <TextBlock Grid.Row="5" Grid.Column="0" Name="PromotedClass1Label" Text="Promoted Class 1:" VerticalAlignment="Center" Margin="0,2" />
+          <TextBox AutomationProperties.AutomationId="UnitPalette_AdvancedClass1_Input" Grid.Row="5" Grid.Column="1" Name="AdvancedClass1Box" Width="160" Margin="0,2" Watermark="Decimal or 0x hex" />
+          <TextBlock AutomationProperties.AutomationId="UnitPalette_AdvancedClass1_Hex_Label" Grid.Row="5" Grid.Column="2" Name="AdvancedClass1HexLabel" Text="0x00" FontFamily="Consolas" VerticalAlignment="Center" Margin="8,2,0,2" />
 
-          <TextBlock Grid.Row="6" Grid.Column="0" Text="Advanced Class 3:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="UnitPalette_AdvancedClass3_Input" FormatString="0" Grid.Row="6" Grid.Column="1" Name="AdvancedClass3Box" Minimum="0" Maximum="255" Width="180" Margin="0,2" />
+          <TextBlock Grid.Row="6" Grid.Column="0" Name="PromotedClass2Label" Text="Promoted Class 2:" VerticalAlignment="Center" Margin="0,2" />
+          <TextBox AutomationProperties.AutomationId="UnitPalette_AdvancedClass2_Input" Grid.Row="6" Grid.Column="1" Name="AdvancedClass2Box" Width="160" Margin="0,2" Watermark="Decimal or 0x hex" />
+          <TextBlock AutomationProperties.AutomationId="UnitPalette_AdvancedClass2_Hex_Label" Grid.Row="6" Grid.Column="2" Name="AdvancedClass2HexLabel" Text="0x00" FontFamily="Consolas" VerticalAlignment="Center" Margin="8,2,0,2" />
 
-          <TextBlock Grid.Row="7" Grid.Column="0" Text="Advanced Class 4:" VerticalAlignment="Center" Margin="0,2" />
-          <NumericUpDown AutomationProperties.AutomationId="UnitPalette_AdvancedClass4_Input" FormatString="0" Grid.Row="7" Grid.Column="1" Name="AdvancedClass4Box" Minimum="0" Maximum="255" Width="180" Margin="0,2" />
+          <TextBlock Grid.Row="7" Grid.Column="0" Name="PromotedClass3Label" Text="Promoted Class 3:" VerticalAlignment="Center" Margin="0,2" />
+          <TextBox AutomationProperties.AutomationId="UnitPalette_AdvancedClass3_Input" Grid.Row="7" Grid.Column="1" Name="AdvancedClass3Box" Width="160" Margin="0,2" Watermark="Decimal or 0x hex" />
+          <TextBlock AutomationProperties.AutomationId="UnitPalette_AdvancedClass3_Hex_Label" Grid.Row="7" Grid.Column="2" Name="AdvancedClass3HexLabel" Text="0x00" FontFamily="Consolas" VerticalAlignment="Center" Margin="8,2,0,2" />
+
+          <TextBlock Grid.Row="8" Grid.Column="0" Name="PromotedClass4Label" Text="Promoted Class 4:" VerticalAlignment="Center" Margin="0,2" />
+          <TextBox AutomationProperties.AutomationId="UnitPalette_AdvancedClass4_Input" Grid.Row="8" Grid.Column="1" Name="AdvancedClass4Box" Width="160" Margin="0,2" Watermark="Decimal or 0x hex" />
+          <TextBlock AutomationProperties.AutomationId="UnitPalette_AdvancedClass4_Hex_Label" Grid.Row="8" Grid.Column="2" Name="AdvancedClass4HexLabel" Text="0x00" FontFamily="Consolas" VerticalAlignment="Center" Margin="8,2,0,2" />
         </Grid>
 
         <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,8,0,0">

--- a/FEBuilderGBA.Avalonia/Views/UnitPaletteView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/UnitPaletteView.axaml.cs
@@ -11,6 +11,7 @@ namespace FEBuilderGBA.Avalonia.Views
     {
         readonly UnitPaletteViewModel _vm = new();
         readonly UndoService _undoService = new();
+        readonly (TextBox Input, TextBlock HexLabel, string DisplayName)[] _classFields;
         bool _hasLoadedList;
 
         public string ViewTitle => "Unit Palette Assignment";
@@ -21,6 +22,20 @@ namespace FEBuilderGBA.Avalonia.Views
         public UnitPaletteView()
         {
             InitializeComponent();
+            _classFields = new[]
+            {
+                (TraineeClassBox, TraineeClassHexLabel, "Trainee Class"),
+                (BaseClass1Box, BaseClass1HexLabel, "Base Class 1"),
+                (BaseClass2Box, BaseClass2HexLabel, "Base Class 2"),
+                (AdvancedClass1Box, AdvancedClass1HexLabel, "Promoted Class 1"),
+                (AdvancedClass2Box, AdvancedClass2HexLabel, "Promoted Class 2"),
+                (AdvancedClass3Box, AdvancedClass3HexLabel, "Promoted Class 3"),
+                (AdvancedClass4Box, AdvancedClass4HexLabel, "Promoted Class 4"),
+            };
+            foreach (var field in _classFields)
+            {
+                field.Input.PropertyChanged += OnClassValuePropertyChanged;
+            }
             EntryList.SelectedAddressChanged += OnSelected;
         }
 
@@ -67,26 +82,27 @@ namespace FEBuilderGBA.Avalonia.Views
         void UpdateUI()
         {
             AddrLabel.Text = $"0x{_vm.CurrentAddr:X08}";
-            TraineeClassBox.Value = _vm.TraineeClass;
-            BaseClass1Box.Value = _vm.BaseClass1;
-            BaseClass2Box.Value = _vm.BaseClass2;
-            AdvancedClass1Box.Value = _vm.AdvancedClass1;
-            AdvancedClass2Box.Value = _vm.AdvancedClass2;
-            AdvancedClass3Box.Value = _vm.AdvancedClass3;
-            AdvancedClass4Box.Value = _vm.AdvancedClass4;
+            SetClassValue(_classFields[0], _vm.TraineeClass);
+            SetClassValue(_classFields[1], _vm.BaseClass1);
+            SetClassValue(_classFields[2], _vm.BaseClass2);
+            SetClassValue(_classFields[3], _vm.AdvancedClass1);
+            SetClassValue(_classFields[4], _vm.AdvancedClass2);
+            SetClassValue(_classFields[5], _vm.AdvancedClass3);
+            SetClassValue(_classFields[6], _vm.AdvancedClass4);
         }
 
         void Write_Click(object? sender, RoutedEventArgs e)
         {
             if (!_vm.IsLoaded) return;
+            if (!TryReadClassValues(out uint[] values)) return;
 
-            _vm.TraineeClass = (uint)(TraineeClassBox.Value ?? 0);
-            _vm.BaseClass1 = (uint)(BaseClass1Box.Value ?? 0);
-            _vm.BaseClass2 = (uint)(BaseClass2Box.Value ?? 0);
-            _vm.AdvancedClass1 = (uint)(AdvancedClass1Box.Value ?? 0);
-            _vm.AdvancedClass2 = (uint)(AdvancedClass2Box.Value ?? 0);
-            _vm.AdvancedClass3 = (uint)(AdvancedClass3Box.Value ?? 0);
-            _vm.AdvancedClass4 = (uint)(AdvancedClass4Box.Value ?? 0);
+            _vm.TraineeClass = values[0];
+            _vm.BaseClass1 = values[1];
+            _vm.BaseClass2 = values[2];
+            _vm.AdvancedClass1 = values[3];
+            _vm.AdvancedClass2 = values[4];
+            _vm.AdvancedClass3 = values[5];
+            _vm.AdvancedClass4 = values[6];
 
             _undoService.Begin("Edit Unit Palette");
             try
@@ -101,6 +117,65 @@ namespace FEBuilderGBA.Avalonia.Views
                 _undoService.Rollback();
                 Log.ErrorF("Write failed: {0}", ex.Message);
             }
+        }
+
+        void OnClassValuePropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+        {
+            if (e.Property != TextBox.TextProperty) return;
+
+            foreach (var field in _classFields)
+            {
+                if (ReferenceEquals(field.Input, sender))
+                {
+                    UpdateHexLabel(field);
+                    return;
+                }
+            }
+        }
+
+        static void SetClassValue(
+            (TextBox Input, TextBlock HexLabel, string DisplayName) field,
+            uint value)
+        {
+            field.Input.Text = value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            field.HexLabel.Text = NumericInputParser.FormatHexByte(value);
+        }
+
+        static void UpdateHexLabel(
+            (TextBox Input, TextBlock HexLabel, string DisplayName) field)
+        {
+            field.HexLabel.Text = NumericInputParser.TryParseUInt32(
+                field.Input.Text,
+                0,
+                byte.MaxValue,
+                out uint value)
+                ? NumericInputParser.FormatHexByte(value)
+                : R._("Invalid");
+        }
+
+        bool TryReadClassValues(out uint[] values)
+        {
+            values = new uint[_classFields.Length];
+            for (int i = 0; i < _classFields.Length; i++)
+            {
+                var field = _classFields[i];
+                if (NumericInputParser.TryParseUInt32(
+                    field.Input.Text,
+                    0,
+                    byte.MaxValue,
+                    out values[i]))
+                {
+                    continue;
+                }
+
+                CoreState.Services?.ShowError(R._(
+                    "{0} must be 0-255 decimal or 0x00-0xFF hexadecimal.",
+                    R._(field.DisplayName)));
+                field.Input.Focus();
+                return false;
+            }
+
+            return true;
         }
 
         public void NavigateTo(uint address) => EntryList.SelectAddress(address);

--- a/FEBuilderGBA.Avalonia/Views/UnitPaletteView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/UnitPaletteView.axaml.cs
@@ -13,6 +13,7 @@ namespace FEBuilderGBA.Avalonia.Views
         readonly UndoService _undoService = new();
         readonly (TextBox Input, TextBlock HexLabel, string DisplayName)[] _classFields;
         bool _hasLoadedList;
+        bool _classValueLanguageSubscribed;
 
         public string ViewTitle => "Unit Palette Assignment";
         public new bool IsLoaded => _vm.IsLoaded;
@@ -42,11 +43,26 @@ namespace FEBuilderGBA.Avalonia.Views
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {
             base.OnAttachedToVisualTree(e);
+            if (!_classValueLanguageSubscribed)
+            {
+                CoreState.LanguageChanged += OnClassValueLanguageChanged;
+                _classValueLanguageSubscribed = true;
+            }
             if (!_hasLoadedList)
             {
                 _hasLoadedList = true;
                 LoadList();
             }
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            if (_classValueLanguageSubscribed)
+            {
+                CoreState.LanguageChanged -= OnClassValueLanguageChanged;
+                _classValueLanguageSubscribed = false;
+            }
+            base.OnDetachedFromVisualTree(e);
         }
 
         void LoadList()
@@ -131,6 +147,17 @@ namespace FEBuilderGBA.Avalonia.Views
                     return;
                 }
             }
+        }
+
+        void OnClassValueLanguageChanged()
+        {
+            global::Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+            {
+                foreach (var field in _classFields)
+                {
+                    UpdateHexLabel(field);
+                }
+            });
         }
 
         static void SetClassValue(

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -1169,6 +1169,51 @@ Advanced クラス 3:
 :Advanced Class 4:
 Advanced クラス 4:
 
+:Promoted Class 1:
+上級クラス1:
+
+:Promoted Class 2:
+上級クラス2:
+
+:Promoted Class 3:
+上級クラス3:
+
+:Promoted Class 4:
+上級クラス4:
+
+:Trainee Class
+見習いクラス
+
+:Base Class 1
+基本クラス1
+
+:Base Class 2
+基本クラス2
+
+:Promoted Class 1
+上級クラス1
+
+:Promoted Class 2
+上級クラス2
+
+:Promoted Class 3
+上級クラス3
+
+:Promoted Class 4
+上級クラス4
+
+:Input (decimal or 0x hex)
+入力 (10進数または0x付き16進数)
+
+:Hex value
+16進数値
+
+:Decimal or 0x hex
+10進数または0x付き16進数
+
+:{0} must be 0-255 decimal or 0x00-0xFF hexadecimal.
+{0}は0～255の10進数、または0x00～0xFFの16進数で入力してください。
+
 :Affinity Type:
 属性 タイプ:
 

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -15170,6 +15170,51 @@ ASM指针:
 :Advanced Class 4:
 上级职业4:
 
+:Promoted Class 1:
+上级职业1:
+
+:Promoted Class 2:
+上级职业2:
+
+:Promoted Class 3:
+上级职业3:
+
+:Promoted Class 4:
+上级职业4:
+
+:Trainee Class
+实习生职业
+
+:Base Class 1
+基础职业1
+
+:Base Class 2
+基础职业2
+
+:Promoted Class 1
+上级职业1
+
+:Promoted Class 2
+上级职业2
+
+:Promoted Class 3
+上级职业3
+
+:Promoted Class 4
+上级职业4
+
+:Input (decimal or 0x hex)
+输入（十进制或 0x 十六进制）
+
+:Hex value
+十六进制值
+
+:Decimal or 0x hex
+十进制或 0x 十六进制
+
+:{0} must be 0-255 decimal or 0x00-0xFF hexadecimal.
+{0}必须是 0-255 的十进制数或 0x00-0xFF 的十六进制数。
+
 :Advanced utilities: hex editing, patching, ROM diagnostics, and more.
 高级工具: 十六进制编辑、补丁、ROM诊断等。
 

--- a/docs/field-completeness-report.txt
+++ b/docs/field-completeness-report.txt
@@ -1,6 +1,6 @@
 === Field Completeness Report ===
 Total WinForms fields: 1562
-Total Avalonia fields: 1822
+Total Avalonia fields: 1823
 Total missing: 0
 Forms with gaps: 0 / 180
 


### PR DESCRIPTION
## Summary

- rename Unit Palette Assignment captions from Advanced Class to WinForms-parity Promoted Class
- show explicit input and canonical hexadecimal columns for all seven class IDs
- accept decimal or `0x`-prefixed hexadecimal byte values and reject invalid input before view-model, undo, or ROM mutation
- add Japanese/Chinese translations plus focused parser and view regression tests

Accepted plans:

- https://github.com/laqieer/FEBuilderGBA/issues/2139#issuecomment-5467144486
- https://github.com/laqieer/FEBuilderGBA/issues/2143#issuecomment-5467144684

Closes #2139
Closes #2143

## Validation

- [x] targeted parser and Unit Palette view tests (23 passed)
- [x] `scripts\validate-automation-ids.ps1` (0 warnings)
- [x] `dotnet test FEBuilderGBA.Avalonia.Tests\FEBuilderGBA.Avalonia.Tests.csproj -c Release --no-restore` (9,914 passed; 11 skipped)
- [x] `dotnet test FEBuilderGBA.Tests\FEBuilderGBA.Tests.csproj -c Release --no-restore` (2,357 passed)
- [x] `dotnet build FEBuilderGBA.Avalonia\FEBuilderGBA.Avalonia.csproj -c Release --no-restore` (0 warnings)

## GUI Test Report

Rendered the real `UnitPaletteView` through the Windows Avalonia desktop backend with a synthetic in-memory ROM entry. The screenshot verifies Promoted Class labels, the explicit input/hex headers, decimal-to-hex display, and direct `0x` input.

![Unit Palette Assignment with decimal and hexadecimal input](https://github.com/user-attachments/assets/1948ad20-4a8e-493d-a800-7b110635748e)

Copilot CLI: 1.0.79
Model: GPT-5.6 Sol (gpt-5.6-sol)



