### PR TITLE
fix(avalonia): surface unit palette write results

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteImageIOTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteImageIOTests.cs
@@ -578,6 +578,29 @@ namespace FEBuilderGBA.Avalonia.Tests
             Assert.False(vm.Write());
         }
 
+        [Fact]
+        public void ViewModelWrite_OverflowAddress_ReturnsFalse()
+        {
+            ROM? previousRom = CoreState.ROM;
+            try
+            {
+                var rom = new ROM();
+                rom.SwapNewROMDataDirect(new byte[0x100]);
+                CoreState.ROM = rom;
+                var vm = new ImageUnitPaletteViewModel
+                {
+                    CanWrite = true,
+                    CurrentAddr = uint.MaxValue - 8,
+                };
+
+                Assert.False(vm.Write());
+            }
+            finally
+            {
+                CoreState.ROM = previousRom;
+            }
+        }
+
         // ===================== helpers =====================
 
         static void EnsureImageService()

--- a/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteImageIOTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteImageIOTests.cs
@@ -187,6 +187,7 @@ namespace FEBuilderGBA.Avalonia.Tests
                 {
                     bool ok = (bool)Invoke(view, "ImportFromFile", imgPath)!;
                     Assert.True(ok);
+                    Assert.False(vm.IsDirty);
 
                     // Assert the 16 NUD triples equal the source palette IN INDEX
                     // ORDER (ordered equality — guards CORRECTION 3b).
@@ -323,6 +324,27 @@ namespace FEBuilderGBA.Avalonia.Tests
                     view, "ImageUnitPalette_PaletteWrite_Button")!.IsEnabled);
                 Assert.True(FindByAutomationId<Button>(
                     view, "ImageUnitPalette_Import_Button")!.IsEnabled);
