### PR TITLE
fix(avalonia): preserve indexed palette exports

### DIFF
--- a/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleAnimePalletParityTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/GapSweep/ImageBattleAnimePalletParityTests.cs
@@ -265,14 +265,10 @@ public class ImageBattleAnimePalletParityTests
     }
 
     /// <summary>
-    /// #828: the Export Image button now reuses <c>GbaImageControl.ExportPng</c>
-    /// (the merged read-only PNG primitive, #815) to export the rendered sample
-    /// grid. It is wired to a Click handler, starts disabled (gated until a
-    /// sample render succeeds), and the code-behind drives its IsEnabled from
-    /// <c>SamplePreview.HasImage</c> — the exact pattern
-    /// <c>ImageBattleScreenView</c> (#810) uses. The stale "Export requires…
-    /// WinForms-coupled DrawBattleAnime via ImageFormRef.ExportImage" marker
-    /// must be gone.
+    /// #828/#2149: the Export Image button writes the rendered sample grid as
+    /// an indexed PNG so palette order survives Unit Palette import. It starts
+    /// disabled until a preview render succeeds, and the stale WinForms-coupled
+    /// export marker must remain absent.
     /// </summary>
     [Fact]
     public void View_ExportButton_WiredAndGated()
@@ -290,9 +286,13 @@ public class ImageBattleAnimePalletParityTests
         Assert.DoesNotContain("ImageFormRef.ExportImage", axaml);
 
         string code = File.ReadAllText(CodeBehindPath());
-        // Handler exports the rendered sample preview (no ROM write).
-        Assert.Matches(new Regex(
-            @"SamplePreview\.ExportPng\(\s*TopLevel\.GetTopLevel\(this\)\s+as\s+Window", RegexOptions.Singleline), code);
+        // Handler exports indexed PNG bytes through the SAF-compatible save path.
+        Assert.Contains("_vm.ExportSampleBattleAnimePng()", code);
+        Assert.Contains("FileDialogHelper.SaveImageFileVia", code);
+        Assert.Contains("File.WriteAllBytes", code);
+        Assert.DoesNotContain(
+            "SamplePreview.ExportPng(TopLevel.GetTopLevel(this)",
+            code);
         // Gate is driven from HasImage and applied to the button.
         Assert.Matches(new Regex(
             @"ExportButton\.IsEnabled\s*=\s*SamplePreview\.HasImage",

--- a/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteImageIOTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteImageIOTests.cs
@@ -220,6 +220,61 @@ namespace FEBuilderGBA.Avalonia.Tests
             finally { CoreState.ROM = prev; }
         }
 
+        [AvaloniaFact]
+        public void Import_TrueIndexedPng_PreservesEmbeddedPaletteOrder()
+        {
+            EnsureImageService();
+            var rom = MakeRom(out uint p12Offset);
+            var prev = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = rom;
+                var view = OpenViewWithSelection(out _);
+                var colors = MakeKnownColors();
+                byte[] gbaPalette = new byte[32];
+                for (int i = 0; i < colors.Length; i++)
+                {
+                    var (r5, g5, b5) = Rgb555(colors[i]);
+                    ushort color = (ushort)(r5 | (g5 << 5) | (b5 << 10));
+                    gbaPalette[i * 2] = (byte)color;
+                    gbaPalette[i * 2 + 1] = (byte)(color >> 8);
+                }
+                byte[] indices = Enumerable.Range(0, 16)
+                    .Select(i => (byte)(15 - i))
+                    .ToArray();
+                byte[] png = IndexedPngWriter.Write(
+                    indices, 16, 1, gbaPalette, 16, transparentIndex: 0);
+                string imagePath = Path.Combine(
+                    Path.GetTempPath(), $"unit-palette-indexed-{Guid.NewGuid():N}.png");
+                try
+                {
+                    File.WriteAllBytes(imagePath, png);
+                    bool ok = (bool)Invoke(view, "ImportFromFile", imagePath)!;
+                    Assert.True(ok);
+
+                    for (int i = 0; i < 16; i++)
+                    {
+                        var (r5, g5, b5) = Rgb555(colors[i]);
+                        Assert.Equal(r5, (uint)(NUD(view, "R", i).Value ?? -1));
+                        Assert.Equal(g5, (uint)(NUD(view, "G", i).Value ?? -1));
+                        Assert.Equal(b5, (uint)(NUD(view, "B", i).Value ?? -1));
+                    }
+
+                    byte[] raw = LZ77.decompress(
+                        rom.Data, U.toOffset(rom.u32(p12Offset)));
+                    Assert.Equal(gbaPalette, raw.Take(32));
+                }
+                finally
+                {
+                    if (File.Exists(imagePath)) File.Delete(imagePath);
+                }
+            }
+            finally
+            {
+                CoreState.ROM = prev;
+            }
+        }
+
         // ----- >16-color rejection: no NUD change, no ROM write -----
 
         [AvaloniaFact]

--- a/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteImageIOTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteImageIOTests.cs
@@ -276,6 +276,50 @@ namespace FEBuilderGBA.Avalonia.Tests
             }
         }
 
+        [AvaloniaFact]
+        public void Import_IndexedPngWithUnusedExtraPaletteEntries_UsesLegacyRgbaFallback()
+        {
+            EnsureImageService();
+            var rom = MakeRom(out _);
+            var prev = CoreState.ROM;
+            try
+            {
+                CoreState.ROM = rom;
+                var view = OpenViewWithSelection(out _);
+                byte[] gbaPalette = new byte[64];
+                for (int i = 0; i < 32; i++)
+                {
+                    ushort color = (ushort)(
+                        (i & 0x1F) |
+                        (((i * 2) & 0x1F) << 5) |
+                        (((i * 3) & 0x1F) << 10));
+                    gbaPalette[i * 2] = (byte)color;
+                    gbaPalette[i * 2 + 1] = (byte)(color >> 8);
+                }
+                byte[] indices = Enumerable.Range(0, 16)
+                    .Select(i => (byte)i)
+                    .ToArray();
+                byte[] png = IndexedPngWriter.Write(
+                    indices, 16, 1, gbaPalette, 32, transparentIndex: 0);
+                string imagePath = Path.Combine(
+                    Path.GetTempPath(), $"unit-palette-indexed-32-{Guid.NewGuid():N}.png");
+                try
+                {
+                    File.WriteAllBytes(imagePath, png);
+                    bool ok = (bool)Invoke(view, "ImportFromFile", imagePath)!;
+                    Assert.True(ok);
+                }
+                finally
+                {
+                    if (File.Exists(imagePath)) File.Delete(imagePath);
+                }
+            }
+            finally
+            {
+                CoreState.ROM = prev;
+            }
+        }
+
         // ----- >16-color rejection: no NUD change, no ROM write -----
 
         [AvaloniaFact]

--- a/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteImageIOTests.cs
+++ b/FEBuilderGBA.Avalonia.Tests/ImageUnitPaletteImageIOTests.cs
@@ -221,7 +221,7 @@ namespace FEBuilderGBA.Avalonia.Tests
         }
 
         [AvaloniaFact]
-        public void Import_TrueIndexedPng_PreservesEmbeddedPaletteOrder()
+        public void Import_True4BitIndexedPng_PreservesEmbeddedPaletteOrder()
         {
             EnsureImageService();
             var rom = MakeRom(out uint p12Offset);
@@ -242,8 +242,9 @@ namespace FEBuilderGBA.Avalonia.Tests
                 byte[] indices = Enumerable.Range(0, 16)
                     .Select(i => (byte)(15 - i))
                     .ToArray();
-                byte[] png = IndexedPngWriter.Write(
-                    indices, 16, 1, gbaPalette, 16, transparentIndex: 0);
+                byte[] png = IndexedPngWriter.WriteWithBitDepth(
+                    indices, 16, 1, gbaPalette, 16,
+                    bitDepth: 4, transparentIndex: 0);
                 string imagePath = Path.Combine(
                     Path.GetTempPath(), $"unit-palette-indexed-{Guid.NewGuid():N}.png");
                 try

--- a/FEBuilderGBA.Avalonia/ViewModels/ImageBattleAnimePalletViewModel.cs
+++ b/FEBuilderGBA.Avalonia/ViewModels/ImageBattleAnimePalletViewModel.cs
@@ -312,6 +312,18 @@ namespace FEBuilderGBA.Avalonia.ViewModels
         }
 
         /// <summary>
