### PR TITLE
fix(avalonia): restore sparse item weapon types

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/WeaponTypeComboTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/WeaponTypeComboTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
@@ -100,6 +101,55 @@ public class WeaponTypeComboTests
             AssertSelectedId(fe6View, 0x12);
             Assert.Equal(0x00u, itemVm.WeaponType);
             Assert.Equal(0x00u, fe6Vm.WeaponType);
+        }
+        finally
+        {
+            itemHost?.Close();
+            fe6Host?.Close();
+            MyTranslateResource.Clear();
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task ItemEditors_MarshalBackgroundLanguageChange()
+    {
+        string tempDir = Path.Combine(
+            Path.GetTempPath(),
+            "weapon_type_background_translation_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        string firstMap = Path.Combine(tempDir, "first.txt");
+        string secondMap = Path.Combine(tempDir, "second.txt");
+        File.WriteAllText(firstMap, ":12=Dancer's Ring\n12=[FIRST]\n\n");
+        File.WriteAllText(secondMap, ":12=Dancer's Ring\n12=[SECOND]\n\n");
+
+        EditorHostWindow? itemHost = null;
+        EditorHostWindow? fe6Host = null;
+        try
+        {
+            MyTranslateResource.LoadResource(firstMap);
+
+            var itemView = new ItemEditorView();
+            itemHost = new EditorHostWindow(itemView);
+            itemHost.Show();
+            var itemVm = GetViewModel<ItemEditorViewModel>(itemView);
+            itemVm.WeaponType = 0x12;
+            Invoke(itemView, "UpdateUI");
+
+            var fe6View = new ItemFE6View();
+            fe6Host = new EditorHostWindow(fe6View);
+            fe6Host.Show();
+            var fe6Vm = GetViewModel<ItemFE6ViewModel>(fe6View);
+            fe6Vm.WeaponType = 0x12;
+            Invoke(fe6View, "UpdateUI");
+
+            MyTranslateResource.LoadResource(secondMap);
+            await Task.Run(() => Invoke(itemView, "OnLanguageChanged"));
+            await Task.Run(() => Invoke(fe6View, "OnLanguageChanged"));
+            await Dispatcher.UIThread.InvokeAsync(() => { });
+
+            Assert.Equal("12 [SECOND]", SelectedLabel(itemView));
+            Assert.Equal("12 [SECOND]", SelectedLabel(fe6View));
         }
         finally
         {

--- a/FEBuilderGBA.Avalonia.Tests/WeaponTypeComboTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/WeaponTypeComboTests.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using FEBuilderGBA;
+using FEBuilderGBA.Avalonia.Services;
+using FEBuilderGBA.Avalonia.ViewModels;
+using FEBuilderGBA.Avalonia.Views;
+
+namespace FEBuilderGBA.Avalonia.Tests;
+
+[Collection("SharedState")]
+public class WeaponTypeComboTests
+{
+    [AvaloniaFact]
+    public void ItemEditor_PreservesUnknownWeaponTypeRoundTrip()
+    {
+        var view = new ItemEditorView();
+        var vm = GetViewModel<ItemEditorViewModel>(view);
+        vm.WeaponType = 0x08;
+
+        Invoke(view, "UpdateUI");
+
+        AssertSelectedId(view, 0x08);
+        Invoke(view, "ReadFromUI");
+        Assert.Equal(0x08u, vm.WeaponType);
+    }
+
+    [AvaloniaFact]
+    public void ItemFE6Editor_PreservesUnknownWeaponTypeRoundTrip()
+    {
+        var view = new ItemFE6View();
+        var vm = GetViewModel<ItemFE6ViewModel>(view);
+        vm.WeaponType = 0x0A;
+
+        Invoke(view, "UpdateUI");
+
+        AssertSelectedId(view, 0x0A);
+        Invoke(view, "ReadFromUI");
+        Assert.Equal(0x0Au, vm.WeaponType);
+    }
+
+    [AvaloniaFact]
+    public void ItemEditors_RefreshWeaponTypeLabelsOnLanguageChange()
+    {
+        string tempDir = Path.Combine(
+            Path.GetTempPath(),
+            "weapon_type_translation_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        string firstMap = Path.Combine(tempDir, "first.txt");
+        string secondMap = Path.Combine(tempDir, "second.txt");
+        File.WriteAllText(firstMap, ":12=Dancer's Ring\n12=[FIRST]\n\n");
+        File.WriteAllText(secondMap, ":12=Dancer's Ring\n12=[SECOND]\n\n");
+
+        EditorHostWindow? itemHost = null;
+        EditorHostWindow? fe6Host = null;
+        try
+        {
+            MyTranslateResource.LoadResource(firstMap);
+
+            var itemView = new ItemEditorView();
+            itemHost = new EditorHostWindow(itemView);
+            itemHost.Show();
+            var itemVm = GetViewModel<ItemEditorViewModel>(itemView);
+            itemVm.WeaponType = 0x00;
+            Invoke(itemView, "UpdateUI");
+            SelectId(itemView, 0x12);
+
+            var fe6View = new ItemFE6View();
+            fe6Host = new EditorHostWindow(fe6View);
+            fe6Host.Show();
+            var fe6Vm = GetViewModel<ItemFE6ViewModel>(fe6View);
+            fe6Vm.WeaponType = 0x00;
+            Invoke(fe6View, "UpdateUI");
+            SelectId(fe6View, 0x12);
+
+            Assert.Equal("12 [FIRST]", SelectedLabel(itemView));
+            Assert.Equal("12 [FIRST]", SelectedLabel(fe6View));
+            Assert.Equal(0x00u, itemVm.WeaponType);
+            Assert.Equal(0x00u, fe6Vm.WeaponType);
+
+            MyTranslateResource.LoadResource(secondMap);
+            CoreState.RaiseLanguageChanged();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal("12 [SECOND]", SelectedLabel(itemView));
+            Assert.Equal("12 [SECOND]", SelectedLabel(fe6View));
+            AssertSelectedId(itemView, 0x12);
+            AssertSelectedId(fe6View, 0x12);
+            Assert.Equal(0x00u, itemVm.WeaponType);
+            Assert.Equal(0x00u, fe6Vm.WeaponType);
+        }
+        finally
+        {
+            itemHost?.Close();
+            fe6Host?.Close();
+            MyTranslateResource.Clear();
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    static void AssertSelectedId(Control view, uint expectedId)
+    {
+        var combo = Assert.IsType<ComboBox>(
+            view.FindControl<ComboBox>("WeaponTypeCombo"));
+        var list = GetWeaponTypeList(view);
+        Assert.InRange(combo.SelectedIndex, 0, list.Count - 1);
+        Assert.Equal(expectedId, list[combo.SelectedIndex].id);
+    }
+
+    static void SelectId(Control view, uint id)
+    {
+        var combo = Assert.IsType<ComboBox>(
+            view.FindControl<ComboBox>("WeaponTypeCombo"));
+        var list = GetWeaponTypeList(view);
+        combo.SelectedIndex = list.FindIndex(x => x.id == id);
+        Assert.True(combo.SelectedIndex >= 0);
+    }
+
+    static string SelectedLabel(Control view)
+    {
+        var combo = Assert.IsType<ComboBox>(
+            view.FindControl<ComboBox>("WeaponTypeCombo"));
+        return Assert.IsType<string>(combo.SelectedItem);
+    }
+
+    static List<(uint id, string name)> GetWeaponTypeList(object view)
+    {
+        FieldInfo? field = view.GetType().GetField(
+            "_weaponTypeList",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        return Assert.IsType<List<(uint id, string name)>>(field!.GetValue(view));
+    }
+
+    static T GetViewModel<T>(object view) where T : class
+    {
+        FieldInfo? field = view.GetType().GetField(
+            "_vm",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        return Assert.IsType<T>(field!.GetValue(view));
+    }
+
+    static void Invoke(object target, string methodName)
+    {
+        MethodInfo? method = target.GetType().GetMethod(
+            methodName,
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        method!.Invoke(target, null);
+    }
+}

--- a/FEBuilderGBA.Avalonia.Tests/WeaponTypeComboTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/WeaponTypeComboTests.cs
@@ -44,7 +44,7 @@ public class WeaponTypeComboTests
     }
 
     [AvaloniaFact]
-    public void ItemEditors_RefreshWeaponTypeLabelsOnLanguageChange()
+    public void ItemEditors_RefreshWeaponTypeLabelsAfterDetachedLanguageChange()
     {
         string tempDir = Path.Combine(
             Path.GetTempPath(),
@@ -82,8 +82,16 @@ public class WeaponTypeComboTests
             Assert.Equal(0x00u, itemVm.WeaponType);
             Assert.Equal(0x00u, fe6Vm.WeaponType);
 
+            itemHost.Content = null;
+            fe6Host.Content = null;
+            Dispatcher.UIThread.RunJobs();
+
             MyTranslateResource.LoadResource(secondMap);
             CoreState.RaiseLanguageChanged();
+            Dispatcher.UIThread.RunJobs();
+
+            itemHost.Content = itemView;
+            fe6Host.Content = fe6View;
             Dispatcher.UIThread.RunJobs();
 
             Assert.Equal("12 [SECOND]", SelectedLabel(itemView));

--- a/FEBuilderGBA.Avalonia.Tests/WeaponTypeComboTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/WeaponTypeComboTests.cs
@@ -160,6 +160,46 @@ public class WeaponTypeComboTests
         }
     }
 
+    [AvaloniaFact]
+    public void ItemEditor_QueuesUiThreadLanguageRefresh()
+    {
+        string tempDir = Path.Combine(
+            Path.GetTempPath(),
+            "weapon_type_queued_translation_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        string firstMap = Path.Combine(tempDir, "first.txt");
+        string secondMap = Path.Combine(tempDir, "second.txt");
+        File.WriteAllText(firstMap, ":12=Dancer's Ring\n12=[FIRST]\n\n");
+        File.WriteAllText(secondMap, ":12=Dancer's Ring\n12=[SECOND]\n\n");
+
+        EditorHostWindow? host = null;
+        try
+        {
+            MyTranslateResource.LoadResource(firstMap);
+
+            var view = new ItemEditorView();
+            host = new EditorHostWindow(view);
+            host.Show();
+            var vm = GetViewModel<ItemEditorViewModel>(view);
+            vm.WeaponType = 0x12;
+            Invoke(view, "UpdateUI");
+            Assert.Equal("12 [FIRST]", SelectedLabel(view));
+
+            MyTranslateResource.LoadResource(secondMap);
+            CoreState.RaiseLanguageChanged();
+
+            Assert.Equal("12 [FIRST]", SelectedLabel(view));
+            Dispatcher.UIThread.RunJobs();
+            Assert.Equal("12 [SECOND]", SelectedLabel(view));
+        }
+        finally
+        {
+            host?.Close();
+            MyTranslateResource.Clear();
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
     static void AssertSelectedId(Control view, uint expectedId)
     {
         var combo = Assert.IsType<ComboBox>(

--- a/FEBuilderGBA.Avalonia/Services/ComboResourceHelper.cs
+++ b/FEBuilderGBA.Avalonia/Services/ComboResourceHelper.cs
@@ -82,11 +82,22 @@ namespace FEBuilderGBA.Avalonia.Services
 
         public static List<(uint id, string name)> MakeWeaponTypeList()
         {
-            string[] names = { "Sword", "Lance", "Axe", "Bow", "Staff", "Anima", "Light", "Dark", "Item" };
-            var result = new List<(uint, string)>();
-            for (uint i = 0; i < (uint)names.Length; i++)
-                result.Add((i, $"{U.ToHexString(i)} {names[i]}"));
-            return result;
+            return new List<(uint id, string name)>
+            {
+                (0x00, "00 Sword"),
+                (0x01, "01 Lance"),
+                (0x02, "02 Axe"),
+                (0x03, "03 Bow"),
+                (0x04, "04 Staff"),
+                (0x05, "05 Anima"),
+                (0x06, "06 Light"),
+                (0x07, "07 Dark"),
+                (0x09, "09 Item"),
+                (0x0B, "0B Dragonstone/Monster Weapon"),
+                (0x0C, "0C Ring"),
+                (0x11, "11 Dragonstone"),
+                (0x12, "12 Dancer's Ring"),
+            };
         }
 
         /// <summary>

--- a/FEBuilderGBA.Avalonia/Services/ComboResourceHelper.cs
+++ b/FEBuilderGBA.Avalonia/Services/ComboResourceHelper.cs
@@ -80,25 +80,33 @@ namespace FEBuilderGBA.Avalonia.Services
             return result;
         }
 
-        public static List<(uint id, string name)> MakeWeaponTypeList()
+        public static List<(uint id, string name)> MakeWeaponTypeList(uint? currentId = null)
         {
-            return new List<(uint id, string name)>
+            var result = new List<(uint id, string name)>
             {
-                (0x00, "00 Sword"),
-                (0x01, "01 Lance"),
-                (0x02, "02 Axe"),
-                (0x03, "03 Bow"),
-                (0x04, "04 Staff"),
-                (0x05, "05 Anima"),
-                (0x06, "06 Light"),
-                (0x07, "07 Dark"),
-                (0x09, "09 Item"),
-                (0x0B, "0B Dragonstone/Monster Weapon"),
-                (0x0C, "0C Ring"),
-                (0x11, "11 Dragonstone"),
-                (0x12, "12 Dancer's Ring"),
+                (0x00, LocalizeComboLabel("00=Sword")),
+                (0x01, LocalizeComboLabel("01=Lance")),
+                (0x02, LocalizeComboLabel("02=Axe")),
+                (0x03, LocalizeComboLabel("03=Bow")),
+                (0x04, LocalizeComboLabel("04=Staff")),
+                (0x05, LocalizeComboLabel("05=Anima")),
+                (0x06, LocalizeComboLabel("06=Light")),
+                (0x07, LocalizeComboLabel("07=Dark")),
+                (0x09, LocalizeComboLabel("09=Item")),
+                (0x0B, LocalizeComboLabel("0B=Dragonstone/Monster Weapon")),
+                (0x0C, LocalizeComboLabel("0C=Ring")),
+                (0x11, LocalizeComboLabel("11=Dragonstone")),
+                (0x12, LocalizeComboLabel("12=Dancer's Ring")),
             };
+
+            if (currentId.HasValue && !result.Exists(x => x.id == currentId.Value))
+                result.Add((currentId.Value, $"{U.ToHexString(currentId.Value)} {R._("Unknown")}"));
+
+            return result;
         }
+
+        private static string LocalizeComboLabel(string source)
+            => R._(source).Replace('=', ' ');
 
         /// <summary>
         /// Resolve a ROMFEINFO pointer address to a ROM offset.

--- a/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml.cs
@@ -62,6 +62,10 @@ namespace FEBuilderGBA.Avalonia.Views
                 _hasLoadedList = true;
                 LoadList();
             }
+            else
+            {
+                OnLanguageChanged();
+            }
         }
 
         void LoadList()

--- a/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml.cs
@@ -69,25 +69,6 @@ namespace FEBuilderGBA.Avalonia.Views
             }
         }
 
-        void LoadList()
-        {
-            try
-            {
-                // Populate combo dropdowns BEFORE SetItems (fixes #52).
-                RefreshWeaponTypeList();
-
-                // Show "Edit Skill Config" button if a skill system is installed
-                EditSkillConfigButton.IsVisible = PatchDetectionService.Instance.HasSkillSystem;
-
-                var items = _vm.LoadItemList();
-                ItemList.SetItemsWithIcons(items, i => ListIconLoaders.ItemIconLoader(items, i));
-            }
-            catch (Exception ex)
-            {
-                Log.ErrorF("ItemEditorView.LoadList failed: {0}", ex.Message);
-            }
-        }
-
         void OnLanguageChanged()
         {
             Dispatcher.UIThread.Post(RefreshForLanguage);
@@ -115,6 +96,25 @@ namespace FEBuilderGBA.Avalonia.Views
             WeaponTypeCombo.SelectedIndex = selectedId.HasValue
                 ? _weaponTypeList.FindIndex(x => x.id == selectedId.Value)
                 : -1;
+        }
+
+        void LoadList()
+        {
+            try
+            {
+                // Populate combo dropdowns BEFORE SetItems (fixes #52).
+                RefreshWeaponTypeList();
+
+                // Show "Edit Skill Config" button if a skill system is installed
+                EditSkillConfigButton.IsVisible = PatchDetectionService.Instance.HasSkillSystem;
+
+                var items = _vm.LoadItemList();
+                ItemList.SetItemsWithIcons(items, i => ListIconLoaders.ItemIconLoader(items, i));
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorF("ItemEditorView.LoadList failed: {0}", ex.Message);
+            }
         }
 
         void OnDescIdChanged(object? sender, NumericUpDownValueChangedEventArgs e)

--- a/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml.cs
@@ -48,15 +48,15 @@ namespace FEBuilderGBA.Avalonia.Views
 
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
         {
+            CoreState.LanguageChanged -= OnLanguageChanged;
             base.OnDetachedFromVisualTree(e);
-            CoreState.LanguageChanged -= UpdateWeaponDebuffsLink;
         }
 
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {
             base.OnAttachedToVisualTree(e);
-            CoreState.LanguageChanged -= UpdateWeaponDebuffsLink;
-            CoreState.LanguageChanged += UpdateWeaponDebuffsLink;
+            CoreState.LanguageChanged -= OnLanguageChanged;
+            CoreState.LanguageChanged += OnLanguageChanged;
             if (!_hasLoadedList)
             {
                 _hasLoadedList = true;
@@ -69,8 +69,7 @@ namespace FEBuilderGBA.Avalonia.Views
             try
             {
                 // Populate combo dropdowns BEFORE SetItems (fixes #52).
-                _weaponTypeList = ComboResourceHelper.MakeWeaponTypeList();
-                WeaponTypeCombo.ItemsSource = _weaponTypeList.Select(x => x.name).ToList();
+                RefreshWeaponTypeList();
 
                 // Show "Edit Skill Config" button if a skill system is installed
                 EditSkillConfigButton.IsVisible = PatchDetectionService.Instance.HasSkillSystem;
@@ -82,6 +81,30 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 Log.ErrorF("ItemEditorView.LoadList failed: {0}", ex.Message);
             }
+        }
+
+        void OnLanguageChanged()
+        {
+            uint selectedId = GetSelectedWeaponTypeId();
+            UpdateWeaponDebuffsLink();
+            RefreshWeaponTypeList(selectedId);
+        }
+
+        uint GetSelectedWeaponTypeId()
+        {
+            int selectedIndex = WeaponTypeCombo.SelectedIndex;
+            return selectedIndex >= 0 && selectedIndex < _weaponTypeList.Count
+                ? _weaponTypeList[selectedIndex].id
+                : _vm.WeaponType;
+        }
+
+        void RefreshWeaponTypeList(uint? selectedId = null)
+        {
+            _weaponTypeList = ComboResourceHelper.MakeWeaponTypeList(selectedId);
+            WeaponTypeCombo.ItemsSource = _weaponTypeList.Select(x => x.name).ToList();
+            WeaponTypeCombo.SelectedIndex = selectedId.HasValue
+                ? _weaponTypeList.FindIndex(x => x.id == selectedId.Value)
+                : -1;
         }
 
         void OnDescIdChanged(object? sender, NumericUpDownValueChangedEventArgs e)
@@ -327,9 +350,7 @@ namespace FEBuilderGBA.Avalonia.Views
             // Identity
             ItemNumberBox.Value = _vm.ItemNumber;
 
-            // Weapon type combo
-            int wtIdx = _weaponTypeList.FindIndex(x => x.id == _vm.WeaponType);
-            WeaponTypeCombo.SelectedIndex = wtIdx >= 0 ? wtIdx : (int)_vm.WeaponType;
+            RefreshWeaponTypeList(_vm.WeaponType);
 
             // Trait flags (BitFlagPanel) + hex preview labels (#409 mirrors
             // WF "特性1/2/3/4" plus the raw-byte readout).
@@ -418,7 +439,8 @@ namespace FEBuilderGBA.Avalonia.Views
 
             // Weapon type from combo
             int wtIdx = WeaponTypeCombo.SelectedIndex;
-            _vm.WeaponType = wtIdx >= 0 && wtIdx < _weaponTypeList.Count ? _weaponTypeList[wtIdx].id : 0;
+            if (wtIdx >= 0 && wtIdx < _weaponTypeList.Count)
+                _vm.WeaponType = _weaponTypeList[wtIdx].id;
 
             // Trait flags from BitFlagPanel
             _vm.Trait1 = Trait1Flags.Value;

--- a/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml.cs
@@ -90,10 +90,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void OnLanguageChanged()
         {
-            if (Dispatcher.UIThread.CheckAccess())
-                RefreshForLanguage();
-            else
-                Dispatcher.UIThread.Post(RefreshForLanguage);
+            Dispatcher.UIThread.Post(RefreshForLanguage);
         }
 
         void RefreshForLanguage()

--- a/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemEditorView.axaml.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using global::Avalonia.Controls;
 using global::Avalonia.Input;
 using global::Avalonia.Interactivity;
+using global::Avalonia.Threading;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
 using FEBuilderGBA.Core;
@@ -88,6 +89,14 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         void OnLanguageChanged()
+        {
+            if (Dispatcher.UIThread.CheckAccess())
+                RefreshForLanguage();
+            else
+                Dispatcher.UIThread.Post(RefreshForLanguage);
+        }
+
+        void RefreshForLanguage()
         {
             uint selectedId = GetSelectedWeaponTypeId();
             UpdateWeaponDebuffsLink();

--- a/FEBuilderGBA.Avalonia/Views/ItemFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemFE6View.axaml.cs
@@ -72,24 +72,6 @@ namespace FEBuilderGBA.Avalonia.Views
             base.OnDetachedFromVisualTree(e);
         }
 
-        void LoadList()
-        {
-            try
-            {
-                // Populate combo dropdown BEFORE SetItems.
-                RefreshWeaponTypeList();
-
-                var items = _vm.LoadItemList();
-                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ItemIconLoader(items, i));
-
-                UpdateListMetadata(items.Count);
-            }
-            catch (Exception ex)
-            {
-                Log.ErrorF("ItemFE6View.LoadList failed: {0}", ex.Message);
-            }
-        }
-
         void OnLanguageChanged()
         {
             Dispatcher.UIThread.Post(RefreshForLanguage);
@@ -115,6 +97,24 @@ namespace FEBuilderGBA.Avalonia.Views
             WeaponTypeCombo.SelectedIndex = selectedId.HasValue
                 ? _weaponTypeList.FindIndex(x => x.id == selectedId.Value)
                 : -1;
+        }
+
+        void LoadList()
+        {
+            try
+            {
+                // Populate combo dropdown BEFORE SetItems.
+                RefreshWeaponTypeList();
+
+                var items = _vm.LoadItemList();
+                EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ItemIconLoader(items, i));
+
+                UpdateListMetadata(items.Count);
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorF("ItemFE6View.LoadList failed: {0}", ex.Message);
+            }
         }
 
         void UpdateListMetadata(int count)

--- a/FEBuilderGBA.Avalonia/Views/ItemFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemFE6View.axaml.cs
@@ -92,10 +92,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void OnLanguageChanged()
         {
-            if (Dispatcher.UIThread.CheckAccess())
-                RefreshForLanguage();
-            else
-                Dispatcher.UIThread.Post(RefreshForLanguage);
+            Dispatcher.UIThread.Post(RefreshForLanguage);
         }
 
         void RefreshForLanguage()

--- a/FEBuilderGBA.Avalonia/Views/ItemFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemFE6View.axaml.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using global::Avalonia.Controls;
 using global::Avalonia.Input;
 using global::Avalonia.Interactivity;
+using global::Avalonia.Threading;
 using FEBuilderGBA.Avalonia.Controls;
 using FEBuilderGBA.Avalonia.Services;
 using FEBuilderGBA.Avalonia.ViewModels;
@@ -90,6 +91,14 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         void OnLanguageChanged()
+        {
+            if (Dispatcher.UIThread.CheckAccess())
+                RefreshForLanguage();
+            else
+                Dispatcher.UIThread.Post(RefreshForLanguage);
+        }
+
+        void RefreshForLanguage()
         {
             RefreshWeaponTypeList(GetSelectedWeaponTypeId());
         }

--- a/FEBuilderGBA.Avalonia/Views/ItemFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemFE6View.axaml.cs
@@ -52,6 +52,8 @@ namespace FEBuilderGBA.Avalonia.Views
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {
             base.OnAttachedToVisualTree(e);
+            CoreState.LanguageChanged -= OnLanguageChanged;
+            CoreState.LanguageChanged += OnLanguageChanged;
             if (!_hasLoadedList)
             {
                 _hasLoadedList = true;
@@ -59,13 +61,18 @@ namespace FEBuilderGBA.Avalonia.Views
             }
         }
 
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            CoreState.LanguageChanged -= OnLanguageChanged;
+            base.OnDetachedFromVisualTree(e);
+        }
+
         void LoadList()
         {
             try
             {
                 // Populate combo dropdown BEFORE SetItems.
-                _weaponTypeList = ComboResourceHelper.MakeWeaponTypeList();
-                WeaponTypeCombo.ItemsSource = _weaponTypeList.Select(x => x.name).ToList();
+                RefreshWeaponTypeList();
 
                 var items = _vm.LoadItemList();
                 EntryList.SetItemsWithIcons(items, i => ListIconLoaders.ItemIconLoader(items, i));
@@ -76,6 +83,28 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 Log.ErrorF("ItemFE6View.LoadList failed: {0}", ex.Message);
             }
+        }
+
+        void OnLanguageChanged()
+        {
+            RefreshWeaponTypeList(GetSelectedWeaponTypeId());
+        }
+
+        uint GetSelectedWeaponTypeId()
+        {
+            int selectedIndex = WeaponTypeCombo.SelectedIndex;
+            return selectedIndex >= 0 && selectedIndex < _weaponTypeList.Count
+                ? _weaponTypeList[selectedIndex].id
+                : _vm.WeaponType;
+        }
+
+        void RefreshWeaponTypeList(uint? selectedId = null)
+        {
+            _weaponTypeList = ComboResourceHelper.MakeWeaponTypeList(selectedId);
+            WeaponTypeCombo.ItemsSource = _weaponTypeList.Select(x => x.name).ToList();
+            WeaponTypeCombo.SelectedIndex = selectedId.HasValue
+                ? _weaponTypeList.FindIndex(x => x.id == selectedId.Value)
+                : -1;
         }
 
         void UpdateListMetadata(int count)
@@ -196,9 +225,7 @@ namespace FEBuilderGBA.Avalonia.Views
             UseDescTextLabel.Text = _vm.UseDescText;
             ItemNumberBox.Value = _vm.ItemNumber;
 
-            // Weapon type combo
-            int wtIdx = _weaponTypeList.FindIndex(x => x.id == _vm.WeaponType);
-            WeaponTypeCombo.SelectedIndex = wtIdx >= 0 ? wtIdx : (int)_vm.WeaponType;
+            RefreshWeaponTypeList(_vm.WeaponType);
 
             // Trait flags (BitFlagPanel) + hex preview labels (#402 mirrors
             // WF "特性1/2/3/4" plus the raw-byte readout).
@@ -462,35 +489,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void Write_Click(object? sender, RoutedEventArgs e)
         {
-            // Read UI values into the ViewModel.
-            _vm.NameId = (uint)(NameIdBox.Value ?? 0);
-            _vm.DescId = (uint)(DescIdBox.Value ?? 0);
-            _vm.UseDescId = (uint)(UseDescIdBox.Value ?? 0);
-            _vm.ItemNumber = (uint)(ItemNumberBox.Value ?? 0);
-
-            // Weapon type from combo.
-            int wtIdx = WeaponTypeCombo.SelectedIndex;
-            _vm.WeaponType = wtIdx >= 0 && wtIdx < _weaponTypeList.Count ? _weaponTypeList[wtIdx].id : 0;
-
-            // Trait flags from BitFlagPanel + raw NumericUpDown.
-            _vm.Trait1 = Trait1Flags.Value;
-            _vm.Trait2 = Trait2Flags.Value;
-            _vm.Trait3 = (uint)(Trait3Box.Value ?? 0);
-            _vm.Trait4 = (uint)(Trait4Box.Value ?? 0);
-
-            _vm.StatBonusesPtr = ParseHexText(StatBonusesPtrBox.Text);
-            _vm.EffectivenessPtr = ParseHexText(EffectivenessPtrBox.Text);
-            _vm.Uses = (uint)(UsesBox.Value ?? 0);
-            _vm.Might = (uint)(MightBox.Value ?? 0);
-            _vm.Hit = (uint)(HitBox.Value ?? 0);
-            _vm.Weight = (uint)(WeightBox.Value ?? 0);
-            _vm.Crit = (uint)(CritBox.Value ?? 0);
-            _vm.Range = (uint)(RangeBox.Value ?? 0);
-            _vm.Price = (uint)(PriceBox.Value ?? 0);
-            _vm.WeaponRank = (uint)(WeaponRankBox.Value ?? 0);
-            _vm.Icon = (uint)(IconBox.Value ?? 0);
-            _vm.UsageEffect = (uint)(UsageEffectBox.Value ?? 0);
-            _vm.DamageEffect = (uint)(DamageEffectBox.Value ?? 0);
+            ReadFromUI();
 
             _undoService.Begin("Edit Item (FE6)");
             try
@@ -518,6 +517,39 @@ namespace FEBuilderGBA.Avalonia.Views
                 _undoService.Rollback();
                 Log.ErrorF("Write failed: {0}", ex.Message);
             }
+        }
+
+        void ReadFromUI()
+        {
+            _vm.NameId = (uint)(NameIdBox.Value ?? 0);
+            _vm.DescId = (uint)(DescIdBox.Value ?? 0);
+            _vm.UseDescId = (uint)(UseDescIdBox.Value ?? 0);
+            _vm.ItemNumber = (uint)(ItemNumberBox.Value ?? 0);
+
+            // Weapon type from combo.
+            int wtIdx = WeaponTypeCombo.SelectedIndex;
+            if (wtIdx >= 0 && wtIdx < _weaponTypeList.Count)
+                _vm.WeaponType = _weaponTypeList[wtIdx].id;
+
+            // Trait flags from BitFlagPanel + raw NumericUpDown.
+            _vm.Trait1 = Trait1Flags.Value;
+            _vm.Trait2 = Trait2Flags.Value;
+            _vm.Trait3 = (uint)(Trait3Box.Value ?? 0);
+            _vm.Trait4 = (uint)(Trait4Box.Value ?? 0);
+
+            _vm.StatBonusesPtr = ParseHexText(StatBonusesPtrBox.Text);
+            _vm.EffectivenessPtr = ParseHexText(EffectivenessPtrBox.Text);
+            _vm.Uses = (uint)(UsesBox.Value ?? 0);
+            _vm.Might = (uint)(MightBox.Value ?? 0);
+            _vm.Hit = (uint)(HitBox.Value ?? 0);
+            _vm.Weight = (uint)(WeightBox.Value ?? 0);
+            _vm.Crit = (uint)(CritBox.Value ?? 0);
+            _vm.Range = (uint)(RangeBox.Value ?? 0);
+            _vm.Price = (uint)(PriceBox.Value ?? 0);
+            _vm.WeaponRank = (uint)(WeaponRankBox.Value ?? 0);
+            _vm.Icon = (uint)(IconBox.Value ?? 0);
+            _vm.UsageEffect = (uint)(UsageEffectBox.Value ?? 0);
+            _vm.DamageEffect = (uint)(DamageEffectBox.Value ?? 0);
         }
 
         // #831: new-alloc the StatBooster (P12) block — mirrors WF

--- a/FEBuilderGBA.Avalonia/Views/ItemFE6View.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ItemFE6View.axaml.cs
@@ -59,6 +59,10 @@ namespace FEBuilderGBA.Avalonia.Views
                 _hasLoadedList = true;
                 LoadList();
             }
+            else
+            {
+                OnLanguageChanged();
+            }
         }
 
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)

--- a/FEBuilderGBA.Core.Tests/ComboResourceHelperTests.cs
+++ b/FEBuilderGBA.Core.Tests/ComboResourceHelperTests.cs
@@ -41,6 +41,15 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void MakeWeaponTypeList_IncludesUnknownCurrentId()
+        {
+            var list = ComboResourceHelper.MakeWeaponTypeList(0x08);
+
+            Assert.Equal(14, list.Count);
+            Assert.Equal((0x08u, "08 Unknown"), list[^1]);
+        }
+
+        [Fact]
         public void MakeUnitList_NoRom_ReturnsEmpty()
         {
             ROM? oldRom = CoreState.ROM;

--- a/FEBuilderGBA.Core.Tests/ComboResourceHelperTests.cs
+++ b/FEBuilderGBA.Core.Tests/ComboResourceHelperTests.cs
@@ -20,24 +20,15 @@ namespace FEBuilderGBA.Core.Tests
         {
             var list = ComboResourceHelper.MakeWeaponTypeList();
 
-            var expected = new (uint id, string name)[]
+            uint[] expectedIds =
             {
-                (0x00, "00 Sword"),
-                (0x01, "01 Lance"),
-                (0x02, "02 Axe"),
-                (0x03, "03 Bow"),
-                (0x04, "04 Staff"),
-                (0x05, "05 Anima"),
-                (0x06, "06 Light"),
-                (0x07, "07 Dark"),
-                (0x09, "09 Item"),
-                (0x0B, "0B Dragonstone/Monster Weapon"),
-                (0x0C, "0C Ring"),
-                (0x11, "11 Dragonstone"),
-                (0x12, "12 Dancer's Ring"),
+                0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+                0x07, 0x09, 0x0B, 0x0C, 0x11, 0x12,
             };
 
-            Assert.Equal(expected, list);
+            Assert.Equal(expectedIds, list.Select(x => x.id));
+            Assert.All(list, entry =>
+                Assert.StartsWith($"{U.ToHexString(entry.id)} ", entry.name));
         }
 
         [Fact]
@@ -46,7 +37,8 @@ namespace FEBuilderGBA.Core.Tests
             var list = ComboResourceHelper.MakeWeaponTypeList(0x08);
 
             Assert.Equal(14, list.Count);
-            Assert.Equal((0x08u, "08 Unknown"), list[^1]);
+            Assert.Equal(0x08u, list[^1].id);
+            Assert.StartsWith("08 ", list[^1].name);
         }
 
         [Fact]

--- a/FEBuilderGBA.Core.Tests/ComboResourceHelperTests.cs
+++ b/FEBuilderGBA.Core.Tests/ComboResourceHelperTests.cs
@@ -16,12 +16,28 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
-        public void MakeWeaponTypeList_ReturnsExpectedEntries()
+        public void MakeWeaponTypeList_ReturnsCanonicalSparseEntries()
         {
             var list = ComboResourceHelper.MakeWeaponTypeList();
-            Assert.Equal(9, list.Count);
-            Assert.Contains("Sword", list[0].name);
-            Assert.Contains("Staff", list[4].name);
+
+            var expected = new (uint id, string name)[]
+            {
+                (0x00, "00 Sword"),
+                (0x01, "01 Lance"),
+                (0x02, "02 Axe"),
+                (0x03, "03 Bow"),
+                (0x04, "04 Staff"),
+                (0x05, "05 Anima"),
+                (0x06, "06 Light"),
+                (0x07, "07 Dark"),
+                (0x09, "09 Item"),
+                (0x0B, "0B Dragonstone/Monster Weapon"),
+                (0x0C, "0C Ring"),
+                (0x11, "11 Dragonstone"),
+                (0x12, "12 Dancer's Ring"),
+            };
+
+            Assert.Equal(expected, list);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary  - Restore the canonical 13-entry sparse item weapon-type mapping used by the stable WinForms editor. - Preserve non-canonical raw B7 bytes with a localized synthetic tuple instead of aliasing them through combo indices. - Refresh dynamically populated weapon-type labels on language changes in both FE6 and FE7/FE8 Avalonia item editors, including after detached reattachment. - Queue language-driven control refreshes on the Avalonia UI dispatcher behind the base AXAML translation pass. - Pin canonical IDs, unknown-value round trips, reattachment refresh, background-thread safety, and UI-thread queue ordering in regression tests.  Accepted plans: - Original: https://github.com/laqieer/FEBuilderGBA/issues/2146#issuecomment-5530856064 - Amended after review: https://github.com/laqieer/FEBuilderGBA/issues/2146#issuecomment-5531593771  Closes #2146  ## Test plan  - [x] Focused helper and view regressions: 7 passed. - [x] `FEBuilderGBA.Core.Tests` excluding the unrelated nested-submodule dead-link scan: 7,601 passed, 19 skipped. - [x] `FEBuilderGBA.Avalonia.Tests`: 9,919 passed, 11 skipped.
- [x] FEBuilderGBA.Tests combo initialization contract: 3 passed. - [x] `FEBuilderGBA.Avalonia` Release build: 0 warnings, 0 errors. - [x] Real `ItemEditorView` GUI validation with Avalonia's Skia renderer: 13 canonical entries loaded and the final `0x12` selection rendered successfully.  The excluded Core test (`DeadWikiLinkTests.NoSourceFile_ReferencesDeadDokuWikiHost`) independently fails on an unchanged URL inside the recursively initialized `DirectPlayS` resource submodule; it is outside this PR.  ## GUI Test Report  - **Surface:** Avalonia Item Editor, Type (B7) combo. - **Environment:** repository Avalonia test host with Skia rasterization, 1200x780, no ROM required. - **Result:** the actual `ItemEditorView` rendered the final `0x12` Dancer's Ring selection; automated view tests prove unknown `0x08`/`0x0A` values survive round trips, selected IDs survive detached language refresh, background notifications are dispatcher-safe, and custom labels refresh after the base translation pass.  ![Item Editor Type B7 showing 12 Dancer's Ring](https://github.com/user-attachments/assets/e970bd49-03e2-4f4c-9467-533c85928e9f)  Copilot CLI: 1.0.79 Model: GPT-5.6 Sol (gpt-5.6-sol)