+            }
+            finally
+            {
+                CoreState.ROM = previousRom;
+            }
+        }
+
+        [AvaloniaFact]
+        public void PaletteColorEdit_MarksViewModelDirty()
+        {
+            EnsureImageService();
+            ROM? previousRom = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = MakeRom(out _);
+                var view = OpenViewWithSelection(out var vm);
+                vm.MarkClean();
+
+                NUD(view, "R", 0).Value = 31;
+
+                Assert.True(vm.IsDirty);
             }
             finally
             {
@@ -556,6 +578,7 @@ namespace FEBuilderGBA.Avalonia.Tests
                 Assert.Equal(r5, (uint)(NUD(view, "R", 0).Value ?? -1));
                 Assert.Equal(g5, (uint)(NUD(view, "G", 0).Value ?? -1));
                 Assert.Equal(b5, (uint)(NUD(view, "B", 0).Value ?? -1));
+                Assert.True(vm.IsDirty);
                 Assert.Equal(R._(
                     "Palette area has not been allocated. Use New Palette Allocation first."),
                     services.LastError);

--- a/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteImageIOTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteImageIOTests.cs
@@ -31,6 +31,19 @@ namespace FEBuilderGBA.Avalonia.Tests
     [Collection("SharedState")]
     public class ImageUnitPaletteImageIOTests
     {
+        sealed class RecordingServices : IAppServices
+        {
+            public string? LastError { get; private set; }
+            public string? LastInfo { get; private set; }
+
+            public void ShowError(string message) => LastError = message;
+            public void ShowInfo(string message) => LastInfo = message;
+            public bool ShowQuestion(string message) => false;
+            public bool ShowYesNo(string message) => false;
+            public void RunOnUIThread(Action action) => action();
+            public bool IsMainThread() => true;
+        }
+
         // ----- control lookup helpers -----
 
         static T? FindByAutomationId<T>(Control root, string automationId) where T : Control
@@ -44,7 +57,7 @@ namespace FEBuilderGBA.Avalonia.Tests
         // ----- wiring parity (regex-declaration style, not hard-coded signature) -----
 
         [AvaloniaFact]
-        public void ExportImport_Buttons_Enabled_And_Handlers_Wired()
+        public void ExportImport_Buttons_HaveExpectedInitialState_AndHandlersWired()
         {
             var view = new ImageUnitPaletteView();
             var export = FindByAutomationId<Button>(view, "ImageUnitPalette_Export_Button");
@@ -52,7 +65,7 @@ namespace FEBuilderGBA.Avalonia.Tests
             Assert.NotNull(export);
             Assert.NotNull(import);
             Assert.True(export!.IsEnabled);
-            Assert.True(import!.IsEnabled);
+            Assert.False(import!.IsEnabled);
 
             // Source-level declaration check: the handlers exist and are wired in
             // AXAML (regex over the source, not a hard-coded reflection signature
@@ -276,6 +289,246 @@ namespace FEBuilderGBA.Avalonia.Tests
                 finally { if (File.Exists(imgPath)) File.Delete(imgPath); }
             }
             finally { CoreState.ROM = prev; }
+        }
+
+        [AvaloniaFact]
+        public void WriteCommands_AreDisabledUntilSelection()
+        {
+            EnsureImageService();
+            var rom = MakeRom(out _);
+            ROM? previousRom = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = rom;
+                var view = new ImageUnitPaletteView();
+                Invoke(view, "CacheSwatchControls");
+
+                Assert.False(FindByAutomationId<Button>(
+                    view, "ImageUnitPalette_Write_Button")!.IsEnabled);
+                Assert.False(FindByAutomationId<Button>(
+                    view, "ImageUnitPalette_PaletteWrite_Button")!.IsEnabled);
+                Assert.False(FindByAutomationId<Button>(
+                    view, "ImageUnitPalette_Import_Button")!.IsEnabled);
+
+                var vm = (ImageUnitPaletteViewModel)Field(view, "_vm")!;
+                var entryList = view.FindControl<AddressListControl>("EntryList")!;
+                entryList.SetItems(vm.LoadList());
+                Pump(view);
+                entryList.SelectByIndex(0);
+                Pump(view);
+
+                Assert.True(FindByAutomationId<Button>(
+                    view, "ImageUnitPalette_Write_Button")!.IsEnabled);
+                Assert.True(FindByAutomationId<Button>(
+                    view, "ImageUnitPalette_PaletteWrite_Button")!.IsEnabled);
+                Assert.True(FindByAutomationId<Button>(
+                    view, "ImageUnitPalette_Import_Button")!.IsEnabled);
+            }
+            finally
+            {
+                CoreState.ROM = previousRom;
+            }
+        }
+
+        [AvaloniaFact]
+        public void Write_NoSelection_ReportsErrorAndPreservesDirtyState()
+        {
+            ROM? previousRom = CoreState.ROM;
+            Undo? previousUndo = CoreState.Undo;
+            IAppServices? previousServices = CoreState.Services;
+            try
+            {
+                CoreState.ROM = MakeRom(out _);
+                CoreState.Undo = new Undo();
+                var services = new RecordingServices();
+                CoreState.Services = services;
+                var view = new ImageUnitPaletteView();
+                var vm = (ImageUnitPaletteViewModel)Field(view, "_vm")!;
+                vm.Id0 = 0x41;
+                Assert.True(vm.IsDirty);
+
+                Invoke(view, "Write_Click", null!,
+                    new global::Avalonia.Interactivity.RoutedEventArgs());
+
+                Assert.Contains("Select a palette entry", services.LastError);
+                Assert.Null(services.LastInfo);
+                Assert.True(vm.IsDirty);
+                Assert.False(CoreState.Undo.IsModified);
+            }
+            finally
+            {
+                CoreState.ROM = previousRom;
+                CoreState.Undo = previousUndo;
+                CoreState.Services = previousServices;
+            }
+        }
+
+        [AvaloniaFact]
+        public void Write_ValidSelection_WritesAndShowsConfirmation()
+        {
+            EnsureImageService();
+            ROM? previousRom = CoreState.ROM;
+            Undo? previousUndo = CoreState.Undo;
+            IAppServices? previousServices = CoreState.Services;
+            try
+            {
+                ROM rom = MakeRom(out _);
+                CoreState.ROM = rom;
+                CoreState.Undo = new Undo();
+                var services = new RecordingServices();
+                CoreState.Services = services;
+                var view = OpenViewWithSelection(out _);
+                view.FindControl<NumericUpDown>("Id0Box")!.Value = 0x41;
+
+                Invoke(view, "Write_Click", null!,
+                    new global::Avalonia.Interactivity.RoutedEventArgs());
+
+                Assert.Equal(0x41u, rom.u8(UNITPAL_BASE));
+                Assert.Null(services.LastError);
+                Assert.Equal("Palette written.", services.LastInfo);
+            }
+            finally
+            {
+                CoreState.ROM = previousRom;
+                CoreState.Undo = previousUndo;
+                CoreState.Services = previousServices;
+            }
+        }
+
+        [AvaloniaFact]
+        public void PaletteWrite_InvalidSource_ReportsAllocationGuidance()
+        {
+            EnsureImageService();
+            ROM? previousRom = CoreState.ROM;
+            Undo? previousUndo = CoreState.Undo;
+            IAppServices? previousServices = CoreState.Services;
+            try
+            {
+                ROM rom = MakeRom(out uint p12Offset);
+                U.write_u32(rom.Data, p12Offset, 0);
+                byte[] before = rom.Data.ToArray();
+                CoreState.ROM = rom;
+                CoreState.Undo = new Undo();
+                var services = new RecordingServices();
+                CoreState.Services = services;
+
+                var view = new ImageUnitPaletteView();
+                Invoke(view, "CacheSwatchControls");
+                var vm = (ImageUnitPaletteViewModel)Field(view, "_vm")!;
+                vm.IsLoading = true;
+                vm.LoadEntry(UNITPAL_BASE);
+                vm.IsLoading = false;
+                vm.MarkClean();
+                Invoke(view, "UpdateUI");
+                vm.Id0 = 0x41;
+                Assert.True(vm.IsDirty);
+
+                bool ok = (bool)Invoke(view, "PerformPaletteWrite")!;
+
+                Assert.False(ok);
+                Assert.Equal(R._(
+                    "Palette area has not been allocated. Use New Palette Allocation first."),
+                    services.LastError);
+                Assert.Null(services.LastInfo);
+                Assert.True(vm.IsDirty);
+                Assert.True(before.SequenceEqual(rom.Data));
+            }
+            finally
+            {
+                CoreState.ROM = previousRom;
+                CoreState.Undo = previousUndo;
+                CoreState.Services = previousServices;
+            }
+        }
+
+        [AvaloniaFact]
+        public void PaletteWrite_ValidSource_WritesAndShowsConfirmation()
+        {
+            EnsureImageService();
+            ROM? previousRom = CoreState.ROM;
+            Undo? previousUndo = CoreState.Undo;
+            IAppServices? previousServices = CoreState.Services;
+            try
+            {
+                ROM rom = MakeRom(out uint p12Offset);
+                CoreState.ROM = rom;
+                CoreState.Undo = new Undo();
+                var services = new RecordingServices();
+                CoreState.Services = services;
+                var view = OpenViewWithSelection(out _);
+                NUD(view, "R", 0).Value = 31;
+
+                bool ok = (bool)Invoke(view, "PerformPaletteWrite")!;
+
+                Assert.True(ok);
+                byte[] raw = LZ77.decompress(
+                    rom.Data, U.toOffset(rom.u32(p12Offset)));
+                Assert.Equal(31u, (uint)(raw[0] & 0x1F));
+                Assert.Null(services.LastError);
+                Assert.Equal("Palette written.", services.LastInfo);
+            }
+            finally
+            {
+                CoreState.ROM = previousRom;
+                CoreState.Undo = previousUndo;
+                CoreState.Services = previousServices;
+            }
+        }
+
+        [AvaloniaFact]
+        public void Import_WriteFailure_ReturnsFalseAndReportsError()
+        {
+            EnsureImageService();
+            ROM? previousRom = CoreState.ROM;
+            Undo? previousUndo = CoreState.Undo;
+            IAppServices? previousServices = CoreState.Services;
+            string? imagePath = null;
+            try
+            {
+                ROM rom = MakeRom(out uint p12Offset);
+                U.write_u32(rom.Data, p12Offset, 0);
+                CoreState.ROM = rom;
+                CoreState.Undo = new Undo();
+                var services = new RecordingServices();
+                CoreState.Services = services;
+
+                var view = new ImageUnitPaletteView();
+                Invoke(view, "CacheSwatchControls");
+                var vm = (ImageUnitPaletteViewModel)Field(view, "_vm")!;
+                vm.IsLoading = true;
+                vm.LoadEntry(UNITPAL_BASE);
+                vm.IsLoading = false;
+                vm.MarkClean();
+                Invoke(view, "UpdateUI");
+
+                imagePath = WriteIndexedPng(MakeKnownColors());
+                bool ok = (bool)Invoke(view, "ImportFromFile", imagePath)!;
+
+                Assert.False(ok);
+                var (r5, g5, b5) = Rgb555(MakeKnownColors()[0]);
+                Assert.Equal(r5, (uint)(NUD(view, "R", 0).Value ?? -1));
+                Assert.Equal(g5, (uint)(NUD(view, "G", 0).Value ?? -1));
+                Assert.Equal(b5, (uint)(NUD(view, "B", 0).Value ?? -1));
+                Assert.Equal(R._(
+                    "Palette area has not been allocated. Use New Palette Allocation first."),
+                    services.LastError);
+                Assert.Null(services.LastInfo);
+            }
+            finally
+            {
+                if (imagePath != null && File.Exists(imagePath))
+                    File.Delete(imagePath);
+                CoreState.ROM = previousRom;
+                CoreState.Undo = previousUndo;
+                CoreState.Services = previousServices;
+            }
+        }
+
+        [Fact]
+        public void ViewModelWrite_ReturnsFalseWithoutSelection()
+        {
+            var vm = new ImageUnitPaletteViewModel();
+            Assert.False(vm.Write());
         }
 
         // ===================== helpers =====================