+        /// Render the current sample grid as an indexed PNG whose PLTE preserves
+        /// the active GBA palette order and whose transparent index is 0.
+        /// </summary>
+        public byte[]? ExportSampleBattleAnimePng()
+        {
+            if (_sourcePointerSlot < PalettePointerOffsetInRecord) return null;
+            uint recordOffset = _sourcePointerSlot - PalettePointerOffsetInRecord;
+            return BattleAnimeRendererCore.RenderSampleBattleAnimeIndexedPng(
+                recordOffset, _paletteTypeIndex);
+        }
+
+        /// <summary>
         /// Apply a 16-color GBA palette (32 bytes, RGB555 u16 LE pairs) to
         /// the VM R/G/B arrays. Mirrors WinForms
         /// <c>PaletteFormRef.MakePaletteBitmapToUI(bitmap, palette_index:0)</c>.

--- a/FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageBattleAnimePalletView.axaml.cs
@@ -8,6 +8,7 @@
 using global::Avalonia;
 using System;
 using System.Globalization;
+using System.IO;
 using global::Avalonia.Controls;
 using global::Avalonia.Interactivity;
 using global::Avalonia.Media;
@@ -245,18 +246,24 @@ namespace FEBuilderGBA.Avalonia.Views
         }
 
         /// <summary>
-        /// Export the rendered battle-animation sample grid to a PNG file via a
-        /// non-modal save dialog. #828: reuses <c>GbaImageControl.ExportPng</c>
-        /// — the identical read-only PNG primitive the merged battle-screen
-        /// (#810) and TSA (#810/#815) editors use. Read-only — no ROM write.
+        /// Export the rendered battle-animation sample grid as an indexed PNG
+        /// via a non-modal save dialog. The Core encoder preserves the active
+        /// 16-color palette order and transparent index 0 so Unit Palette import
+        /// can round-trip the file without reconstructing colors from RGBA.
+        /// Read-only — no ROM write.
         /// Enabled only when a render succeeded (<see cref="RefreshSamplePreview"/>
