### PR TITLE
docs(maintenance): track final pass summaries in one discussion

### DIFF
--- a/.github/skills/daily-maintenance/SKILL.md
+++ b/.github/skills/daily-maintenance/SKILL.md
@@ -7,6 +7,8 @@ description: "Run the unattended FEBuilderGBA maintenance loop: CI and security 
 
 Run unattended and make the safest reasonable decision. Any repository change must invoke `dev-flow`.
 
+At pass start, persist a unique UTC pass ID in the compact checkpoint; reuse it on retries/resume. Designate one coordinator to publish that pass's summary.
+
 ## Always-retained safeguards
 
 - Target only `laqieer/FEBuilderGBA`; verify `origin` before GitHub reads or writes.
@@ -32,6 +34,17 @@ Run unattended and make the safest reasonable decision. Any repository change mu
 ## Completion loop
 
 After each pass, re-query open issues and PRs. Continue until both counts are zero. Persist a compact queue/checkpoint and use a fresh child or session per independent item instead of accumulating every artifact in one context.
+
+## Final step: maintenance summary
+
+Use the permanent [Daily maintenance track](https://github.com/laqieer/FEBuilderGBA/discussions/2155), not a new discussion per pass.
+
+1. After the zero-queue loop, freshly verify current `master` CI, security alerts, discussions, open issue/PR counts, and the release outcome. Return to the loop if work remains; never publish a completed summary while checks are pending or blocking work remains.
+2. Prepare a concise top-level comment with `<!-- daily-maintenance-pass:<pass-id> -->`, UTC date, and **completed** or **blocked/incomplete** status. Report actual issue/PR outcomes with useful links, master SHA/CI and security results, final queue counts, release link or no-release reason, and limitations. Use a few bullets, not logs, secrets, ROMs, or fabricated results; finish with the live footer below.
+3. Before any write, paginate all top-level comments and match the exact marker. Skip an identical report. Correct or complete an existing report only after verifying its marker, author matches the authenticated operator, and it is that operator's own pass report; retain its comment ID/URL in the checkpoint. Never edit another author's comment. Conflicting authors or ambiguous duplicates block publication; do not delete comments or invent a new pass ID to evade the conflict.
+4. If absent, post one new comment and checkpoint its ID/URL. After a timeout or ambiguous write failure, re-read remote comments before retrying the same pass; do not blindly repeat a write. If the discussion is missing, locked, or unavailable, retain the intended report/checkpoint, record the publication blocker, and retry later without creating a replacement discussion. Do not claim the pass fully reported until publication is verified.
+
+Blocked/interrupted work may publish an explicitly **blocked/incomplete** report with the same marker, known outcomes, blockers, and remaining work; never imply zero queues or successful unchecked results. Preserve the checkpoint and resume the completion loop, then update only the verified own report after final checks pass. Publication failure remains an explicit blocker even if maintenance checks passed.
 
 ## Mandatory GitHub footer
 


### PR DESCRIPTION
## Summary
- Establish the permanent [Daily maintenance track](https://github.com/laqieer/FEBuilderGBA/discussions/2155) and link it from the daily-maintenance skill.
- Add the final summary step after fresh completion checks, with stable pass markers, verified same-author updates, ambiguous-write recovery, and explicit blocked/publication-failure reporting.
- Preserve every existing safeguard and the zero-open-issue/zero-open-PR loop. This docs-only PR does not release or publish the active pass's final summary.

## Plan Reference
[Canonical implementation plan](https://github.com/laqieer/FEBuilderGBA/issues/2152#issuecomment-5553607096) · [Accepted high-tier plan gate](https://github.com/laqieer/FEBuilderGBA/issues/2152#issuecomment-5555247566)

## Scope
Closes #2152

Only `.github/skills/daily-maintenance/SKILL.md` changes. Review Tier: **high** (agent instructions).

## Test plan
- [x] Copilot customization tests: 10 passed; repository customization validator passed.
- [x] Review-risk classifier tests: 25 passed; proposed scope classified high.
- [x] `pre-commit install --hook-type commit-msg --install-hooks` and config validation succeeded; commitlint forwarding checks and commit-time hook passed. No unauthenticated ggshield pre-commit hook was enabled or bypassed.
- [x] Whitespace, original-instruction preservation/order, summary ordering, stable marker, and canonical discussion link checks passed.
- [x] Skill size 5,193 bytes (<8,192); always-loaded instructions unchanged at 4,712 bytes (<12,288).
- [x] Verified discussion #2155 is the canonical General target, with no duplicate maintenance discussion or premature pass-summary comment.

## Known limitations
Reporting is operator guidance, not an automatic publisher. One coordinator owns a pass's publication; it must verify remote state on retries. No application build or GUI screenshot is applicable.

Copilot CLI: 1.0.83
Model: GPT-6 Astra (gpt-6-astra)