--- a/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteImageIOTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteImageIOTests.cs
@@ -331,6 +331,53 @@ namespace FEBuilderGBA.Avalonia.Tests
         }
 
         [AvaloniaFact]
+        public void FilterClearingSelection_DisablesCommandsAndBlocksStaleWrite()
+        {
+            EnsureImageService();
+            ROM? previousRom = CoreState.ROM;
+            Undo? previousUndo = CoreState.Undo;
+            IAppServices? previousServices = CoreState.Services;
+            try
+            {
+                ROM rom = MakeRom(out _);
+                CoreState.ROM = rom;
+                CoreState.Undo = new Undo();
+                var services = new RecordingServices();
+                CoreState.Services = services;
+                var view = OpenViewWithSelection(out var vm);
+                var entryList = view.FindControl<AddressListControl>("EntryList")!;
+                uint originalId0 = rom.u8(UNITPAL_BASE);
+                view.FindControl<NumericUpDown>("Id0Box")!.Value = 0x41;
+
+                entryList.ApplySearchFilter("no matching palette");
+                Pump(view);
+
+                Assert.Null(entryList.SelectedItem);
+                Assert.Equal(0u, vm.CurrentAddr);
+                Assert.False(vm.CanWrite);
+                Assert.False(FindByAutomationId<Button>(
+                    view, "ImageUnitPalette_Write_Button")!.IsEnabled);
+                Assert.False(FindByAutomationId<Button>(
+                    view, "ImageUnitPalette_PaletteWrite_Button")!.IsEnabled);
+                Assert.False(FindByAutomationId<Button>(
+                    view, "ImageUnitPalette_Import_Button")!.IsEnabled);
+
+                Invoke(view, "Write_Click", null!,
+                    new global::Avalonia.Interactivity.RoutedEventArgs());
+
+                Assert.Equal(originalId0, rom.u8(UNITPAL_BASE));
+                Assert.Contains("Select a palette entry", services.LastError);
+                Assert.False(CoreState.Undo.IsModified);
+            }
+            finally
+            {
+                CoreState.ROM = previousRom;
+                CoreState.Undo = previousUndo;
+                CoreState.Services = previousServices;
+            }
+        }
+
+        [AvaloniaFact]
         public void Write_NoSelection_ReportsErrorAndPreservesDirtyState()
         {
             ROM? previousRom = CoreState.ROM;

--- a/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteParityTests.cs
@@ -137,6 +137,22 @@ namespace FEBuilderGBA.Avalonia.Tests
             Assert.NotNull(FindByAutomationId<Button>(view, "ImageUnitPalette_REDO_Button"));
         }
 