-        /// set <c>HasImage</c>); <c>ExportPng</c> early-returns on a null bitmap.
+        /// set <c>HasImage</c>).
         /// </summary>
         async void Export_Click(object sender, RoutedEventArgs e)
         {
             try
             {
-                await SamplePreview.ExportPng(TopLevel.GetTopLevel(this) as Window, ExportSuggestedName());
+                byte[]? png = _vm.ExportSampleBattleAnimePng();
+                if (png == null || png.Length == 0) return;
+                await FileDialogHelper.SaveImageFileVia(
+                    TopLevel.GetTopLevel(this) as Window,
+                    ExportSuggestedName(),
+                    path => File.WriteAllBytes(path, png));
             }
             catch (Exception ex)
             {

--- a/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml.cs
@@ -664,7 +664,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
             byte[] gbaPalette;
             byte[] rgbaPixels;
-            using (IImage image = imgService.LoadImage(path))
+            using (IImage image = imgService.LoadImagePreservingIndexed(path))
             {
                 // Prefer a loader-preserved indexed palette; fall back to the
                 // RGBA pixels (the SkiaSharp loader decodes to RGBA, so this is

--- a/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml.cs
+++ b/FEBuilderGBA.Avalonia/Views/ImageUnitPaletteView.axaml.cs
@@ -664,7 +664,7 @@ namespace FEBuilderGBA.Avalonia.Views
 
             byte[] gbaPalette;
             byte[] rgbaPixels;
-            using (IImage image = imgService.LoadImagePreservingIndexed(path))
+            using (IImage image = LoadPaletteImportImage(imgService, path))
             {
                 // Prefer a loader-preserved indexed palette; fall back to the
                 // RGBA pixels (the SkiaSharp loader decodes to RGBA, so this is
@@ -698,6 +698,19 @@ namespace FEBuilderGBA.Avalonia.Views
             // repeating the import.
             RefreshSamplePreview();
             return written;
+        }
+
+        static IImage LoadPaletteImportImage(IImageService imageService, string path)
+        {
+            IImage image = imageService.LoadImagePreservingIndexed(path);
+            if (!image.IsIndexed ||
+                image.GetPaletteGBA().Length <= UnitPaletteImportCore.PALETTE_COUNT * 2)
+            {
+                return image;
+            }
+
+            image.Dispose();
+            return imageService.LoadImage(path);
         }
 
         /// <summary>

--- a/FEBuilderGBA.Core.Tests/BattleAnimeSamplePreviewTests.cs
+++ b/FEBuilderGBA.Core.Tests/BattleAnimeSamplePreviewTests.cs
@@ -225,6 +225,29 @@ namespace FEBuilderGBA.Core.Tests
         }
 
         [Fact]
+        public void RenderSampleIndexedPng_PreservesPaletteOrderAndTransparency()
+        {
+            ROM rom = MakeAnimeRom();
+            CoreState.ROM = rom;
+
+            byte[] png = BattleAnimeRendererCore.RenderSampleBattleAnimeIndexedPng(
+                RECORD_OFFSET, 0);
+
+            Assert.NotNull(png);
+            IndexedPngInfo info = IndexedPngReader.Read(png);
+            Assert.True(info.Ok, info.Error);
+            Assert.Equal(3, info.ColorType);
+            Assert.Equal(16, info.PaletteColorCount);
+            Assert.True(info.IndicesAvailable);
+            Assert.Contains(0, info.TransparentIndices);
+            Assert.Contains((byte)0, info.Indices);
+            Assert.Contains((byte)5, info.Indices);
+            Assert.Equal(0, info.PaletteRgb[5 * 3 + 0]);
+            Assert.Equal(248, info.PaletteRgb[5 * 3 + 1]);
+            Assert.Equal(0, info.PaletteRgb[5 * 3 + 2]);
+        }
+
+        [Fact]
         public void RenderSample_OutOfRangePaletteIndex_FallsBackToBlock0()
         {
             // paletteIndex 9 is beyond the planted 2 blocks => fall back to

--- a/FEBuilderGBA.Core.Tests/BattleAnimeSamplePreviewTests.cs
+++ b/FEBuilderGBA.Core.Tests/BattleAnimeSamplePreviewTests.cs
@@ -236,6 +236,7 @@ namespace FEBuilderGBA.Core.Tests
             Assert.NotNull(png);
             IndexedPngInfo info = IndexedPngReader.Read(png);
             Assert.True(info.Ok, info.Error);
+            Assert.Equal(4, info.BitDepth);
             Assert.Equal(3, info.ColorType);
             Assert.Equal(16, info.PaletteColorCount);
             Assert.True(info.IndicesAvailable);

--- a/FEBuilderGBA.Core.Tests/IndexedPngReaderFilterTests.cs
+++ b/FEBuilderGBA.Core.Tests/IndexedPngReaderFilterTests.cs
@@ -42,6 +42,22 @@ namespace FEBuilderGBA.Core.Tests
             Assert.Null(actual);
         }
 
+        [Fact]
+        public void Read_Adam7IndexedPng_DoesNotExposeLinearIndices()
+        {
+            byte[] palette = new byte[32];
+            byte[] indices = new byte[8 * 8];
+            byte[] png = IndexedPngWriter.Write(
+                indices, 8, 8, palette, 16, transparentIndex: 0);
+            png[28] = 1; // IHDR interlace method (CRC is not validated by this reader).
+
+            IndexedPngInfo info = IndexedPngReader.Read(png);
+
+            Assert.True(info.Ok, info.Error);
+            Assert.Equal(1, info.InterlaceMethod);
+            Assert.False(info.IndicesAvailable);
+        }
+
         static byte[] EncodeFiltered(
             byte[] pixels, int width, int height, int filter)
         {

--- a/FEBuilderGBA.Core.Tests/IndexedPngReaderFilterTests.cs
+++ b/FEBuilderGBA.Core.Tests/IndexedPngReaderFilterTests.cs
@@ -1,0 +1,88 @@
+using System;
+using Xunit;
+
+namespace FEBuilderGBA.Core.Tests
+{
+    public class IndexedPngReaderFilterTests
+    {
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        public void ReconstructIndexedScanlines_SupportsStandardFilters(int filter)
+        {
+            const int width = 5;
+            const int height = 3;
+            byte[] expected =
+            {
+                0, 1, 2, 3, 4,
+                5, 6, 7, 8, 9,
+                10, 11, 12, 13, 14,
+            };
+            byte[] raw = EncodeFiltered(expected, width, height, filter);
+
+            byte[] actual = IndexedPngReader.ReconstructIndexedScanlines(
+                raw, width, height, out bool unsupported);
+
+            Assert.False(unsupported);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ReconstructIndexedScanlines_UnknownFilter_IsUnavailable()
+        {
+            byte[] raw = { 5, 0 };
+
+            byte[] actual = IndexedPngReader.ReconstructIndexedScanlines(
+                raw, 1, 1, out bool unsupported);
+
+            Assert.True(unsupported);
+            Assert.Null(actual);
+        }
+
+        static byte[] EncodeFiltered(
+            byte[] pixels, int width, int height, int filter)
+        {
+            var raw = new byte[height * (width + 1)];
+            for (int y = 0; y < height; y++)
+            {
+                int rawRow = y * (width + 1);
+                int sourceRow = y * width;
+                raw[rawRow] = (byte)filter;
+                for (int x = 0; x < width; x++)
+                {
+                    int value = pixels[sourceRow + x];
+                    int left = x > 0 ? pixels[sourceRow + x - 1] : 0;
+                    int up = y > 0 ? pixels[sourceRow - width + x] : 0;
+                    int upLeft = x > 0 && y > 0
+                        ? pixels[sourceRow - width + x - 1]
+                        : 0;
+                    int predictor = filter switch
+                    {
+                        0 => 0,
+                        1 => left,
+                        2 => up,
+                        3 => (left + up) / 2,
+                        4 => PaethPredictor(left, up, upLeft),
+                        _ => 0,
+                    };
+                    raw[rawRow + 1 + x] = unchecked((byte)(value - predictor));
+                }
+            }
+            return raw;
+        }
+
+        static int PaethPredictor(int left, int up, int upLeft)
+        {
+            int estimate = left + up - upLeft;
+            int leftDistance = Math.Abs(estimate - left);
+            int upDistance = Math.Abs(estimate - up);
+            int upperLeftDistance = Math.Abs(estimate - upLeft);
+            if (leftDistance <= upDistance && leftDistance <= upperLeftDistance)
+                return left;
+            return upDistance <= upperLeftDistance ? up : upLeft;
+        }
+    }
+}

--- a/FEBuilderGBA.Core.Tests/IndexedPngReaderFilterTests.cs
+++ b/FEBuilderGBA.Core.Tests/IndexedPngReaderFilterTests.cs
@@ -58,6 +58,28 @@ namespace FEBuilderGBA.Core.Tests
             Assert.False(info.IndicesAvailable);
         }
 
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(4)]
+        public void Read_PackedIndexedPng_RecoversExactIndices(int bitDepth)
+        {
+            int colorCount = 1 << bitDepth;
+            byte[] palette = new byte[colorCount * 2];
+            byte[] indices = new byte[16];
+            for (int i = 0; i < indices.Length; i++)
+                indices[i] = (byte)(i % colorCount);
+            byte[] png = IndexedPngWriter.WriteWithBitDepth(
+                indices, 16, 1, palette, colorCount, bitDepth, transparentIndex: 0);
+
+            IndexedPngInfo info = IndexedPngReader.Read(png);
+
+            Assert.True(info.Ok, info.Error);
+            Assert.Equal(bitDepth, info.BitDepth);
+            Assert.True(info.IndicesAvailable);
+            Assert.Equal(indices, info.Indices);
+        }
+
         static byte[] EncodeFiltered(
             byte[] pixels, int width, int height, int filter)
         {

--- a/FEBuilderGBA.Core.Tests/IndexedPngReaderFilterTests.cs
+++ b/FEBuilderGBA.Core.Tests/IndexedPngReaderFilterTests.cs
@@ -58,6 +58,21 @@ namespace FEBuilderGBA.Core.Tests
             Assert.False(info.IndicesAvailable);
         }
 
+        [Fact]
+        public void Read_InvalidInterlaceMethod_IsRejected()
+        {
+            byte[] palette = new byte[32];
+            byte[] indices = new byte[8 * 8];
+            byte[] png = IndexedPngWriter.Write(
+                indices, 8, 8, palette, 16, transparentIndex: 0);
+            png[28] = 2; // PNG only defines 0 (none) and 1 (Adam7).
+
+            IndexedPngInfo info = IndexedPngReader.Read(png);
+
+            Assert.False(info.Ok);
+            Assert.Contains("interlace", info.Error, StringComparison.OrdinalIgnoreCase);
+        }
+
         [Theory]
         [InlineData(1)]
         [InlineData(2)]

--- a/FEBuilderGBA.Core/BattleAnimeRendererCore.cs
+++ b/FEBuilderGBA.Core/BattleAnimeRendererCore.cs
@@ -616,8 +616,9 @@ namespace FEBuilderGBA
                 return null;
 
             byte[] indices = MapRgbaToPaletteIndices(rgba, palette);
-            return IndexedPngWriter.Write(
-                indices, grid.Width, grid.Height, palette, 16, transparentIndex: 0);
+            return IndexedPngWriter.WriteWithBitDepth(
+                indices, grid.Width, grid.Height, palette, 16,
+                bitDepth: 4, transparentIndex: 0);
         }
 
         /// <summary>

--- a/FEBuilderGBA.Core/BattleAnimeRendererCore.cs
+++ b/FEBuilderGBA.Core/BattleAnimeRendererCore.cs
@@ -594,6 +594,33 @@ namespace FEBuilderGBA
             => RenderSampleBattleAnime(animeRecordAddr, paletteIndex, 0);
 
         /// <summary>
+        /// Render the sample grid as an indexed PNG so palette order and
+        /// transparent index 0 survive export/import round trips.
+        /// </summary>
+        public static byte[] RenderSampleBattleAnimeIndexedPng(
+            uint animeRecordAddr, int paletteIndex)
+        {
+            ROM rom = CoreState.ROM;
+            if (rom == null || (ulong)animeRecordAddr + 32 > (ulong)rom.Data.Length)
+                return null;
+            if (paletteIndex < 0) paletteIndex = 0;
+
+            byte[] palette = ResolveSamplePaletteBlock(
+                rom, rom.u32(animeRecordAddr + 28), paletteIndex);
+            if (palette == null || palette.Length < 32) return null;
+
+            using IImage grid = RenderSampleBattleAnime(animeRecordAddr, paletteIndex);
+            if (grid == null) return null;
+            byte[] rgba = grid.GetPixelData();
+            if (rgba == null || rgba.Length < grid.Width * grid.Height * 4)
+                return null;
+
+            byte[] indices = MapRgbaToPaletteIndices(rgba, palette);
+            return IndexedPngWriter.Write(
+                indices, grid.Width, grid.Height, palette, 16, transparentIndex: 0);
+        }
+
+        /// <summary>
         /// Palette-override overload of <see cref="RenderSampleBattleAnime(uint,int)"/>.
         /// When <paramref name="paletteOverrideAddr"/> is non-zero, the 12-cell
         /// grid is rendered with the palette block at THAT address (a GBA pointer
@@ -878,6 +905,52 @@ namespace FEBuilderGBA
             byte[] sub = new byte[blockBytes];
             Array.Copy(decompressed, start, sub, 0, blockBytes);
             return sub;
+        }
+
+        static byte[] MapRgbaToPaletteIndices(byte[] rgba, byte[] gbaPalette)
+        {
+            int pixelCount = rgba.Length / 4;
+            var indices = new byte[pixelCount];
+            var palette = new ushort[16];
+            for (int i = 0; i < palette.Length; i++)
+                palette[i] = (ushort)(gbaPalette[i * 2] | (gbaPalette[i * 2 + 1] << 8));
+
+            for (int pixel = 0; pixel < pixelCount; pixel++)
+            {
+                int offset = pixel * 4;
+                if (rgba[offset + 3] == 0)
+                {
+                    indices[pixel] = 0;
+                    continue;
+                }
+
+                ushort color = (ushort)(
+                    ((rgba[offset] >> 3) & 0x1F) |
+                    (((rgba[offset + 1] >> 3) & 0x1F) << 5) |
+                    (((rgba[offset + 2] >> 3) & 0x1F) << 10));
+                int bestIndex = 1;
+                int bestDistance = int.MaxValue;
+                for (int i = 1; i < palette.Length; i++)
+                {
+                    if (palette[i] == color)
+                    {
+                        bestIndex = i;
+                        break;
+                    }
+
+                    int dr = (palette[i] & 0x1F) - (color & 0x1F);
+                    int dg = ((palette[i] >> 5) & 0x1F) - ((color >> 5) & 0x1F);
+                    int db = ((palette[i] >> 10) & 0x1F) - ((color >> 10) & 0x1F);
+                    int distance = dr * dr + dg * dg + db * db;
+                    if (distance < bestDistance)
+                    {
+                        bestDistance = distance;
+                        bestIndex = i;
+                    }
+                }
+                indices[pixel] = (byte)bestIndex;
+            }
+            return indices;
         }
 
         /// <summary>

--- a/FEBuilderGBA.Core/IImageService.cs
+++ b/FEBuilderGBA.Core/IImageService.cs
@@ -66,6 +66,20 @@ namespace FEBuilderGBA
         /// <summary>Load an image from PNG byte data.</summary>
         IImage LoadImageFromBytes(byte[] pngData);
 