+        [Fact]
+        public void Axaml_WriteCommands_StartDisabledUntilSelection()
+        {
+            string axaml = ReadViewAxaml();
+            foreach (string automationId in new[]
+            {
+                "ImageUnitPalette_Write_Button",
+                "ImageUnitPalette_PaletteWrite_Button",
+                "ImageUnitPalette_Import_Button",
+            })
+            {
+                Assert.Contains("IsEnabled=\"False\"",
+                    ExtractElement(axaml, automationId));
+            }
+        }
+
         [AvaloniaFact]
         public void View_Has_Three_Tabs()
         {

--- a/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteParityTests.cs
@@ -805,17 +805,18 @@ namespace FEBuilderGBA.Avalonia.Tests
         }
 
         [Fact]
-        public void View_RgbValueChanged_RefreshesSamplePreview_GuardedByIsLoading()
+        public void View_RgbValueChanged_MarksDirtyAndRefreshesPreview_WhenNotLoading()
         {
-            // The R/G/B ValueChanged handlers must call RefreshSamplePreview()
-            // guarded by !_vm.IsLoading (the bulk-load suppression).
+            // The R/G/B ValueChanged handlers share one helper so each genuine
+            // user edit marks dirty and refreshes the sample, while bulk loads
+            // still return before either action.
             string src = ReadViewSource();
-            Assert.Contains("if (!_vm.IsLoading) RefreshSamplePreview()", src);
-            // All three channels (R/G/B) wire the guarded refresh.
-            int guarded = System.Text.RegularExpressions.Regex.Matches(
-                src, @"if \(!_vm\.IsLoading\) RefreshSamplePreview\(\)").Count;
-            Assert.True(guarded >= 3,
-                $"expected R/G/B (>=3) guarded RefreshSamplePreview calls, found {guarded}");
+            int wired = System.Text.RegularExpressions.Regex.Matches(
+                src, @"ValueChanged \+= \(_, _\) => OnPaletteColorChanged\(captureIdx\)").Count;
+            Assert.Equal(3, wired);
+            Assert.Matches(new System.Text.RegularExpressions.Regex(
+                @"void\s+OnPaletteColorChanged\(int index\)\s*\{[\s\S]*?RefreshSwatch\(index\);[\s\S]*?if \(_vm\.IsLoading\) return;[\s\S]*?_vm\.MarkDirty\(\);[\s\S]*?RefreshSamplePreview\(\);",
+                System.Text.RegularExpressions.RegexOptions.Singleline), src);
         }
 
         [Fact]

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageUnitPaletteViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageUnitPaletteViewModel.cs
@@ -231,7 +231,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         {
             ROM rom = CoreState.ROM;
             if (rom == null || !CanWrite || CurrentAddr == 0 ||
-                CurrentAddr + SIZE > (uint)rom.Data.Length)
+                (ulong)CurrentAddr + SIZE > (ulong)rom.Data.Length)
             {
                 return false;
             }

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageUnitPaletteViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageUnitPaletteViewModel.cs
@@ -227,10 +227,14 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             OnPropertyChanged(nameof(BChannel));
         }
 
-        public void Write()
+        public bool Write()
         {
             ROM rom = CoreState.ROM;
-            if (rom == null || CurrentAddr == 0) return;
+            if (rom == null || !CanWrite || CurrentAddr == 0 ||
+                CurrentAddr + SIZE > (uint)rom.Data.Length)
+            {
+                return false;
+            }
 
             uint addr = CurrentAddr;
             rom.write_u8(addr + 0, Id0);
@@ -246,6 +250,7 @@ namespace FEBuilderGBA.Avalonia.ViewModels
             rom.write_u8(addr + 10, Id10);
             rom.write_u8(addr + 11, Id11);
             rom.write_u32(addr + 12, PalettePointer);
+            return true;
         }
 
         /// <summary>

--- a/FEBuilderGBA.Avalonia/ViewModels/ViewModelBase.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ViewModelBase.cs
@@ -31,6 +31,13 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         /// <summary>Reset dirty state (call after save or initial load).</summary>
         public void MarkClean() => IsDirty = false;
 
+        /// <summary>Mark a non-property editor change as dirty.</summary>
+        public void MarkDirty()
+        {
+            if (!IsLoading)
+                IsDirty = true;
+        }
+
         protected void OnPropertyChanged([CallerMemberName] string? name = null)
             => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
 

--- a/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml
+++ b/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml
@@ -96,7 +96,8 @@
                         ToolTip.Tip="Allocate a fresh palette block in free space and repoint this slot's P12" />
 
                 <Button AutomationProperties.AutomationId="ImageUnitPalette_Write_Button"
-                        Content="Write" Name="WriteButton" Click="Write_Click" Margin="0,8,0,0" />
+                        Content="Write" Name="WriteButton" Click="Write_Click"
+                        IsEnabled="False" Margin="0,8,0,0" />
               </StackPanel>
 
               <!-- Right half: class selector + battle-anime sample preview (#840),
@@ -346,13 +347,15 @@
 
               <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,12,0,0">
                 <Button AutomationProperties.AutomationId="ImageUnitPalette_PaletteWrite_Button"
-                        Content="Palette Write" Name="PaletteWriteButton" Click="PaletteWrite_Click" />
+                        Content="Palette Write" Name="PaletteWriteButton"
+                        IsEnabled="False" Click="PaletteWrite_Click" />
                 <Button AutomationProperties.AutomationId="ImageUnitPalette_Clipboard_Button"
                         Content="Clipboard" Name="ClipboardButton" Click="Clipboard_Click" />
                 <Button AutomationProperties.AutomationId="ImageUnitPalette_Export_Button"
                         Content="Export Image" Name="ExportImageButton" Click="ExportImage_Click" />
                 <Button AutomationProperties.AutomationId="ImageUnitPalette_Import_Button"
-                        Content="Import Image" Name="ImportImageButton" Click="ImportImage_Click" />
+                        Content="Import Image" Name="ImportImageButton"
+                        IsEnabled="False" Click="ImportImage_Click" />
                 <Button AutomationProperties.AutomationId="ImageUnitPalette_UNDO_Button"
                         Content="UNDO" Name="UndoButton" Click="Undo_Click" />
                 <Button AutomationProperties.AutomationId="ImageUnitPalette_REDO_Button"

--- a/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml.cs
@@ -37,7 +37,7 @@ namespace FEBuilderGBA.Avalonia.Views
         public ImageUnitPaletteView()
         {
             InitializeComponent();
-            EntryList.SelectedAddressChanged += OnSelected;
+            EntryList.SelectedItemChanged += OnSelectedItemChanged;
 
             // Populate the preview sub-palette combo via R._() so it picks up
             // ja/zh translations (ComboBoxItem.Content is not touched by
@@ -147,6 +147,7 @@ namespace FEBuilderGBA.Avalonia.Views
             {
                 _vm.CurrentAddr = 0;
                 _vm.CanWrite = false;
+                _vm.IsLoaded = false;
                 UpdateWriteCommandState();
                 var items = _vm.LoadList();
                 EntryList.SetItems(items);
@@ -158,6 +159,37 @@ namespace FEBuilderGBA.Avalonia.Views
                 Log.ErrorF("ImageUnitPaletteView.LoadList failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
+        }
+
+        void OnSelectedItemChanged(AddrResult? item)
+        {
+            if (item == null)
+            {
+                ClearSelectedEntry();
+                return;
+            }
+            OnSelected(item.addr);
+        }
+
+        void ClearSelectedEntry()
+        {
+            bool wasLoading = _vm.IsLoading;
+            _vm.IsLoading = true;
+            try
+            {
+                _vm.CurrentAddr = 0;
+                _vm.CanWrite = false;
+                _vm.IsLoaded = false;
+                _vm.SelectedPaletteSlot = 0;
+            }
+            finally
+            {
+                _vm.IsLoading = wasLoading;
+            }
+
+            AddrLabel.Text = "";
+            SelectedAddressBox.Text = "";
+            UpdateWriteCommandState();
         }
 
         void OnSelected(uint addr)
@@ -601,9 +633,11 @@ namespace FEBuilderGBA.Avalonia.Views
         /// Dialog-free import core (testable seam): load the image, run the
         /// ≤16-color guard + ordered extraction, populate the NumericUpDowns,
         /// then reuse the ROM write. Returns <c>true</c> when the palette was
-        /// applied + written; <c>false</c> when the image was rejected (no UI
-        /// or ROM change). The <see cref="ImportImage_Click"/> handler owns the
-        /// pre-checks (selected entry, image service) + file dialog.
+        /// applied + written. Returns <c>false</c> when the image was rejected
+        /// before changing UI/ROM state, or when the imported control values
+        /// were retained but the ROM write failed. The
+        /// <see cref="ImportImage_Click"/> handler owns the pre-checks (selected
+        /// entry, image service) + file dialog.
         /// </summary>
         internal bool ImportFromFile(string path)
         {

--- a/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml.cs
@@ -134,10 +134,18 @@ namespace FEBuilderGBA.Avalonia.Views
                 // around their 48-spinner writes) so a single entry-load/import
                 // fires ZERO per-spinner renders — the load path runs ONE final
                 // RefreshSamplePreview() itself.
-                if (_rBoxes[i] != null) _rBoxes[i].ValueChanged += (_, _) => { RefreshSwatch(captureIdx); if (!_vm.IsLoading) RefreshSamplePreview(); };
-                if (_gBoxes[i] != null) _gBoxes[i].ValueChanged += (_, _) => { RefreshSwatch(captureIdx); if (!_vm.IsLoading) RefreshSamplePreview(); };
-                if (_bBoxes[i] != null) _bBoxes[i].ValueChanged += (_, _) => { RefreshSwatch(captureIdx); if (!_vm.IsLoading) RefreshSamplePreview(); };
+                if (_rBoxes[i] != null) _rBoxes[i].ValueChanged += (_, _) => OnPaletteColorChanged(captureIdx);
+                if (_gBoxes[i] != null) _gBoxes[i].ValueChanged += (_, _) => OnPaletteColorChanged(captureIdx);
+                if (_bBoxes[i] != null) _bBoxes[i].ValueChanged += (_, _) => OnPaletteColorChanged(captureIdx);
             }
+        }
+
+        void OnPaletteColorChanged(int index)
+        {
+            RefreshSwatch(index);
+            if (_vm.IsLoading) return;
+            _vm.MarkDirty();
+            RefreshSamplePreview();
         }
 
         void LoadList()
@@ -679,6 +687,7 @@ namespace FEBuilderGBA.Avalonia.Views
             // would cause a stale write. UI-only updates — no undo scope here
             // (PaletteWrite_Click owns its own).
             ApplyImportedChannels(r, g, b);
+            _vm.MarkDirty();
 
             // Reuse the existing ROM write (owns its single undo scope +
             // LZ77/repoint). #906 review: call the sender/args-free core method,

--- a/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml.cs
@@ -465,6 +465,16 @@ namespace FEBuilderGBA.Avalonia.Views
             int paletteIndex = PaletteTypeCombo.SelectedIndex;
             if (paletteIndex < 0) paletteIndex = 0;
             bool isOverrideAll = PaletteOverrideAllCheck.IsChecked ?? false;
+            ulong p12SlotValue = (ulong)_vm.CurrentAddr + 12;
+            if (p12SlotValue > uint.MaxValue ||
+                !UnitPaletteWriteCore.HasWritablePaletteSource(
+                    CoreState.ROM, (uint)p12SlotValue))
+            {
+                CoreState.Services?.ShowError(R._(
+                    "Palette area has not been allocated. Use New Palette Allocation first."));
+                return false;
+            }
+
             _undoService.Begin("Write Unit Palette");
             try
             {
@@ -482,9 +492,8 @@ namespace FEBuilderGBA.Avalonia.Views
                 if (newP12 == U.NOT_FOUND)
                 {
                     _undoService.Rollback();
-                    Log.Error("ImageUnitPaletteView.PaletteWrite: WritePalette returned NOT_FOUND (invalid pointer or LZ77 stream).");
-                    CoreState.Services?.ShowError(R._(
-                        "Palette area has not been allocated. Use New Palette Allocation first."));
+                    Log.Error("ImageUnitPaletteView.PaletteWrite: WritePalette returned NOT_FOUND.");
+                    CoreState.Services?.ShowError(R._("Failed to write palette data."));
                     return false;
                 }
                 _vm.PalettePointer = newP12;

--- a/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml.cs
@@ -67,6 +67,7 @@ namespace FEBuilderGBA.Avalonia.Views
             ClassBox.ValueChanged += OnClassChanged;
             PreviewPaletteTypeCombo.SelectionChanged += OnPreviewPaletteTypeChanged;
 
+            UpdateWriteCommandState();
         }
 
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
@@ -144,6 +145,9 @@ namespace FEBuilderGBA.Avalonia.Views
             _vm.IsLoading = true;
             try
             {
+                _vm.CurrentAddr = 0;
+                _vm.CanWrite = false;
+                UpdateWriteCommandState();
                 var items = _vm.LoadList();
                 EntryList.SetItems(items);
                 ReadStartAddressBox.Text = _vm.LoadListBaseAddress();
@@ -198,6 +202,7 @@ namespace FEBuilderGBA.Avalonia.Views
                 }
 
                 UpdateUI();
+                UpdateWriteCommandState();
                 RefreshSamplePreview();
             }
             catch (Exception ex)
@@ -205,6 +210,14 @@ namespace FEBuilderGBA.Avalonia.Views
                 Log.ErrorF("ImageUnitPaletteView.OnSelected failed: {0}", ex.Message);
             }
             finally { _vm.IsLoading = false; _vm.MarkClean(); }