+        /// <summary>
+        /// Load an image while preserving indexed PNG palette/index data when
+        /// the implementation supports it. The default keeps legacy RGBA load
+        /// behavior for existing image-service implementations.
+        /// </summary>
+        IImage LoadImagePreservingIndexed(string filePath) => LoadImage(filePath);
+
+        /// <summary>
+        /// Load PNG bytes while preserving indexed palette/index data when the
+        /// implementation supports it. The default keeps legacy RGBA behavior.
+        /// </summary>
+        IImage LoadImageFromBytesPreservingIndexed(byte[] pngData)
+            => LoadImageFromBytes(pngData);
+
         // ---- GBA Color Conversion ----
 
         /// <summary>

--- a/FEBuilderGBA.Core/IndexedPngReader.cs
+++ b/FEBuilderGBA.Core/IndexedPngReader.cs
@@ -195,8 +195,10 @@ namespace FEBuilderGBA
 
                 info.Ok = true;
 
-                // Index recovery only for indexed 8-bit (what the writer emits) with IDAT.
-                if (info.ColorType == 3 && info.BitDepth == 8 &&
+                // Recover all standard indexed bit depths for non-interlaced PNGs.
+                if (info.ColorType == 3 &&
+                    (info.BitDepth == 1 || info.BitDepth == 2 ||
+                     info.BitDepth == 4 || info.BitDepth == 8) &&
                     info.InterlaceMethod == 0 &&
                     idat != null && info.Width > 0 && info.Height > 0)
                 {
@@ -235,12 +237,13 @@ namespace FEBuilderGBA
                 }
 
                 int w = info.Width, h = info.Height;
-                long expected = (long)h * (1 + w);
+                long rowBytes = ((long)w * info.BitDepth + 7) / 8;
+                long expected = (long)h * (1 + rowBytes);
                 if (raw.Length < expected)
                     return; // not enough scanline data; leave indices unavailable
 
                 byte[] indices = ReconstructIndexedScanlines(
-                    raw, w, h, out bool unsupportedFilter);
+                    raw, w, h, info.BitDepth, out bool unsupportedFilter);
                 info.FiltersUnsupportedForIndexCheck = unsupportedFilter;
                 if (indices == null) return;
                 info.Indices = indices;
@@ -255,16 +258,28 @@ namespace FEBuilderGBA
 
         internal static byte[] ReconstructIndexedScanlines(
             byte[] raw, int width, int height, out bool unsupportedFilter)
+            => ReconstructIndexedScanlines(
+                raw, width, height, bitDepth: 8, out unsupportedFilter);
+
+        internal static byte[] ReconstructIndexedScanlines(
+            byte[] raw, int width, int height, int bitDepth,
+            out bool unsupportedFilter)
         {
             unsupportedFilter = false;
             if (raw == null || width <= 0 || height <= 0) return null;
-            if (raw.Length < (long)height * (width + 1)) return null;
+            if (bitDepth != 1 && bitDepth != 2 &&
+                bitDepth != 4 && bitDepth != 8)
+                return null;
+            long rowBytesValue = ((long)width * bitDepth + 7) / 8;
+            if (rowBytesValue > int.MaxValue) return null;
+            int rowBytes = (int)rowBytesValue;
+            if (raw.Length < (long)height * (rowBytes + 1)) return null;
 
-            var indices = new byte[width * height];
+            var packed = new byte[rowBytes * height];
             for (int y = 0; y < height; y++)
             {
-                int rawRow = y * (width + 1);
-                int outputRow = y * width;
+                int rawRow = y * (rowBytes + 1);
+                int outputRow = y * rowBytes;
                 byte filter = raw[rawRow];
                 if (filter > 4)
                 {
@@ -272,13 +287,13 @@ namespace FEBuilderGBA
                     return null;
                 }
 
-                for (int x = 0; x < width; x++)
+                for (int x = 0; x < rowBytes; x++)
                 {
                     byte encoded = raw[rawRow + 1 + x];
-                    byte left = x > 0 ? indices[outputRow + x - 1] : (byte)0;
-                    byte up = y > 0 ? indices[outputRow - width + x] : (byte)0;
+                    byte left = x > 0 ? packed[outputRow + x - 1] : (byte)0;
+                    byte up = y > 0 ? packed[outputRow - rowBytes + x] : (byte)0;
                     byte upLeft = x > 0 && y > 0
-                        ? indices[outputRow - width + x - 1]
+                        ? packed[outputRow - rowBytes + x - 1]
                         : (byte)0;
                     int predictor = filter switch
                     {
@@ -289,7 +304,22 @@ namespace FEBuilderGBA
                         4 => PaethPredictor(left, up, upLeft),
                         _ => 0,
                     };
-                    indices[outputRow + x] = unchecked((byte)(encoded + predictor));
+                    packed[outputRow + x] = unchecked((byte)(encoded + predictor));
+                }
+            }
+
+            var indices = new byte[width * height];
+            int mask = (1 << bitDepth) - 1;
+            for (int y = 0; y < height; y++)
+            {
+                int packedRow = y * rowBytes;
+                int outputRow = y * width;
+                for (int x = 0; x < width; x++)
+                {
+                    int bitOffset = x * bitDepth;
+                    int shift = 8 - bitDepth - (bitOffset % 8);
+                    indices[outputRow + x] =
+                        (byte)((packed[packedRow + bitOffset / 8] >> shift) & mask);
                 }
             }
             return indices;

--- a/FEBuilderGBA.Core/IndexedPngReader.cs
+++ b/FEBuilderGBA.Core/IndexedPngReader.cs
@@ -125,6 +125,12 @@ namespace FEBuilderGBA
                             info.BitDepth = pngBytes[dataPos + 8];
                             info.ColorType = pngBytes[dataPos + 9];
                             info.InterlaceMethod = pngBytes[dataPos + 12];
+                            if (info.InterlaceMethod != 0 &&
+                                info.InterlaceMethod != 1)
+                            {
+                                info.Error = "Invalid PNG interlace method.";
+                                return info;
+                            }
                             sawIhdr = true;
                             break;
 

--- a/FEBuilderGBA.Core/IndexedPngReader.cs
+++ b/FEBuilderGBA.Core/IndexedPngReader.cs
@@ -63,10 +63,8 @@ namespace FEBuilderGBA
     /// <see cref="IndexedPngWriter"/>. Parses the PNG signature + IHDR + PLTE + tRNS and
     /// INFLATEs IDAT to recover the per-pixel palette indices for validation.
     ///
-    /// Only PNG scanline filter type 0 (None) is reconstructed — the writer always emits
-    /// filter 0, so a FEBuilder-exported PNG round-trips exactly. A PNG that uses other
-    /// filters parses structurally (dims/palette/tRNS) but sets
-    /// <see cref="IndexedPngInfo.FiltersUnsupportedForIndexCheck"/> instead of throwing.
+    /// PNG scanline filter types 0-4 are reconstructed for 8-bit indexed images,
+    /// so files resaved by external editors retain their exact palette indices.
     ///
     /// NEVER throws: any malformed input yields <c>Ok=false</c> + an <c>Error</c>.
     /// </summary>
@@ -203,9 +201,8 @@ namespace FEBuilderGBA
         }
 
         /// <summary>
-        /// Inflate the zlib IDAT stream and reconstruct filter-0 scanlines into a flat
-        /// index array. Sets <see cref="IndexedPngInfo.FiltersUnsupportedForIndexCheck"/>
-        /// (instead of throwing) when a non-zero filter byte appears. NEVER throws.
+        /// Inflate the zlib IDAT stream and reconstruct PNG filter types 0-4
+        /// into a flat index array. NEVER throws.
         /// </summary>
         static void TryRecoverIndices(byte[] idat, IndexedPngInfo info)
         {
@@ -228,21 +225,10 @@ namespace FEBuilderGBA
                 if (raw.Length < expected)
                     return; // not enough scanline data; leave indices unavailable
 
-                var indices = new byte[w * h];
-                for (int y = 0; y < h; y++)
-                {
-                    int rowBase = y * (1 + w);
-                    byte filter = raw[rowBase];
-                    if (filter != 0)
-                    {
-                        // Only filter type 0 (None) is reconstructed here.
-                        info.FiltersUnsupportedForIndexCheck = true;
-                        info.IndicesAvailable = false;
-                        return;
-                    }
-                    Array.Copy(raw, rowBase + 1, indices, y * w, w);
-                }
-
+                byte[] indices = ReconstructIndexedScanlines(
+                    raw, w, h, out bool unsupportedFilter);
+                info.FiltersUnsupportedForIndexCheck = unsupportedFilter;
+                if (indices == null) return;
                 info.Indices = indices;
                 info.IndicesAvailable = true;
             }