+        }
+
+        void UpdateWriteCommandState()
+        {
+            bool canWrite = _vm.CanWrite && _vm.CurrentAddr != 0;
+            WriteButton.IsEnabled = canWrite;
+            PaletteWriteButton.IsEnabled = canWrite;
+            ImportImageButton.IsEnabled = canWrite;
         }
 
         void UpdateUI()
@@ -343,6 +356,12 @@ namespace FEBuilderGBA.Avalonia.Views
 
         void Write_Click(object? sender, RoutedEventArgs e)
         {
+            if (!_vm.CanWrite || _vm.CurrentAddr == 0)
+            {
+                CoreState.Services?.ShowError(R._("Select a palette entry first."));
+                return;
+            }
+
             _undoService.Begin("Edit Unit Palette");
             try
             {
@@ -359,11 +378,23 @@ namespace FEBuilderGBA.Avalonia.Views
                 _vm.Id10 = (uint)(Id10Box.Value ?? 0);
                 _vm.Id11 = (uint)(Id11Box.Value ?? 0);
                 _vm.PalettePointer = ParseHexText(PalettePointerBox.Text);
-                _vm.Write();
+                if (!_vm.Write())
+                {
+                    _undoService.Rollback();
+                    CoreState.Services?.ShowError(R._("Failed to write palette data."));
+                    return;
+                }
                 _undoService.Commit();
                 _vm.MarkClean();
+                CoreState.Services?.ShowInfo(R._("Palette written."));
             }
-            catch (Exception ex) { _undoService.Rollback(); Log.ErrorF("ImageUnitPaletteView.Write: {0}", ex.Message); }
+            catch (Exception ex)
+            {
+                _undoService.Rollback();
+                Log.ErrorF("ImageUnitPaletteView.Write: {0}", ex.Message);
+                CoreState.Services?.ShowError(
+                    $"{R._("Failed to write palette data.")} {ex.Message}");
+            }
         }
 
         /// <summary>Palette Write button handler — delegates to