@@ -251,6 +237,59 @@ namespace FEBuilderGBA
                 // inflate / shape fault: indices simply unavailable (structural still ok).
                 info.IndicesAvailable = false;
             }
+        }
+
+        internal static byte[] ReconstructIndexedScanlines(
+            byte[] raw, int width, int height, out bool unsupportedFilter)
+        {
+            unsupportedFilter = false;
+            if (raw == null || width <= 0 || height <= 0) return null;
+            if (raw.Length < (long)height * (width + 1)) return null;
+
+            var indices = new byte[width * height];
+            for (int y = 0; y < height; y++)
+            {
+                int rawRow = y * (width + 1);
+                int outputRow = y * width;
+                byte filter = raw[rawRow];
+                if (filter > 4)
+                {
+                    unsupportedFilter = true;
+                    return null;
+                }
+
+                for (int x = 0; x < width; x++)
+                {
+                    byte encoded = raw[rawRow + 1 + x];
+                    byte left = x > 0 ? indices[outputRow + x - 1] : (byte)0;
+                    byte up = y > 0 ? indices[outputRow - width + x] : (byte)0;
+                    byte upLeft = x > 0 && y > 0
+                        ? indices[outputRow - width + x - 1]
+                        : (byte)0;
+                    int predictor = filter switch
+                    {
+                        0 => 0,
+                        1 => left,
+                        2 => up,
+                        3 => (left + up) / 2,
+                        4 => PaethPredictor(left, up, upLeft),
+                        _ => 0,
+                    };
+                    indices[outputRow + x] = unchecked((byte)(encoded + predictor));
+                }
+            }
+            return indices;
+        }
+
+        static int PaethPredictor(int left, int up, int upLeft)
+        {
+            int estimate = left + up - upLeft;
+            int leftDistance = Math.Abs(estimate - left);
+            int upDistance = Math.Abs(estimate - up);
+            int upperLeftDistance = Math.Abs(estimate - upLeft);
+            if (leftDistance <= upDistance && leftDistance <= upperLeftDistance)
+                return left;
+            return upDistance <= upperLeftDistance ? up : upLeft;
         }
 
         /// <summary>

--- a/FEBuilderGBA.Core/IndexedPngReader.cs
+++ b/FEBuilderGBA.Core/IndexedPngReader.cs
@@ -57,8 +57,8 @@ namespace FEBuilderGBA
         public bool IndicesAvailable;
 
         /// <summary>
-        /// True when the IDAT used a PNG scanline filter other than 0 (None), so the
-        /// index-level recovery was skipped — a structural check is still valid.
+        /// True when the IDAT used an unknown scanline filter, so index-level
+        /// recovery was skipped while structural parsing remained valid.
         /// </summary>
         public bool FiltersUnsupportedForIndexCheck;
 
@@ -71,8 +71,9 @@ namespace FEBuilderGBA
     /// <see cref="IndexedPngWriter"/>. Parses the PNG signature + IHDR + PLTE + tRNS and
     /// INFLATEs IDAT to recover the per-pixel palette indices for validation.
     ///
-    /// PNG scanline filter types 0-4 are reconstructed for 8-bit indexed images,
-    /// so files resaved by external editors retain their exact palette indices.
+    /// PNG scanline filter types 0-4 are reconstructed for 1-, 2-, 4-, and
+    /// 8-bit indexed images, so files resaved by external editors retain their
+    /// exact palette indices.
     ///
     /// NEVER throws: any malformed input yields <c>Ok=false</c> + an <c>Error</c>.
     /// </summary>

--- a/FEBuilderGBA.Core/IndexedPngReader.cs
+++ b/FEBuilderGBA.Core/IndexedPngReader.cs
@@ -26,6 +26,9 @@ namespace FEBuilderGBA
         /// <summary>Color type from IHDR (3 == indexed/palette).</summary>
         public int ColorType;
 
+        /// <summary>Interlace method from IHDR (0 == none, 1 == Adam7).</summary>
+        public int InterlaceMethod;
+
         /// <summary>Number of palette entries (PLTE length / 3); 0 when no PLTE.</summary>
         public int PaletteColorCount;
 
@@ -38,6 +41,11 @@ namespace FEBuilderGBA
 
         /// <summary>True when a tRNS chunk is present.</summary>
         public bool HasTrns;
+
+        /// <summary>
+        /// Raw tRNS alpha bytes. Palette entries beyond this array are opaque.
+        /// </summary>
+        public byte[] PaletteAlpha = Array.Empty<byte>();
 
         /// <summary>Transparent palette indices (from tRNS, value 0); empty when none.</summary>
         public int[] TransparentIndices = Array.Empty<int>();
@@ -116,6 +124,7 @@ namespace FEBuilderGBA
                             info.Height = ReadU32BE(pngBytes, dataPos + 4);
                             info.BitDepth = pngBytes[dataPos + 8];
                             info.ColorType = pngBytes[dataPos + 9];
+                            info.InterlaceMethod = pngBytes[dataPos + 12];
                             sawIhdr = true;
                             break;
 
@@ -132,6 +141,9 @@ namespace FEBuilderGBA
                         case "tRNS":
                         {
                             info.HasTrns = true;
+                            var alpha = new byte[len];
+                            Array.Copy(pngBytes, dataPos, alpha, 0, len);
+                            info.PaletteAlpha = alpha;
                             // An index i is fully transparent when its tRNS alpha byte == 0;
                             // indices beyond the tRNS length are implicitly opaque (255).
                             var trans = new System.Collections.Generic.List<int>();
@@ -184,7 +196,9 @@ namespace FEBuilderGBA
                 info.Ok = true;
 
                 // Index recovery only for indexed 8-bit (what the writer emits) with IDAT.
-                if (info.ColorType == 3 && info.BitDepth == 8 && idat != null && info.Width > 0 && info.Height > 0)
+                if (info.ColorType == 3 && info.BitDepth == 8 &&
+                    info.InterlaceMethod == 0 &&
+                    idat != null && info.Width > 0 && info.Height > 0)
                 {
                     TryRecoverIndices(idat, info);
                 }

--- a/FEBuilderGBA.Core/IndexedPngWriter.cs
+++ b/FEBuilderGBA.Core/IndexedPngWriter.cs
@@ -40,16 +40,47 @@ namespace FEBuilderGBA
             byte[] gbaPalette,
             int paletteColorCount,
             int transparentIndex = 0)
+            => WriteCore(indices, width, height, gbaPalette,
+                paletteColorCount, bitDepth: 8, transparentIndex);
+
+        /// <summary>
+        /// Encode an indexed PNG with an explicit standard indexed bit depth
+        /// (1, 2, 4, or 8). Primarily used for compatibility fixtures.
+        /// </summary>
+        public static byte[] WriteWithBitDepth(
+            byte[] indices,
+            int width,
+            int height,
+            byte[] gbaPalette,
+            int paletteColorCount,
+            int bitDepth,
+            int transparentIndex = 0)
+            => WriteCore(indices, width, height, gbaPalette,
+                paletteColorCount, bitDepth, transparentIndex);
+
+        static byte[] WriteCore(
+            byte[] indices,
+            int width,
+            int height,
+            byte[] gbaPalette,
+            int paletteColorCount,
+            int bitDepth,
+            int transparentIndex)
         {
             try
             {
                 // ---- Validate inputs ----
                 if (indices == null) return null;
                 if (width <= 0 || height <= 0) return null;
-                if (indices.Length != width * height) return null;
+                long pixelCount = (long)width * height;
+                if (pixelCount > int.MaxValue || indices.Length != pixelCount) return null;
                 if (gbaPalette == null) return null;
                 if (paletteColorCount < 1 || paletteColorCount > 256) return null;
                 if (gbaPalette.Length < paletteColorCount * 2) return null;
+                if (bitDepth != 1 && bitDepth != 2 &&
+                    bitDepth != 4 && bitDepth != 8)
+                    return null;
+                if (paletteColorCount > (1 << bitDepth)) return null;
 
                 // Every pixel index must be representable by the PLTE
                 // (color type 3 requires index < palette size). An out-of-range
@@ -68,7 +99,7 @@ namespace FEBuilderGBA
                 byte[] ihdrData = new byte[13];
                 WriteU32BE(ihdrData, 0, (uint)width);
                 WriteU32BE(ihdrData, 4, (uint)height);
-                ihdrData[8] = 8;   // bit depth = 8
+                ihdrData[8] = (byte)bitDepth;
                 ihdrData[9] = 3;   // color type = indexed (palette)
                 ihdrData[10] = 0;  // compression method = deflate
                 ihdrData[11] = 0;  // filter method = adaptive
@@ -102,13 +133,21 @@ namespace FEBuilderGBA
                 }
 
                 // ---- IDAT ----
-                // Raw scanlines: for each row, prefix with filter byte 0, then width pixel indices
-                byte[] scanlines = new byte[height * (1 + width)];
+                // Raw scanlines: filter byte 0 followed by packed indices.
+                int rowBytes = (int)(((long)width * bitDepth + 7) / 8);
+                byte[] scanlines = new byte[height * (1 + rowBytes)];
                 for (int y = 0; y < height; y++)
                 {
-                    int scanlineBase = y * (1 + width);
+                    int scanlineBase = y * (1 + rowBytes);
                     scanlines[scanlineBase] = 0; // filter type = None
-                    Array.Copy(indices, y * width, scanlines, scanlineBase + 1, width);
+                    for (int x = 0; x < width; x++)
+                    {
+                        int bitOffset = x * bitDepth;
+                        int byteOffset = bitOffset / 8;
+                        int shift = 8 - bitDepth - (bitOffset % 8);
+                        scanlines[scanlineBase + 1 + byteOffset] |=
+                            (byte)(indices[y * width + x] << shift);
+                    }
                 }
 
                 // zlib compress: 2-byte header (0x78 0x01) + deflate body + Adler-32 (4 bytes BE)

--- a/FEBuilderGBA.SkiaSharp/SkiaImageService.cs
+++ b/FEBuilderGBA.SkiaSharp/SkiaImageService.cs
@@ -21,10 +21,7 @@ namespace FEBuilderGBA.SkiaSharp
 
         public IImage LoadImage(string filePath)
         {
-            var bitmap = SKBitmap.Decode(filePath);
-            if (bitmap == null)
-                throw new IOException($"Failed to load image: {filePath}");
-            return new SkiaImage(bitmap);
+            return LoadImageFromBytes(File.ReadAllBytes(filePath));
         }
 
         public IImage LoadImageFromBytes(byte[] pngData)
@@ -32,7 +29,91 @@ namespace FEBuilderGBA.SkiaSharp
             var bitmap = SKBitmap.Decode(pngData);
             if (bitmap == null)
                 throw new InvalidOperationException("Failed to decode image from byte data.");
+
+            IndexedPngInfo indexed = IndexedPngReader.Read(pngData);
+            if (indexed.Ok && indexed.ColorType == 3 &&
+                indexed.PaletteColorCount > 0 &&
+                indexed.PaletteColorCount <= 256 &&
+                indexed.PaletteRgb.Length >= indexed.PaletteColorCount * 3 &&
+                indexed.Width > 0 && indexed.Height > 0 &&
+                (long)indexed.Width * indexed.Height <= int.MaxValue &&
+                bitmap.Width == indexed.Width && bitmap.Height == indexed.Height)
+            {
+                try
+                {
+                    byte[] gbaPalette = ConvertIndexedPaletteToGba(
+                        indexed.PaletteRgb, indexed.PaletteColorCount);
+                    byte[] indices = indexed.IndicesAvailable &&
+                        indexed.Indices?.Length == indexed.Width * indexed.Height
+                        ? indexed.Indices
+                        : MapBitmapToPaletteIndices(bitmap, indexed);
+
+                    var image = new SkiaImage(
+                        indexed.Width, indexed.Height, gbaPalette,
+                        indexed.PaletteColorCount);
+                    image.SetPixelData(indices);
+                    return image;
+                }
+                finally
+                {
+                    bitmap.Dispose();
+                }
+            }
             return new SkiaImage(bitmap);
+        }
+
+        byte[] ConvertIndexedPaletteToGba(byte[] paletteRgb, int colorCount)
+        {
+            var result = new byte[colorCount * 2];
+            for (int i = 0; i < colorCount; i++)
+            {
+                ushort color = RGBAToGBAColor(
+                    paletteRgb[i * 3],
+                    paletteRgb[i * 3 + 1],
+                    paletteRgb[i * 3 + 2]);
+                result[i * 2] = (byte)color;
+                result[i * 2 + 1] = (byte)(color >> 8);
+            }
+            return result;
+        }
+
+        static byte[] MapBitmapToPaletteIndices(
+            SKBitmap bitmap, IndexedPngInfo indexed)
+        {
+            SKColor[] pixels = bitmap.Pixels;
+            var result = new byte[indexed.Width * indexed.Height];
+            int transparentIndex = indexed.TransparentIndices.Length > 0
+                ? indexed.TransparentIndices[0]
+                : 0;
+
+            for (int p = 0; p < result.Length; p++)
+            {
+                SKColor pixel = pixels[p];
+                if (pixel.Alpha == 0)
+                {
+                    result[p] = (byte)transparentIndex;
+                    continue;
+                }
+
+                int bestIndex = 0;
+                int bestDistance = int.MaxValue;
+                for (int i = 0; i < indexed.PaletteColorCount; i++)
+                {
+                    int offset = i * 3;
+                    int dr = indexed.PaletteRgb[offset] - pixel.Red;
+                    int dg = indexed.PaletteRgb[offset + 1] - pixel.Green;
+                    int db = indexed.PaletteRgb[offset + 2] - pixel.Blue;
+                    int distance = dr * dr + dg * dg + db * db;
+                    if (distance < bestDistance)
+                    {
+                        bestDistance = distance;
+                        bestIndex = i;
+                        if (distance == 0) break;
+                    }
+                }
+                result[p] = (byte)bestIndex;
+            }
+            return result;
         }
 
         public void GBAColorToRGBA(ushort gbaColor, out byte r, out byte g, out byte b)

--- a/FEBuilderGBA.SkiaSharp/SkiaImageService.cs
+++ b/FEBuilderGBA.SkiaSharp/SkiaImageService.cs
@@ -51,14 +51,16 @@ namespace FEBuilderGBA.SkiaSharp
                 indexed.PaletteRgb.Length >= indexed.PaletteColorCount * 3 &&
                 indexed.Width > 0 && indexed.Height > 0 &&
                 (long)indexed.Width * indexed.Height <= int.MaxValue &&
-                bitmap.Width == indexed.Width && bitmap.Height == indexed.Height)
+                bitmap.Width == indexed.Width && bitmap.Height == indexed.Height &&
+                indexed.InterlaceMethod == 0 &&
+                indexed.IndicesAvailable &&
+                indexed.Indices?.Length == indexed.Width * indexed.Height &&
+                HasGbaTransparency(indexed))
             {
-                if (indexed.IndicesAvailable &&
-                    indexed.Indices?.Length == indexed.Width * indexed.Height)
+                try
                 {
                     byte[] gbaPalette = ConvertIndexedPaletteToGba(
                         indexed.PaletteRgb, indexed.PaletteColorCount);
-                    bitmap.Dispose();
 
                     var image = new SkiaImage(
                         indexed.Width, indexed.Height, gbaPalette,
@@ -66,8 +68,26 @@ namespace FEBuilderGBA.SkiaSharp
                     image.SetPixelData(indexed.Indices);
                     return image;
                 }
+                finally
+                {
+                    bitmap.Dispose();
+                }
             }
             return new SkiaImage(bitmap);
+        }
+
+        static bool HasGbaTransparency(IndexedPngInfo indexed)
+        {
+            if (!indexed.HasTrns) return false;
+            for (int i = 0; i < indexed.PaletteColorCount; i++)
+            {
+                byte alpha = i < indexed.PaletteAlpha.Length
+                    ? indexed.PaletteAlpha[i]
+                    : (byte)255;
+                byte expected = i == 0 ? (byte)0 : (byte)255;
+                if (alpha != expected) return false;
+            }
+            return true;
         }
 
         byte[] ConvertIndexedPaletteToGba(byte[] paletteRgb, int colorCount)

--- a/FEBuilderGBA.SkiaSharp/SkiaImageService.cs
+++ b/FEBuilderGBA.SkiaSharp/SkiaImageService.cs
@@ -21,10 +21,24 @@ namespace FEBuilderGBA.SkiaSharp
 
         public IImage LoadImage(string filePath)
         {
-            return LoadImageFromBytes(File.ReadAllBytes(filePath));
+            var bitmap = SKBitmap.Decode(filePath);
+            if (bitmap == null)
+                throw new IOException($"Failed to load image: {filePath}");
+            return new SkiaImage(bitmap);
         }
 
         public IImage LoadImageFromBytes(byte[] pngData)