@@ -387,6 +418,7 @@ namespace FEBuilderGBA.Avalonia.Views
             if (_vm.CurrentAddr == 0)
             {
                 Log.Error("ImageUnitPaletteView.PaletteWrite: no selected entry.");
+                CoreState.Services?.ShowError(R._("Select a palette entry first."));
                 return false;
             }
             var r = new uint[16];
@@ -419,6 +451,8 @@ namespace FEBuilderGBA.Avalonia.Views
                 {
                     _undoService.Rollback();
                     Log.Error("ImageUnitPaletteView.PaletteWrite: WritePalette returned NOT_FOUND (invalid pointer or LZ77 stream).");
+                    CoreState.Services?.ShowError(R._(
+                        "Palette area has not been allocated. Use New Palette Allocation first."));
                     return false;
                 }
                 _vm.PalettePointer = newP12;
@@ -426,12 +460,15 @@ namespace FEBuilderGBA.Avalonia.Views
                 PaletteAddressBox.Text = $"0x{newP12:X08}";
                 _undoService.Commit();
                 _vm.MarkClean();
+                CoreState.Services?.ShowInfo(R._("Palette written."));
                 return true;
             }
             catch (Exception ex)
             {
                 _undoService.Rollback();
                 Log.ErrorF("ImageUnitPaletteView.PaletteWrite: {0}", ex.Message);
+                CoreState.Services?.ShowError(
+                    $"{R._("Failed to write palette data.")} {ex.Message}");
                 return false;
             }
         }
@@ -603,11 +640,12 @@ namespace FEBuilderGBA.Avalonia.Views
             // Reuse the existing ROM write (owns its single undo scope +
             // LZ77/repoint). #906 review: call the sender/args-free core method,
             // NOT the event handler with null RoutedEventArgs.
-            PerformPaletteWrite();
-
-            // Refresh the sample preview to reflect the new palette.
+            bool written = PerformPaletteWrite();
+            // Keep the imported colors visible even when the ROM write fails,
+            // so the user can allocate a palette block and retry without
+            // repeating the import.
             RefreshSamplePreview();
-            return true;
+            return written;
         }
 
         /// <summary>

--- a/FEBuilderGBA.Core.Tests/UnitPaletteWriteCoreTests.cs
+++ b/FEBuilderGBA.Core.Tests/UnitPaletteWriteCoreTests.cs
@@ -171,6 +171,22 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void WritePalette_OverflowSlot_ReturnsNotFound()
+        {
+            var compressed = LZ77.compress(PackRgb555(
+                MakeUniquePalette().r,
+                MakeUniquePalette().g,
+                MakeUniquePalette().b));
+            var (rom, _, _) = BuildRomWithPaletteAt(compressed);
+            var (r, g, b) = MakeUniquePalette();
+
+            Assert.Equal(U.NOT_FOUND, UnitPaletteWriteCore.WritePalette(
+                rom, uint.MaxValue - 1, r, g, b, 0, false, undo: null));
+            Assert.False(UnitPaletteWriteCore.HasWritablePaletteSource(
+                rom, uint.MaxValue - 1));
+        }
+
+        [Fact]
         public void WritePalette_NonLZ77Source_ReturnsNotFound()
         {
             byte[] data = new byte[0x10000];
@@ -185,6 +201,24 @@ namespace FEBuilderGBA.Core.Tests
             CoreState.ROM = rom;
             var (r, g, b) = MakeUniquePalette();
             Assert.Equal(U.NOT_FOUND, UnitPaletteWriteCore.WritePalette(rom, 0x4Cu, r, g, b, 0, false, undo: null));
+        }
+
+        [Fact]
+        public void HasWritablePaletteSource_DistinguishesValidAndMissingStreams()
+        {
+            var (r, g, b) = MakeUniquePalette();
+            byte[] compressed = LZ77.compress(PackRgb555(r, g, b));
+            var (rom, _, p12Slot) = BuildRomWithPaletteAt(compressed);
+
+            Assert.True(UnitPaletteWriteCore.HasWritablePaletteSource(rom, p12Slot));
+
+            U.write_u32(rom.Data, p12Slot, 0);
+            Assert.False(UnitPaletteWriteCore.HasWritablePaletteSource(rom, p12Slot));
+
+            uint junkOffset = 0x400;
+            for (int i = 0; i < 32; i++) rom.Data[junkOffset + i] = 0xAB;
+            U.write_u32(rom.Data, p12Slot, U.toPointer(junkOffset));
+            Assert.False(UnitPaletteWriteCore.HasWritablePaletteSource(rom, p12Slot));
         }
 
         // ===== Single-slot in-place writes (no other slots present) =====

--- a/FEBuilderGBA.Core/UnitPaletteWriteCore.cs
+++ b/FEBuilderGBA.Core/UnitPaletteWriteCore.cs
@@ -142,7 +142,7 @@ namespace FEBuilderGBA
             if (paletteIndex < 0) return U.NOT_FOUND;
 
             // ----- Read raw P12 pointer (preserve raw for round-trip) -----
-            if (rowP12SlotOffset + 4 > (uint)rom.Data.Length) return U.NOT_FOUND;
+            if ((ulong)rowP12SlotOffset + 4 > (ulong)rom.Data.Length) return U.NOT_FOUND;
             uint rawP12 = rom.u32(rowP12SlotOffset);
             if (!U.isPointer(rawP12)) return U.NOT_FOUND;
 
@@ -287,7 +287,7 @@ namespace FEBuilderGBA
             try
             {
                 uint result;
-                if (HasValidLz77Source(rom, rowP12SlotOffset))
+                if (HasWritablePaletteSource(rom, rowP12SlotOffset))
                 {
                     // Existing multi-bank stream: splice + force-append (preserves
                     // untouched banks).
@@ -326,11 +326,12 @@ namespace FEBuilderGBA
         /// <see cref="AllocNewPalette"/> never feeds <see cref="WritePalette"/> a
         /// pointer it would reject. Guarded against every fault; never throws.
         /// </summary>
-        static bool HasValidLz77Source(ROM rom, uint rowP12SlotOffset)
+        public static bool HasWritablePaletteSource(ROM? rom, uint rowP12SlotOffset)
         {
             try
             {
-                if (rowP12SlotOffset + 4 > (uint)rom.Data.Length) return false;
+                if (rom == null) return false;
+                if ((ulong)rowP12SlotOffset + 4 > (ulong)rom.Data.Length) return false;
                 uint rawP12 = rom.u32(rowP12SlotOffset);
                 if (!U.isPointer(rawP12)) return false;
                 uint srcOffset = U.toOffset(rawP12);

--- a/config/translate/ja.txt
+++ b/config/translate/ja.txt
@@ -12981,6 +12981,12 @@ OBJタイルシートを{0}にエクスポートしました。
 :Palette write refused (invalid address or out of bounds).
 パレットの書き込みが拒否されました（無効なアドレスまたは範囲外）。
 
+:Failed to write palette data.
+パレットデータの書き込みに失敗しました。
+
+:Palette area has not been allocated. Use New Palette Allocation first.
+パレット領域が割り当てられていません。先に「新規パレット割り当て」を使用してください。
+
 :Palette written.
 パレットを書き込みました。
 

--- a/config/translate/zh.txt
+++ b/config/translate/zh.txt
@@ -26812,6 +26812,12 @@ OBJ 图像已导入，但界面刷新失败：{0}。请重新选择该地图样�
 :Palette write refused (invalid address or out of bounds).
 调色板写入被拒绝（地址无效或越界）。
 
+:Failed to write palette data.
+写入调色板数据失败。
+
+:Palette area has not been allocated. Use New Palette Allocation first.
+尚未分配调色板区域。请先使用“新建调色板分配”。
+
 :Palette written.
 调色板已写入。
 


### PR DESCRIPTION
## Summary  - Disable Unit Palette Write, Palette Write, and Import commands until a palette row is selected. - Clear the cached write target when filtering or deselection removes the selected row, preventing writes to a hidden stale entry. - Make metadata writes return explicit, overflow-safe success/failure results; preserve dirty state on failure and show localized feedback. - Distinguish missing/corrupt palette streams from other write failures so New Palette Allocation guidance is only shown when actionable. - Propagate Palette Write failure through image import while keeping imported colors visible for retry.  Accepted plan: https://github.com/laqieer/FEBuilderGBA/issues/2148#issuecomment-5549715788  Closes #2148  ## Test plan  - [x] Focused Unit Palette Core and IO/state regressions: 48 passed. - [x] `FEBuilderGBA.Core.Tests` excluding the unrelated nested-submodule dead-link scan: 7,603 passed, 19 skipped. - [x] `FEBuilderGBA.Avalonia.Tests`: 9,929 passed, 11 skipped. - [x] `FEBuilderGBA.Tests`: 2,359 passed. - [x] `FEBuilderGBA.Avalonia` Release build: 0 warnings, 0 errors. - [x] ImageUnitPalette parity, AddressList deselection/filter, overflow, source validation, and ja/zh localization coverage passed. - [x] Real Unit Palette Editor render verified commands disabled with no selection and enabled after selecting a palette row.  ## GUI Test Report  - **Surface:** Avalonia Unit Palette Editor, Palette tab. - **Environment:** repository Avalonia test host with Skia rasterization and a synthetic FE8-compatible palette row. - **Before:** no row selected; Palette Write and Import Image are disabled. - **After:** row selected; Palette Write and Import Image are enabled and palette fields are populated.  **Before selection**  ![Unit Palette commands disabled before selection](https://github.com/user-attachments/assets/181e0de5-a0c7-41a9-96a9-0e1e29ff710f)  **After selection**  ![Unit Palette commands enabled after selection](https://github.com/user-attachments/assets/c6e46c95-4396-40cc-8429-1c0ecc6d7ce3)  Issue #2149 is intentionally excluded because its image color/transparency conversion path is independent of this write-state/feedback fix.  Copilot CLI: 1.0.79 Model: GPT-5.6 Sol (gpt-5.6-sol)