+        {
+            var bitmap = SKBitmap.Decode(pngData);
+            if (bitmap == null)
+                throw new InvalidOperationException("Failed to decode image from byte data.");
+            return new SkiaImage(bitmap);
+        }
+
+        public IImage LoadImagePreservingIndexed(string filePath)
+            => LoadImageFromBytesPreservingIndexed(File.ReadAllBytes(filePath));
+
+        public IImage LoadImageFromBytesPreservingIndexed(byte[] pngData)
         {
             var bitmap = SKBitmap.Decode(pngData);
             if (bitmap == null)
@@ -39,24 +53,18 @@ namespace FEBuilderGBA.SkiaSharp
                 (long)indexed.Width * indexed.Height <= int.MaxValue &&
                 bitmap.Width == indexed.Width && bitmap.Height == indexed.Height)
             {
-                try
+                if (indexed.IndicesAvailable &&
+                    indexed.Indices?.Length == indexed.Width * indexed.Height)
                 {
                     byte[] gbaPalette = ConvertIndexedPaletteToGba(
                         indexed.PaletteRgb, indexed.PaletteColorCount);
-                    byte[] indices = indexed.IndicesAvailable &&
-                        indexed.Indices?.Length == indexed.Width * indexed.Height
-                        ? indexed.Indices
-                        : MapBitmapToPaletteIndices(bitmap, indexed);
+                    bitmap.Dispose();
 
                     var image = new SkiaImage(
                         indexed.Width, indexed.Height, gbaPalette,
                         indexed.PaletteColorCount);
-                    image.SetPixelData(indices);
+                    image.SetPixelData(indexed.Indices);
                     return image;
-                }
-                finally
-                {
-                    bitmap.Dispose();
                 }
             }
             return new SkiaImage(bitmap);
@@ -73,45 +81,6 @@ namespace FEBuilderGBA.SkiaSharp
                     paletteRgb[i * 3 + 2]);
                 result[i * 2] = (byte)color;
                 result[i * 2 + 1] = (byte)(color >> 8);
-            }
-            return result;
-        }
-
-        static byte[] MapBitmapToPaletteIndices(
-            SKBitmap bitmap, IndexedPngInfo indexed)
-        {
-            SKColor[] pixels = bitmap.Pixels;
-            var result = new byte[indexed.Width * indexed.Height];
-            int transparentIndex = indexed.TransparentIndices.Length > 0
-                ? indexed.TransparentIndices[0]
-                : 0;
-
-            for (int p = 0; p < result.Length; p++)
-            {
-                SKColor pixel = pixels[p];
-                if (pixel.Alpha == 0)
-                {
-                    result[p] = (byte)transparentIndex;
-                    continue;
-                }
-
-                int bestIndex = 0;
-                int bestDistance = int.MaxValue;
-                for (int i = 0; i < indexed.PaletteColorCount; i++)
-                {
-                    int offset = i * 3;
-                    int dr = indexed.PaletteRgb[offset] - pixel.Red;
-                    int dg = indexed.PaletteRgb[offset + 1] - pixel.Green;
-                    int db = indexed.PaletteRgb[offset + 2] - pixel.Blue;
-                    int distance = dr * dr + dg * dg + db * db;
-                    if (distance < bestDistance)
-                    {
-                        bestDistance = distance;
-                        bestIndex = i;
-                        if (distance == 0) break;
-                    }
-                }
-                result[p] = (byte)bestIndex;
             }
             return result;
         }

--- a/FEBuilderGBA.Tests/Unit/SkiaImageServiceTests.cs
+++ b/FEBuilderGBA.Tests/Unit/SkiaImageServiceTests.cs
@@ -1,4 +1,7 @@
+using System;
+using System.IO;
 using Xunit;
+using FEBuilderGBA;
 using FEBuilderGBA.SkiaSharp;
 
 namespace FEBuilderGBA.Tests.Unit
@@ -334,6 +337,71 @@ namespace FEBuilderGBA.Tests.Unit
             Assert.Equal(16, loaded.Width);
             Assert.Equal(8, loaded.Height);
             Assert.False(loaded.IsIndexed);
+        }
+
+        [Fact]
+        public void LoadImageFromBytes_IndexedPng_PreservesPaletteAndIndices()
+        {
+            var svc = new SkiaImageService();
+            byte[] palette = MakeIndexedPalette();
+            byte[] indices = MakeIndexedPixels(8, 8);
+            byte[] png = IndexedPngWriter.Write(
+                indices, 8, 8, palette, 16, transparentIndex: 0);
+
+            using var loaded = svc.LoadImageFromBytes(png);
+
+            Assert.True(loaded.IsIndexed);
+            Assert.Equal(indices, loaded.GetPixelData());
+            Assert.Equal(palette, loaded.GetPaletteGBA());
+            Assert.Equal(0, loaded.GetPaletteRGBA()[3]);
+        }
+
+        [Fact]
+        public void LoadImage_IndexedPng_PreservesPaletteAndIndices()
+        {
+            var svc = new SkiaImageService();
+            byte[] palette = MakeIndexedPalette();
+            byte[] indices = MakeIndexedPixels(8, 8);
+            byte[] png = IndexedPngWriter.Write(
+                indices, 8, 8, palette, 16, transparentIndex: 0);
+            string path = Path.Combine(
+                Path.GetTempPath(), $"indexed-{Guid.NewGuid():N}.png");
+            try
+            {
+                File.WriteAllBytes(path, png);
+                using var loaded = svc.LoadImage(path);
+
+                Assert.True(loaded.IsIndexed);
+                Assert.Equal(indices, loaded.GetPixelData());
+                Assert.Equal(palette, loaded.GetPaletteGBA());
+            }
+            finally
+            {
+                if (File.Exists(path)) File.Delete(path);
+            }
+        }
+
+        static byte[] MakeIndexedPalette()
+        {
+            var palette = new byte[32];
+            for (int i = 0; i < 16; i++)
+            {
+                ushort color = (ushort)(
+                    (i & 0x1F) |
+                    (((i * 2) & 0x1F) << 5) |
+                    (((i * 3) & 0x1F) << 10));
+                palette[i * 2] = (byte)color;
+                palette[i * 2 + 1] = (byte)(color >> 8);
+            }
+            return palette;
+        }
+
+        static byte[] MakeIndexedPixels(int width, int height)
+        {
+            var indices = new byte[width * height];
+            for (int i = 0; i < indices.Length; i++)
+                indices[i] = (byte)(i % 16);
+            return indices;
         }
 
         [Fact]

--- a/FEBuilderGBA.Tests/Unit/SkiaImageServiceTests.cs
+++ b/FEBuilderGBA.Tests/Unit/SkiaImageServiceTests.cs
@@ -345,8 +345,9 @@ namespace FEBuilderGBA.Tests.Unit
             var svc = new SkiaImageService();
             byte[] palette = MakeIndexedPalette();
             byte[] indices = MakeIndexedPixels(8, 8);
-            byte[] png = IndexedPngWriter.Write(
-                indices, 8, 8, palette, 16, transparentIndex: 0);
+            byte[] png = IndexedPngWriter.WriteWithBitDepth(
+                indices, 8, 8, palette, 16,
+                bitDepth: 4, transparentIndex: 0);
 
             using var loaded = svc.LoadImageFromBytes(png);
 
@@ -360,8 +361,9 @@ namespace FEBuilderGBA.Tests.Unit
             var svc = new SkiaImageService();
             byte[] palette = MakeIndexedPalette();
             byte[] indices = MakeIndexedPixels(8, 8);
-            byte[] png = IndexedPngWriter.Write(
-                indices, 8, 8, palette, 16, transparentIndex: 0);
+            byte[] png = IndexedPngWriter.WriteWithBitDepth(
+                indices, 8, 8, palette, 16,
+                bitDepth: 4, transparentIndex: 0);
 
             using var loaded = svc.LoadImageFromBytesPreservingIndexed(png);
 

--- a/FEBuilderGBA.Tests/Unit/SkiaImageServiceTests.cs
+++ b/FEBuilderGBA.Tests/Unit/SkiaImageServiceTests.cs
@@ -396,6 +396,117 @@ namespace FEBuilderGBA.Tests.Unit
             }
         }
 
+        [Fact]
+        public void LoadImageFromBytesPreservingIndexed_NoTransparency_FallsBackToRgba()
+        {
+            var svc = new SkiaImageService();
+            byte[] png = IndexedPngWriter.Write(
+                MakeIndexedPixels(8, 8), 8, 8,
+                MakeIndexedPalette(), 16, transparentIndex: -1);
+
+            using var loaded = svc.LoadImageFromBytesPreservingIndexed(png);
+
+            Assert.False(loaded.IsIndexed);
+            Assert.Equal(8 * 8 * 4, loaded.GetPixelData().Length);
+        }
+
+        [Fact]
+        public void LoadImageFromBytesPreservingIndexed_NonzeroTransparentIndex_FallsBackToRgba()
+        {
+            var svc = new SkiaImageService();
+            byte[] png = IndexedPngWriter.Write(
+                MakeIndexedPixels(8, 8), 8, 8,
+                MakeIndexedPalette(), 16, transparentIndex: 1);
+
+            using var loaded = svc.LoadImageFromBytesPreservingIndexed(png);
+
+            Assert.False(loaded.IsIndexed);
+        }
+
+        [Fact]
+        public void LoadImageFromBytesPreservingIndexed_PartialAlpha_FallsBackToRgba()
+        {
+            var svc = new SkiaImageService();
+            byte[] png = IndexedPngWriter.Write(
+                MakeIndexedPixels(8, 8), 8, 8,
+                MakeIndexedPalette(), 16, transparentIndex: 0);
+            SetFirstTrnsAlphaAndRepairCrc(png, 128);
+
+            using var loaded = svc.LoadImageFromBytesPreservingIndexed(png);
+
+            Assert.False(loaded.IsIndexed);
+        }
+
+        [Fact]
+        public void LoadImageFromBytesPreservingIndexed_Adam7_FallsBackToRgba()
+        {
+            var svc = new SkiaImageService();
+            byte[] png = IndexedPngWriter.Write(
+                new byte[] { 1 }, 1, 1,
+                MakeIndexedPalette(), 16, transparentIndex: 0);
+            SetIhdrInterlaceAndRepairCrc(png, 1);
+
+            using var loaded = svc.LoadImageFromBytesPreservingIndexed(png);
+
+            Assert.False(loaded.IsIndexed);
+        }
+
+        static void SetIhdrInterlaceAndRepairCrc(byte[] png, byte interlace)
+        {
+            png[28] = interlace;
+            uint crc = Crc32(png, 12, 17);
+            png[29] = (byte)(crc >> 24);
+            png[30] = (byte)(crc >> 16);
+            png[31] = (byte)(crc >> 8);
+            png[32] = (byte)crc;
+        }
+
+        static void SetFirstTrnsAlphaAndRepairCrc(byte[] png, byte alpha)
+        {
+            int offset = 8;
+            while (offset + 12 <= png.Length)
+            {
+                int length = ReadU32Be(png, offset);
+                if (png[offset + 4] == (byte)'t' &&
+                    png[offset + 5] == (byte)'R' &&
+                    png[offset + 6] == (byte)'N' &&
+                    png[offset + 7] == (byte)'S')
+                {
+                    int dataOffset = offset + 8;
+                    png[dataOffset] = alpha;
+                    uint crc = Crc32(png, offset + 4, 4 + length);
+                    int crcOffset = dataOffset + length;
+                    png[crcOffset] = (byte)(crc >> 24);
+                    png[crcOffset + 1] = (byte)(crc >> 16);
+                    png[crcOffset + 2] = (byte)(crc >> 8);
+                    png[crcOffset + 3] = (byte)crc;
+                    return;
+                }
+                offset += 12 + length;
+            }
+            throw new InvalidDataException("tRNS chunk not found.");
+        }
+
+        static int ReadU32Be(byte[] data, int offset)
+            => (data[offset] << 24) |
+               (data[offset + 1] << 16) |
+               (data[offset + 2] << 8) |
+               data[offset + 3];
+
+        static uint Crc32(byte[] data, int offset, int count)
+        {
+            uint crc = 0xFFFFFFFF;
+            for (int i = offset; i < offset + count; i++)
+            {
+                crc ^= data[i];
+                for (int bit = 0; bit < 8; bit++)
+                    crc = (crc & 1) != 0
+                        ? 0xEDB88320 ^ (crc >> 1)
+                        : crc >> 1;
+            }
+            return crc ^ 0xFFFFFFFF;
+        }
+
         static byte[] MakeIndexedPalette()
         {
             var palette = new byte[32];

--- a/FEBuilderGBA.Tests/Unit/SkiaImageServiceTests.cs
+++ b/FEBuilderGBA.Tests/Unit/SkiaImageServiceTests.cs
@@ -340,7 +340,7 @@ namespace FEBuilderGBA.Tests.Unit
         }
 
         [Fact]
-        public void LoadImageFromBytes_IndexedPng_PreservesPaletteAndIndices()
+        public void LoadImageFromBytes_IndexedPng_DefaultRemainsRgba()
         {
             var svc = new SkiaImageService();
             byte[] palette = MakeIndexedPalette();
@@ -350,6 +350,21 @@ namespace FEBuilderGBA.Tests.Unit
 
             using var loaded = svc.LoadImageFromBytes(png);
 
+            Assert.False(loaded.IsIndexed);
+            Assert.Equal(8 * 8 * 4, loaded.GetPixelData().Length);
+        }
+
+        [Fact]
+        public void LoadImageFromBytesPreservingIndexed_PreservesPaletteAndIndices()
+        {
+            var svc = new SkiaImageService();
+            byte[] palette = MakeIndexedPalette();
+            byte[] indices = MakeIndexedPixels(8, 8);
+            byte[] png = IndexedPngWriter.Write(
+                indices, 8, 8, palette, 16, transparentIndex: 0);
+
+            using var loaded = svc.LoadImageFromBytesPreservingIndexed(png);
+
             Assert.True(loaded.IsIndexed);
             Assert.Equal(indices, loaded.GetPixelData());
             Assert.Equal(palette, loaded.GetPaletteGBA());
@@ -357,7 +372,7 @@ namespace FEBuilderGBA.Tests.Unit
         }
 
         [Fact]
-        public void LoadImage_IndexedPng_PreservesPaletteAndIndices()
+        public void LoadImagePreservingIndexed_PreservesPaletteAndIndices()
         {
             var svc = new SkiaImageService();
             byte[] palette = MakeIndexedPalette();
@@ -369,7 +384,7 @@ namespace FEBuilderGBA.Tests.Unit
             try
             {
                 File.WriteAllBytes(path, png);
-                using var loaded = svc.LoadImage(path);
+                using var loaded = svc.LoadImagePreservingIndexed(path);
 
                 Assert.True(loaded.IsIndexed);
                 Assert.Equal(indices, loaded.GetPixelData());


### PR DESCRIPTION
## Summary  - Export Battle Animation Palette sample grids as indexed PNGs with the active 16-color PLTE order and transparent index 0 preserved. - Add opt-in palette-preserving image loads while keeping the existing `LoadImage` / `LoadImageFromBytes` RGBA contract unchanged for all current callers. - Reconstruct standard PNG scanline filters 0-4 so externally resaved indexed PNGs retain exact pixel indices. - Let only Unit Palette import opt into indexed loading and consume the embedded GBA palette directly, eliminating first-appearance reordering and transparent-slot shifts.  Accepted plans: - Original: https://github.com/laqieer/FEBuilderGBA/issues/2149#issuecomment-5550910772 - Compatibility amendment: https://github.com/laqieer/FEBuilderGBA/issues/2149#issuecomment-5551186259  Closes #2149  ## Test plan  - [x] Indexed Battle sample export structure/palette/index regression passed. - [x] PNG filter 0-4, packed 1/2/4/8-bit decoding, invalid-interlace rejection, and Adam7 fallback regressions: 11 passed. - [x] Default Skia indexed-PNG loads remain RGBA; opt-in file/byte loads preserve exact palette/indices only for GBA-compatible transparency, with packed 4-bit, no-tRNS, nonzero/partial-alpha, and Adam7 coverage: 8 focused tests passed. - [x] True 4-bit indexed Battle export → Unit Palette import and >16-entry PLTE legacy-fallback regressions passed. - [x] `FEBuilderGBA.Core.Tests`: 7,615 passed, 19 skipped (excluding the unrelated nested-submodule dead-link scan). - [x] `FEBuilderGBA.Tests`: 2,366 passed. - [x] `FEBuilderGBA.Avalonia.Tests`: 9,931 passed, 11 skipped. - [x] `FEBuilderGBA.SkiaSharp`, `FEBuilderGBA.Avalonia`, and `FEBuilderGBA.CLI` Release builds: 0 warnings, 0 errors. - [x] Real end-to-end fixture export/import generated an indexed PNG (color type 3, 16-entry palette, transparent index 0) and rendered the imported Unit Palette editor.  ## GUI Test Report  - **Source:** Battle Animation Palette synthetic FE8-compatible sample exported through the production indexed-PNG path. - **Target:** the exact exported PNG loaded through the Unit Palette opt-in indexed loader and imported into the real Unit Palette Editor. - **Result:** palette index order is retained; the green color remains in slot 6 rather than moving by first pixel appearance, and transparent index 0 remains reserved.  **Indexed Battle Palette export**  ![Indexed Battle Palette export with transparent background](https://github.com/user-attachments/assets/cfd63c85-52a8-4e85-af77-d2021f4549e3)  **Unit Palette after importing that file**  ![Unit Palette import preserving the indexed green slot](https://github.com/user-attachments/assets/3258c427-ce42-4ded-9657-c3ae5d00feb7)  Copilot CLI: 1.0.79 Model: GPT-5.6 Sol (gpt-5.6-sol)